### PR TITLE
Only group minor and patch eslint upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,8 +63,8 @@ updates:
 # Updates for npm dependencies used in web
 - package-ecosystem: npm
   directories: 
-    - "web/"
-    - "admin/"
+    - "/web"
+    - "/admin"
   schedule:
     interval: "weekly"
   open-pull-requests-limit: 10
@@ -90,6 +90,9 @@ updates:
       patterns:
       - "*eslint*"
       - "prettier"
+      update-types:
+        - "minor"
+        - "patch"
     emotion:
       patterns:
       - "@emotion*"


### PR DESCRIPTION
#1248 can't merge because the major eslint upgrade isn't yet compatible with next.js
There are minor and patch versions that aren't getting merged because this PR can't merge. By grouping only minor versions together we can get partial upgrades