### PR TITLE
Fix ProGuard rule for DynamoDB entity classes to prevent instantiation crash

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -21,7 +21,7 @@
 -renamesourcefileattribute SourceFile
 
 #Amazon
--keep class com.litus_animae.refitted.models.dynamo.*   { *; }
+-keep class com.litus_animae.refitted.dynamo.entities.** { *; }
 -keep class org.apache.commons.logging.**               { *; }
 -keep class com.amazonaws.services.sqs.QueueUrlHandler  { *; }
 -keep class com.amazonaws.javax.xml.transform.sax.*     { public *; }


### PR DESCRIPTION
The keep rule referenced the old package path models.dynamo which no longer exists.
R8 was obfuscating DynamoGroupDefinition (and other entities) to ns0, causing
DynamoDBMapper to fail with InstantiationException when loading records via reflection.

https://claude.ai/code/session_01FGLFE7asKr6djFPM2jHTig