### PR TITLE
Add CDK for RefittedDatabase and RefittedAuth stacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .claude/settings.local.json
 .claude/worktrees/
+.claude/launch.json
 
 # API keys
 **/google-services.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .claude/settings.local.json
+.claude/worktrees/
 
 # API keys
 **/google-services.json

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,16 @@
+*.js
+*.d.ts
+!jest.config.js
+!cdk.json
+
+# Root .gitignore has a blanket `bin/` rule for Android build output —
+# this CDK app's entry point source lives at bin/refitted.ts, not build output.
+!bin/
+!bin/**
+
+cdk.out/
+cdk.context.json
+import-mapping.*.json
+import-record.md
+node_modules/
+dist/

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,166 @@
+# Refitted Infra (CDK)
+
+CDK v2 (TypeScript) managing the Refitted AWS backend: DynamoDB table and
+Cognito identity pools + IAM roles/policies. Replaces a prior ad-hoc
+Terraform import exercise kept outside this repo.
+
+The admin Lambda functions (`admin/lambda/*.ts`) are deliberately **not**
+managed by CDK — they're slated for removal/replacement, so there's no value
+in importing them here. If that changes, add a stack for them then.
+
+Stacks (deploy in order — `RefittedAuth` depends on `RefittedDatabase`'s
+table ARN export):
+
+| Stack             | File                      | Owns |
+|--------------------|---------------------------|------|
+| `RefittedDatabase` | `lib/database-stack.ts`  | DynamoDB table `refitted.dev01` + GSIs |
+| `RefittedAuth`     | `lib/auth-stack.ts`      | Cognito identity pools, IAM roles, IAM policies, role-mapping rules |
+
+## Context values
+
+`paid1GroupId` (the Firebase custom-claim group UUID for the Paid1 tier) is
+kept out of the repo via `cdk.context.json`, which is gitignored. Create it
+locally:
+
+```json
+{
+  "paid1GroupId": "<uuid>"
+}
+```
+
+Or pass it inline: `cdk deploy -c paid1GroupId=<uuid>`.
+
+To find/verify the live value (e.g. after a suspected drift), pull it from
+the deployed Cognito role mapping — this is the authoritative source, not
+CDK:
+
+```bash
+aws cognito-identity list-identity-pools --max-results 20
+aws cognito-identity get-identity-pool-roles --identity-pool-id <android-pool-id>
+# → RoleMappings...RulesConfiguration.Rules[].Value for Claim "group"
+```
+
+To compare any deployed IAM policy's live document against what's in Git
+(useful before a `cdk deploy` if you suspect drift):
+
+```bash
+ARN=$(aws iam list-policies --query "Policies[?PolicyName=='<name>'].Arn" --output text)
+VER=$(aws iam get-policy --policy-arn $ARN --query "Policy.DefaultVersionId" --output text)
+aws iam get-policy-version --policy-arn $ARN --version-id $VER --query "PolicyVersion.Document"
+```
+
+## Ownership boundary: CDK vs. admin Lambdas
+
+**This is the most important thing to understand before touching `auth-stack.ts`.**
+
+The Paid1 DynamoDB access policy (`DynamoDb-Refitted.Dev01-Paid1`) has a
+`dynamodb:LeadingKeys` condition listing which workout programs that tier can
+read. That list is **live, admin-mutable application data — and the actual
+program names are proprietary content, not open-source app code.** This repo
+is public; the workout program catalog is not. The `RefittedUpdateIamGroup`
+Lambda (`admin/lambda/updateRefittedIamGroup.ts`) rewrites the `LeadingKeys`
+list as a new IAM policy version whenever a program is added/removed through
+the admin tooling, and `RefittedUpdateDynamoGroup` does the equivalent for
+the corresponding DynamoDB group item's workout list. **No program name
+should ever be written into CDK source, `cdk.context.json`, or this repo in
+any form** — the policy/data content only ever exists in live AWS state,
+written there exclusively by the admin Lambdas.
+
+This split is permanent, not a stopgap: the long-term plan is for the
+website's admin UI to be the tool for managing the program catalog (calling
+these same Lambdas). CDK's job stays scoped to infrastructure shape — it
+should never grow into managing program content, now or later.
+
+Which groups those Lambdas manage is defined in `admin/refitted.ts`
+(`RefittedGroup` enum + `RefittedGroupIdMapping` / `RefittedGroupPolicyMapping`).
+Today only `Paid1` is in that enum.
+
+**Rule: if a policy's content can be rewritten by an admin Lambda, CDK must
+never declare that policy's document.** If it did, the next `cdk deploy`
+would create a new policy version reverting to whatever was baked into the
+CDK code, silently undoing real admin changes. `auth-stack.ts` currently
+treats Paid1/Free/Anon uniformly this way (referenced by ARN via
+`iam.ManagedPolicy.fromManagedPolicyArn`, never created/updated by CDK) —
+kept uniform across all three even though only Paid1 is presently
+Lambda-managed, so adding Free/Anon to the enum later doesn't require an
+infra change.
+
+CDK *does* own: the roles themselves (trust policy, name), which policy ARN
+gets attached to which role, the identity pool role-mapping rules (which
+Firebase claim routes to which role), and any policy with fully static
+content (`DynamoDb-Refitted.Dev01-Read-Only`, `IAM-Refitted-EditGroups`,
+`Refitted-InvokeFirebaseAdminLambda`, `DynamoDb-Role-Permissions-Testing`).
+
+There's no native CloudFormation "create once, then ignore forever" mode for
+a resource like this — every deploy reconciles to the template. The only way
+to get that behavior in CDK is an `AwsCustomResource` with only
+`onCreate`/`onDelete` handlers (no `onUpdate`), which is Lambda-backed
+machinery we've deliberately avoided for the (rare) new-role bootstrap case
+below.
+
+## Runbook: adding a new role/tier
+
+Example: adding a hypothetical "Paid2" tier.
+
+1. **Bootstrap the IAM policy outside CDK** (one-time, manual — CDK never
+   creates group-scoped policies, see above):
+   ```bash
+   aws iam create-policy --policy-name DynamoDb-Refitted.Dev01-Paid2 \
+     --policy-document file://initial-paid2-policy.json
+   ```
+   Minimal starting document: same shape as the existing Paid1 policy, with
+   `dynamodb:LeadingKeys` containing just the new group's UUID. Keep
+   `initial-paid2-policy.json` local/uncommitted — same rule as above, no
+   program names in the repo.
+
+2. **`admin/refitted.ts`**: add the new value to `RefittedGroup`, and entries
+   in `RefittedGroupIdMapping` / `RefittedGroupPolicyMapping` pointing at the
+   UUID and policy ARN from step 1. No Lambda code changes needed — both
+   admin Lambdas are already generic over `group`.
+
+3. **`infra/lib/auth-stack.ts`**:
+   - Add `const paid2PolicyArn = ...` + `iam.ManagedPolicy.fromManagedPolicyArn(...)`.
+   - Add a new `iam.Role` (`Cognito_refitted_androidPaid2_Role`) with the
+     same `WebIdentityPrincipal` trust pattern as `androidPaid1Role`, and
+     attach the new policy.
+   - Add a rule to the `AndroidPoolRoles` `CfnIdentityPoolRoleAttachment`
+     mapping the new group's Firebase claim value to the new role.
+
+4. `cdk deploy RefittedAuth` (context: pass the new group id the same way as
+   `paid1GroupId` if you want it out of source).
+
+## Import notes
+
+For a stack with cross-stack references (`RefittedAuth` reads
+`RefittedDatabase`'s table ARN via `Fn::ImportValue`), the producer stack
+must already be **deployed** with that value exported before the consumer
+can import — `cdk import` synthesizes the whole app, but an export only
+exists in the producer's live template once something has actually consumed
+it in a real deploy. If you hit `No export named ... found` mid-import,
+`cdk deploy` the producer stack first (safe — it only adds the missing
+Output), then retry the import.
+
+`AWS::Cognito::IdentityPoolRoleAttachment` **does** support CloudFormation
+import (primary identifier `Id`, which equals the identity pool ID) — despite
+an earlier assumption in this repo's history that it didn't. What it does
+**not** support is idempotent create: declaring it fresh against a pool that
+already has a live role mapping fails with `AlreadyExists` rather than
+upserting. Before importing a resource type you're unsure about, confirm its
+identifier against live state with Cloud Control API rather than guessing:
+`aws cloudcontrol get-resource --type-name <Type> --identifier <id>`. Also
+useful: `aws cloudformation describe-type --type-name <Type> --type RESOURCE
+--query Schema` to get the exact `primaryIdentifier` property name `cdk
+import --resource-mapping` expects.
+
+A failed `cdk import` can leave the CloudFormation stack in
+`ROLLBACK_COMPLETE` (or `IMPORT_ROLLBACK_COMPLETE`), which blocks retrying
+until deleted. This is safe to delete without any AWS-side impact if the
+stack held zero resources when it failed (check with
+`list-stack-resources` first):
+
+```bash
+aws cloudformation describe-stacks --stack-name RefittedAuth --query "Stacks[0].StackStatus"
+aws cloudformation list-stack-resources --stack-name RefittedAuth
+aws cloudformation delete-stack --stack-name RefittedAuth
+aws cloudformation wait stack-delete-complete --stack-name RefittedAuth
+```

--- a/infra/bin/refitted.ts
+++ b/infra/bin/refitted.ts
@@ -1,0 +1,13 @@
+import * as cdk from 'aws-cdk-lib';
+import { DatabaseStack } from '../lib/database-stack';
+import { AuthStack } from '../lib/auth-stack';
+
+const app = new cdk.App();
+
+const env: cdk.Environment = {
+  account: process.env.CDK_DEFAULT_ACCOUNT,
+  region: 'us-east-2',
+};
+
+const db = new DatabaseStack(app, 'RefittedDatabase', { env });
+new AuthStack(app, 'RefittedAuth', { env, table: db.table });

--- a/infra/cdk.json
+++ b/infra/cdk.json
@@ -1,0 +1,14 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/refitted.ts",
+  "watch": {
+    "include": ["**"],
+    "exclude": [
+      "README.md", "cdk*.json", "**/*.js", "**/*.d.ts",
+      "tsconfig.json", "package*.json", "node_modules", "dist", "cdk.out"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true
+  }
+}

--- a/infra/lib/auth-stack.ts
+++ b/infra/lib/auth-stack.ts
@@ -1,0 +1,243 @@
+import * as cdk from 'aws-cdk-lib';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
+
+// Firebase project is already embedded in the Android binary — not a secret.
+const FIREBASE_PROJECT_ID = 'refitted-361ee';
+const FIREBASE_OIDC_DOMAIN = `securetoken.google.com/${FIREBASE_PROJECT_ID}`;
+
+interface AuthStackProps extends cdk.StackProps {
+  table: dynamodb.Table;
+}
+
+export class AuthStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: AuthStackProps) {
+    super(scope, id, props);
+
+    // Group UUID is kept out of source via cdk.context.json (gitignored).
+    // Set it locally or pass -c flags: cdk deploy -c paid1GroupId=xxx
+    //
+    // NOTE: the Paid1/Free/Anon DynamoDB policies' workout-program LeadingKeys are NOT
+    // managed here. They're live admin-mutable data — the admin Lambdas
+    // (RefittedUpdateIamGroup / RefittedUpdateDynamoGroup) rewrite those policy documents
+    // (as new IAM policy versions) whenever a program is added/removed. If CDK owned that
+    // content, every deploy would revert whatever the admin tools last wrote. So those three
+    // policies are referenced by ARN only below, never created/updated by this stack.
+    const paid1GroupId = this.node.tryGetContext('paid1GroupId') as string | undefined;
+
+    const oidcProviderArn = `arn:aws:iam::${this.account}:oidc-provider/${FIREBASE_OIDC_DOMAIN}`;
+
+    // ===========================================================================
+    // Cognito Identity Pools
+    // ===========================================================================
+
+    const webPool = new cognito.CfnIdentityPool(this, 'WebPool', {
+      identityPoolName: 'refitted',
+      allowUnauthenticatedIdentities: false,
+      openIdConnectProviderArns: [oidcProviderArn],
+    });
+    webPool.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+
+    const androidPool = new cognito.CfnIdentityPool(this, 'AndroidPool', {
+      identityPoolName: 'refitted_android',
+      allowUnauthenticatedIdentities: false,
+      openIdConnectProviderArns: [oidcProviderArn],
+    });
+    androidPool.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+
+    // ===========================================================================
+    // IAM Policies
+    // ===========================================================================
+
+    const tableArn = props.table.tableArn;
+    const reverseIndexArn = `${tableArn}/index/Reverse-index`;
+
+    // Paid1/Free/Anon policy content is owned by the admin Lambdas (see note above) —
+    // reference by ARN only, never create/import as CDK-managed resources.
+    const paid1PolicyArn = `arn:aws:iam::${this.account}:policy/DynamoDb-Refitted.Dev01-Paid1`;
+    const freePolicyArn = `arn:aws:iam::${this.account}:policy/DynamoDb-Refitted.Dev01-Free`;
+    const anonPolicyArn = `arn:aws:iam::${this.account}:policy/DynamoDb-Refitted.Dev01-Anon`;
+
+    const paid1Policy = iam.ManagedPolicy.fromManagedPolicyArn(this, 'DynamoDbPaid1', paid1PolicyArn);
+    const freePolicy = iam.ManagedPolicy.fromManagedPolicyArn(this, 'DynamoDbFree', freePolicyArn);
+    const anonPolicy = iam.ManagedPolicy.fromManagedPolicyArn(this, 'DynamoDbAnon', anonPolicyArn);
+
+    const readOnlyPolicy = new iam.ManagedPolicy(this, 'DynamoDbReadOnly', {
+      managedPolicyName: 'DynamoDb-Refitted.Dev01-Read-Only',
+      statements: [new iam.PolicyStatement({
+        actions: ['dynamodb:BatchGetItem', 'dynamodb:GetItem', 'dynamodb:Query'],
+        resources: [tableArn],
+      })],
+    });
+    readOnlyPolicy.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+
+    // Grants the admin Lambda permission to update the Paid1 policy versions.
+    const iamEditGroupsPolicy = new iam.ManagedPolicy(this, 'IamEditGroups', {
+      managedPolicyName: 'IAM-Refitted-EditGroups',
+      statements: [new iam.PolicyStatement({
+        sid: 'VisualEditor0',
+        actions: [
+          'iam:GetPolicyVersion', 'iam:ListPolicyVersions',
+          'iam:CreatePolicyVersion', 'iam:DeletePolicyVersion',
+        ],
+        resources: [paid1Policy.managedPolicyArn],
+      })],
+    });
+    iamEditGroupsPolicy.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+
+    // Grants web admin users permission to invoke the Firebase user-listing Lambda.
+    const invokeLambdaPolicy = new iam.ManagedPolicy(this, 'InvokeFirebaseLambda', {
+      managedPolicyName: 'Refitted-InvokeFirebaseAdminLambda',
+      statements: [new iam.PolicyStatement({
+        sid: 'VisualEditor0',
+        actions: ['lambda:InvokeFunction', 'lambda:InvokeAsync'],
+        resources: [`arn:aws:lambda:${this.region}:${this.account}:function:RefittedListFirebaseUsers`],
+      })],
+    });
+    invokeLambdaPolicy.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+
+    // Per-user DynamoDB access scoped to the user's own sub (Firebase subject claim).
+    const testingPolicy = new iam.ManagedPolicy(this, 'DynamoDbTesting', {
+      managedPolicyName: 'DynamoDb-Role-Permissions-Testing',
+      statements: [new iam.PolicyStatement({
+        actions: ['dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:UpdateItem'],
+        resources: [tableArn, reverseIndexArn],
+        conditions: {
+          'ForAllValues:StringEquals': {
+            'dynamodb:LeadingKeys': [
+              'Plan',
+              `\${${FIREBASE_OIDC_DOMAIN}:sub}`,
+            ],
+          },
+        },
+      })],
+    });
+    testingPolicy.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+
+    // ===========================================================================
+    // IAM Roles
+    // ===========================================================================
+
+    // Unauth roles are AWS auto-generated at Identity Pool creation time; import by name.
+    const webUnauthRole = iam.Role.fromRoleName(this, 'WebUnauthRole', 'Cognito_refittedUnauth_Role');
+    const androidUnauthRole = iam.Role.fromRoleName(this, 'AndroidUnauthRole', 'Cognito_refitted_androidUnauth_Role');
+
+    const webAuthRole = new iam.Role(this, 'WebAuthRole', {
+      roleName: 'Cognito_refittedAuth_Role',
+      assumedBy: new iam.WebIdentityPrincipal('cognito-identity.amazonaws.com', {
+        StringEquals: { 'cognito-identity.amazonaws.com:aud': webPool.ref },
+        'ForAnyValue:StringLike': { 'cognito-identity.amazonaws.com:amr': FIREBASE_OIDC_DOMAIN },
+      }),
+    });
+    webAuthRole.addManagedPolicy(readOnlyPolicy);
+    webAuthRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonDynamoDBReadOnlyAccess'));
+    webAuthRole.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+
+    // Android auth role is assumed by any authenticated user (web or Android pool).
+    const androidAuthRole = new iam.Role(this, 'AndroidAuthRole', {
+      roleName: 'Cognito_refitted_androidAuth_Role',
+      assumedBy: new iam.WebIdentityPrincipal('cognito-identity.amazonaws.com', {
+        StringEquals: {
+          'cognito-identity.amazonaws.com:aud': [androidPool.ref, webPool.ref],
+        },
+        'ForAnyValue:StringLike': { 'cognito-identity.amazonaws.com:amr': 'authenticated' },
+      }),
+    });
+    androidAuthRole.addManagedPolicy(anonPolicy);
+    androidAuthRole.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+
+    const androidPaid1Role = new iam.Role(this, 'AndroidPaid1Role', {
+      roleName: 'Cognito_refitted_androidPaid1_Role',
+      assumedBy: new iam.WebIdentityPrincipal('cognito-identity.amazonaws.com', {
+        StringEquals: { 'cognito-identity.amazonaws.com:aud': androidPool.ref },
+        'ForAnyValue:StringLike': { 'cognito-identity.amazonaws.com:amr': FIREBASE_OIDC_DOMAIN },
+      }),
+    });
+    androidPaid1Role.addManagedPolicy(paid1Policy);
+    androidPaid1Role.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+
+    const androidFreeRole = new iam.Role(this, 'AndroidFreeRole', {
+      roleName: 'Cognito_refitted_androidFree_Role',
+      assumedBy: new iam.WebIdentityPrincipal('cognito-identity.amazonaws.com', {
+        StringEquals: { 'cognito-identity.amazonaws.com:aud': androidPool.ref },
+        'ForAnyValue:StringLike': { 'cognito-identity.amazonaws.com:amr': FIREBASE_OIDC_DOMAIN },
+      }),
+    });
+    androidFreeRole.addManagedPolicy(freePolicy);
+    androidFreeRole.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+
+    const firebaseAdminRole = new iam.Role(this, 'FirebaseAdminRole', {
+      roleName: 'RefittedFirebaseAdmin',
+      assumedBy: new iam.WebIdentityPrincipal('cognito-identity.amazonaws.com', {
+        StringEquals: { 'cognito-identity.amazonaws.com:aud': webPool.ref },
+        'ForAnyValue:StringLike': { 'cognito-identity.amazonaws.com:amr': FIREBASE_OIDC_DOMAIN },
+      }),
+    });
+    firebaseAdminRole.addManagedPolicy(testingPolicy);
+    firebaseAdminRole.addManagedPolicy(invokeLambdaPolicy);
+    firebaseAdminRole.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+
+    // ===========================================================================
+    // Identity Pool Role Attachments
+    // ===========================================================================
+
+    const webPoolRoles = new cognito.CfnIdentityPoolRoleAttachment(this, 'WebPoolRoles', {
+      identityPoolId: webPool.ref,
+      roles: {
+        authenticated: webAuthRole.roleArn,
+        unauthenticated: webUnauthRole.roleArn,
+      },
+      roleMappings: {
+        firebase: {
+          type: 'Rules',
+          ambiguousRoleResolution: 'AuthenticatedRole',
+          identityProvider: oidcProviderArn,
+          rulesConfiguration: {
+            rules: [{
+              claim: 'admin',
+              matchType: 'Equals',
+              roleArn: firebaseAdminRole.roleArn,
+              value: 'true',
+            }],
+          },
+        },
+      },
+    });
+    webPoolRoles.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+
+    const androidRules: cognito.CfnIdentityPoolRoleAttachment.MappingRuleProperty[] = [];
+    if (paid1GroupId) {
+      androidRules.push({
+        claim: 'group',
+        matchType: 'Equals',
+        roleArn: androidPaid1Role.roleArn,
+        value: paid1GroupId,
+      });
+    }
+    androidRules.push({
+      claim: 'email',
+      matchType: 'Contains',
+      roleArn: androidFreeRole.roleArn,
+      value: '@',
+    });
+
+    const androidPoolRoles = new cognito.CfnIdentityPoolRoleAttachment(this, 'AndroidPoolRoles', {
+      identityPoolId: androidPool.ref,
+      roles: {
+        authenticated: androidAuthRole.roleArn,
+        unauthenticated: androidUnauthRole.roleArn,
+      },
+      roleMappings: {
+        firebase: {
+          type: 'Rules',
+          ambiguousRoleResolution: 'AuthenticatedRole',
+          identityProvider: oidcProviderArn,
+          rulesConfiguration: { rules: androidRules },
+        },
+      },
+    });
+    androidPoolRoles.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+  }
+}

--- a/infra/lib/database-stack.ts
+++ b/infra/lib/database-stack.ts
@@ -1,0 +1,39 @@
+import * as cdk from 'aws-cdk-lib';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
+
+export class DatabaseStack extends cdk.Stack {
+  readonly table: dynamodb.Table;
+
+  constructor(scope: Construct, id: string, props: cdk.StackProps) {
+    super(scope, id, props);
+
+    this.table = new dynamodb.Table(this, 'Table', {
+      tableName: 'refitted.dev01',
+      partitionKey: { name: 'Id', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'Disc', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PROVISIONED,
+      readCapacity: 5,
+      writeCapacity: 5,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    this.table.addGlobalSecondaryIndex({
+      indexName: 'Name-Id-index',
+      partitionKey: { name: 'Name', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'Id', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+      readCapacity: 5,
+      writeCapacity: 5,
+    });
+
+    this.table.addGlobalSecondaryIndex({
+      indexName: 'Reverse-index',
+      partitionKey: { name: 'Disc', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'Id', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+      readCapacity: 5,
+      writeCapacity: 5,
+    });
+  }
+}

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,0 +1,677 @@
+{
+  "name": "refitted-infra",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "refitted-infra",
+      "version": "0.1.0",
+      "dependencies": {
+        "aws-cdk-lib": "^2.180.0",
+        "constructs": "^10.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "aws-cdk": "^2.180.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.2.2"
+      }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.282",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "54.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.2.0.tgz",
+      "integrity": "sha512-u3lFXmiXSBozxGBmKTCVD/2mTDsaXzLZH3KYiIQKcB+zPldXOeE5TnooBgKV9ih2jVTo8ML0HpkhfAq2eiv0eQ==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.8.1",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk": {
+      "version": "2.1126.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1126.0.tgz",
+      "integrity": "sha512-uNoocb3vCPiAT3j9+SwL6pn/VVggHWBsgC2XpxyhNvYQYt6cE9BM/149GWwtdcwnLrPjnwW1+CV/5nSSh5dV+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.259.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.259.0.tgz",
+      "integrity": "sha512-qcsbyRBZpFMUzx/Nle5vKXFC14Z1VutvAqw6S4Duh3Yj5ZFl4e/RhN2Vg8QmYktxu9l1aF9H5UyF+Xz81qk9gw==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "table",
+        "yaml",
+        "mime-types"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.5",
+        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.3.5",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
+        "mime-types": "^2.1.35",
+        "minimatch": "^10.2.5",
+        "punycode": "^2.3.1",
+        "semver": "^7.8.1",
+        "table": "^6.9.0",
+        "yaml": "1.10.3"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.5",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.20.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.1.2",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.3.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "10.2.5",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.8.1",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.9.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.3",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/constructs": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
+      "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "refitted-infra",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "cdk": "cdk",
+    "synth": "cdk synth",
+    "diff": "cdk diff",
+    "deploy": "cdk deploy --all"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.180.0",
+    "constructs": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "aws-cdk": "^2.180.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.2.2"
+  }
+}

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "resolveJsonModule": true
+  },
+  "include": ["bin/**/*.ts", "lib/**/*.ts"],
+  "exclude": ["node_modules", "dist", "cdk.out"]
+}


### PR DESCRIPTION
## Summary
- Imports the existing DynamoDB table (`RefittedDatabase`) and Cognito/IAM auth resources (`RefittedAuth`) into AWS CDK management, replacing a prior ad-hoc Terraform import exercise kept outside this repo
- Group-scoped DynamoDB policies (Paid1/Free/Anon) are referenced by ARN only, never created/updated by CDK, since their `LeadingKeys` content is rewritten by existing admin tooling outside this stack — see `infra/README.md` for the full ownership boundary and runbook for adding a new role/tier
- Admin Lambda functions are deliberately excluded from CDK management (slated for removal/replacement)
- Fixes the root `.gitignore`'s blanket `bin/` rule (meant for Android build output) that was silently excluding `infra/bin/refitted.ts`, the CDK app's actual entry point
- Gitignores `.claude/worktrees/`, a local Claude Code artifact

## Test plan
- [x] `cdk synth` succeeds for both stacks
- [x] `cdk diff` shows zero drift against live AWS state for both stacks after import
- [x] Verified no AWS account ID, group UUIDs, pool IDs, or proprietary content committed (all ARNs built dynamically via `this.account`/`this.region`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnBTsfetntYGjXM3oGXU9k