### PR TITLE
Group @mui/* npm dependency updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -120,6 +120,9 @@ updates:
     emotion:
       patterns:
       - "@emotion*"
+    mui:
+      patterns:
+      - "@mui/*"
     base:
       patterns:
       - "typescript"


### PR DESCRIPTION
PRs #1840 and #1841 were opened separately for @mui/material-nextjs
and @mui/material despite being closely related; add a mui group so
future updates are combined into one PR.