### PR TITLE
Drop stale KSP source-set override, restore --warning-mode=fail

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,6 @@
       "Bash(./gradlew :app:assembleDebugAndroidTest:*)",
       "Bash(./gradlew projects:*)",
       "Bash(./gradlew:*)",
-      "Bash(find:*)",
       "Bash(git ls-tree *)",
       "Bash(npx tsc *)",
       "Bash(xargs cat:*)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           # ORG_GRADLE_PROJECT_Refitted_OpenIdSource: ${{ secrets.REFITTED_OPENIDSOURCE }}
           ORG_GRADLE_PROJECT_Refitted_IdentityPoolId: "not-needed"
           ORG_GRADLE_PROJECT_Refitted_OpenIdSource: "not-needed"
-        run: ./gradlew assembleRelease --warning-mode=summary
+        run: ./gradlew assembleRelease --warning-mode=fail
 
       - name: Run buildHealth
         env:

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,9 +18,6 @@ android.nonFinalResIds=true
 android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
-# KSP still registers generated sources via the legacy kotlin.sourceSets DSL, which
-# built-in Kotlin disallows: https://github.com/google/ksp/issues/2729 (open, no fix yet)
-android.disallowKotlinSourceSets=false
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
## Summary
- Removes `android.disallowKotlinSourceSets=false` from `gradle.properties` — the underlying KSP bug ([google/ksp#2729](https://github.com/google/ksp/issues/2729)) was fixed upstream around ksp 2.3.4, and we're on 2.3.10. Verified `kspReleaseKotlin`/`kspDebugKotlin` succeed across all modules without it, so the override (and the AGP sync warning it caused) is dropped rather than suppressed.
- Restores `--warning-mode=fail` in the `build-android` CI job. The deprecation warning that forced `--warning-mode=summary` (#1858) was in AGP's `VariantManager.createTestComponents`, and got fixed by the AGP 9.2.1 → 9.3.0 bump already on `master`. Verified with a full, uncached `./gradlew assembleRelease --warning-mode=fail` run (309/309 tasks executed, no deprecation warnings).

Closes #1858

## Test plan
- [x] `./gradlew kspReleaseKotlin kspDebugKotlin --rerun-tasks` succeeds without `android.disallowKotlinSourceSets`
- [x] `./gradlew assembleRelease --rerun-tasks --warning-mode=fail` succeeds with no deprecation warnings