### PR TITLE
Add Material elevation shadows to exercise cards

### DIFF
--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerInstruction.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerInstruction.kt
@@ -365,7 +365,11 @@ private fun CardContent(
           translationX = swapProgress * (size.width + 32.dp.toPx())
           translationY = -swapProgress * (size.height + 32.dp.toPx())
           rotationZ = swapProgress * 18f
-        }
+        },
+        // The front-and-center card gets a pronounced shadow so it visibly lifts off the
+        // deck; cards still sitting in the deck stay near-flat so the depth reads from
+        // the active card alone rather than every jittered card casting its own shadow.
+        elevation = if (isActivePage) 6.dp else 1.dp
       ) {
         CompositionLocalProvider(
           LocalOverscrollFactory provides null

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
@@ -1,6 +1,7 @@
 package com.litus_animae.refitted.ui.compose.exercise.set
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -137,10 +138,10 @@ fun ColumnScope.ExerciseSetView(
     // when space is tight the weight card absorbs the difference
     Layout(
       content = {
-        Card(Modifier.fillMaxWidth()) {
+        Card(Modifier.fillMaxWidth(), elevation = 2.dp) {
           WeightDisplay(onStartEditWeight, weight, saveWeight)
         }
-        Card(Modifier.fillMaxWidth()) {
+        Card(Modifier.fillMaxWidth(), elevation = 2.dp) {
           RepsDisplay(setWithRecord, reps)
         }
       },
@@ -162,27 +163,35 @@ fun ColumnScope.ExerciseSetView(
         repsPlaceable.place(0, weightPlaceable.height + spacing)
       }
     }
-    Column(
+    Box(
       Modifier
         .weight(1f)
-        .padding(start = 8.dp)
+        .fillMaxHeight()
+        .padding(start = 8.dp),
+      contentAlignment = Alignment.Center
     ) {
-      CircularRestTimer(
-        restSeconds = effectiveRestSeconds,
-        maxRestSeconds = maxRestSeconds,
-        isRunning = isTimerRunning,
-        startedAt = effectiveTimerStart,
-        nextRestSeconds = nextRestSeconds,
-        onAdjust = onRestOverrideChange,
-        onFinish = {
-          if (onTimerToggle != null) {
-            onTimerToggle()
-          } else {
-            timerRunning.value = false
-            timerDuration.intValue = exerciseSet.rest * 1000
+      // Wraps its content instead of filling the row's height (which the Weight/Reps
+      // stack next to it doesn't fully occupy either) so it floats centered rather than
+      // stretching to an arbitrary bottom edge that never quite matched theirs.
+      Card(Modifier.fillMaxWidth(), elevation = 2.dp) {
+        CircularRestTimer(
+          restSeconds = effectiveRestSeconds,
+          maxRestSeconds = maxRestSeconds,
+          isRunning = isTimerRunning,
+          startedAt = effectiveTimerStart,
+          modifier = Modifier.fillMaxWidth().height(RepsDisplayMinHeight),
+          nextRestSeconds = nextRestSeconds,
+          onAdjust = onRestOverrideChange,
+          onFinish = {
+            if (onTimerToggle != null) {
+              onTimerToggle()
+            } else {
+              timerRunning.value = false
+              timerDuration.intValue = exerciseSet.rest * 1000
+            }
           }
-        }
-      )
+        )
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Front card in the exercise instruction deck (`PagerExerciseInstructions`) gets 6dp elevation while stacked-behind cards stay at 1dp, so the active card visibly lifts off the pile — matching the shadow treatment from the [Refitted redesign exploration mock](https://claude.ai/design/p/3b3ef0f6-ad5a-40a0-af5d-64ba8f96a938?file=Refitted+Redesign+Exploration.dc.html).
- Weight, Reps, and rest-timer cards in `ExerciseSetView` all get a matching 2dp shadow.
- Rest-timer card now wraps its content and floats centered in its column instead of stretching to fill the row, which previously left its bottom edge misaligned with the Weight/Reps stack next to it.

## Test plan
- [x] `./gradlew :ui:compileDebugKotlin` succeeds
- [ ] Visual check on device/emulator: exercise screen deck shadow depth, and rest-timer card alignment next to Weight/Reps cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)