### PR TITLE
Align calendar to real dates with a start-date picker

### DIFF
--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Calendar.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Calendar.kt
@@ -2,25 +2,53 @@ package com.litus_animae.refitted.ui.compose.calendar
 
 import android.util.Log
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.ButtonDefaults
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
 import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
 import androidx.compose.material.contentColorFor
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
-import com.litus_animae.refitted.ui.compose.util.ConstrainedButton
+import androidx.compose.ui.unit.sp
 import com.litus_animae.refitted.ui.compose.util.Theme
 import com.litus_animae.refitted.data.models.WorkoutPlan
 import java.time.Instant
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import kotlin.math.ceil
 
 @Preview(showBackground = true)
@@ -28,11 +56,24 @@ import kotlin.math.ceil
 fun PreviewCalendar() {
   MaterialTheme(colors = Theme.darkColors) {
     WorkoutCalendar(
-      WorkoutPlan("test", 110, 4), mapOf(
+      WorkoutPlan("test", 110, 4, Instant.now().minus(3, ChronoUnit.DAYS)), mapOf(
         Pair(1, Instant.ofEpochMilli(1L)),
         Pair(2, Instant.ofEpochMilli(2L))
       ),
       contentPadding = PaddingValues(0.dp)
+    ) {}
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewCalendarUnaligned() {
+  MaterialTheme(colors = Theme.darkColors) {
+    WorkoutCalendar(
+      WorkoutPlan("test", 110, 1),
+      emptyMap(),
+      contentPadding = PaddingValues(0.dp),
+      onPickStartDate = {}
     ) {}
   }
 }
@@ -42,53 +83,243 @@ fun WorkoutCalendar(
   plan: WorkoutPlan,
   completedDays: Map<Int, Instant>,
   contentPadding: PaddingValues,
+  onPickStartDate: (() -> Unit)? = null,
   navigateToDay: (Int) -> Unit,
 ) {
   LaunchedEffect(plan) {
     Log.d("WorkoutCalendar", "Plan is $plan")
   }
-  // TODO handle different screen sizes
-  // spacing between is 6dp so I am guessing that we are seeing 90x100 squares.
-  // we should calculate days per row to something that makes sense for orientation
-  val daysPerRow = 7
-  val daysInCalendar = plan.totalDays
-  val cellsInGrid = ceil(daysInCalendar.toDouble() / daysPerRow).toInt() * daysPerRow
+  val zone = remember { ZoneId.systemDefault() }
+  val today = remember { LocalDate.now(zone) }
+  // Epoch is the WorkoutPlan default and marks a plan as unaligned - see
+  // WorkoutViewModel.alignToDayIfUnaligned/setStartDate.
+  val aligned = plan.workoutStartDate.toEpochMilli() != 0L
+  val anchorDate = if (aligned) plan.workoutStartDate.atZone(zone).toLocalDate() else today
+
+  var displayedMonthKey by rememberSaveable {
+    mutableIntStateOf(today.year * 12 + (today.monthValue - 1))
+  }
+  val displayedMonth = remember(displayedMonthKey) {
+    YearMonth.of(displayedMonthKey / 12, displayedMonthKey % 12 + 1)
+  }
+
+  var hideRestDays by rememberSaveable { mutableStateOf(false) }
+
+  val firstOfMonth = displayedMonth.atDay(1)
+  // Sunday-first grid: ISO Sunday (7) should wrap to 0 leading cells, not 7.
+  val leadingOffset = firstOfMonth.dayOfWeek.value % 7
+  val gridStart = firstOfMonth.minusDays(leadingOffset.toLong())
+  val totalCells = ceil((leadingOffset + displayedMonth.lengthOfMonth()) / 7.0).toInt() * 7
+  val weeks: List<List<LocalDate>> =
+    (0 until totalCells).map { gridStart.plusDays(it.toLong()) }.chunked(7)
+
   LazyColumn(
     Modifier
       .fillMaxWidth()
       .padding(contentPadding)
       .padding(10.dp, 10.dp)
   ) {
-    val rows: List<List<Int>> = (1..cellsInGrid).chunked(daysPerRow)
-    item {
-      Row {
-        // TODO legend
-      }
+    if (onPickStartDate != null) {
+      item { StartDatePrompt(onPickStartDate) }
     }
-    items(rows) { chunk ->
+    item {
+      MonthNavRow(
+        displayedMonth,
+        onPrevious = { displayedMonthKey -= 1 },
+        onNext = { displayedMonthKey += 1 }
+      )
+    }
+    item { CalendarLegend() }
+    item { HideRestDaysRow(hideRestDays) { hideRestDays = it } }
+    item { WeekdayHeader() }
+    items(weeks) { week ->
       Row(Modifier.fillMaxWidth()) {
-        chunk.map {
-          Column(
+        week.forEach { cellDate ->
+          val workoutDay = ChronoUnit.DAYS.between(anchorDate, cellDate).toInt() + 1
+          val inRange = YearMonth.from(cellDate) == displayedMonth && workoutDay in 1..plan.totalDays
+          Box(
             Modifier
               .weight(1f)
-              .height(50.dp)
-              .padding(horizontal = 3.dp, vertical = 5.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
+              .height(52.dp)
+              .padding(3.dp)
           ) {
-            if (it > daysInCalendar) Box {}
-            else CalendarDayButton(
-              it,
-              DayProperties(
-                isDayComplete(it, completedDays, plan.workoutStartDate),
-                isLastViewedDay = it == plan.lastViewedDay,
-                isRestDay = plan.restDays.contains(it)
-              ),
-              navigateToDay
-            )
+            if (!inRange) {
+              OutOfRangeDayCell(cellDate.dayOfMonth)
+            } else {
+              val isRestDay = plan.restDays.contains(workoutDay)
+              if (isRestDay && hideRestDays) {
+                Box(Modifier.fillMaxSize())
+              } else {
+                CalendarDayCell(
+                  cellDate.dayOfMonth,
+                  workoutDay,
+                  DayProperties(
+                    isCompletedDay = aligned && isDayComplete(
+                      workoutDay,
+                      completedDays,
+                      plan.workoutStartDate
+                    ),
+                    isLastViewedDay = workoutDay == plan.lastViewedDay,
+                    isRestDay = isRestDay
+                  ),
+                  onClick = { navigateToDay(workoutDay) }
+                )
+              }
+            }
           }
         }
       }
+    }
+  }
+}
+
+@Composable
+private fun StartDatePrompt(onPickStartDate: () -> Unit) {
+  Surface(
+    Modifier
+      .fillMaxWidth()
+      .padding(bottom = 12.dp),
+    shape = RoundedCornerShape(10.dp),
+    color = MaterialTheme.colors.primary,
+    contentColor = MaterialTheme.colors.onPrimary,
+    elevation = 1.dp
+  ) {
+    Column(Modifier.padding(14.dp)) {
+      // TODO localize
+      Text("Pick the day you'll start this program", fontSize = 13.sp)
+      Spacer(Modifier.height(8.dp))
+      Button(onClick = onPickStartDate, modifier = Modifier.fillMaxWidth()) {
+        // TODO localize
+        Text("Set start date")
+      }
+    }
+  }
+}
+
+@Composable
+private fun MonthNavRow(
+  displayedMonth: YearMonth,
+  onPrevious: () -> Unit,
+  onNext: () -> Unit
+) {
+  Row(
+    Modifier
+      .fillMaxWidth()
+      .padding(bottom = 12.dp),
+    horizontalArrangement = Arrangement.SpaceBetween,
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    Surface(shape = CircleShape, modifier = Modifier.size(32.dp), elevation = 1.dp) {
+      IconButton(onClick = onPrevious) {
+        Icon(
+          Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+          // TODO localize
+          "previous month",
+          tint = MaterialTheme.colors.primary
+        )
+      }
+    }
+    Text(
+      displayedMonth.format(DateTimeFormatter.ofPattern("MMMM yyyy")),
+      fontSize = 17.sp,
+      fontWeight = FontWeight.SemiBold
+    )
+    Surface(shape = CircleShape, modifier = Modifier.size(32.dp), elevation = 1.dp) {
+      IconButton(onClick = onNext) {
+        Icon(
+          Icons.AutoMirrored.Filled.KeyboardArrowRight,
+          // TODO localize
+          "next month",
+          tint = MaterialTheme.colors.primary
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun CalendarLegend() {
+  Surface(
+    Modifier
+      .fillMaxWidth()
+      .padding(bottom = 10.dp),
+    shape = RoundedCornerShape(10.dp),
+    elevation = 1.dp
+  ) {
+    Row(
+      Modifier
+        .fillMaxWidth()
+        .padding(12.dp, 10.dp),
+      horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+      LegendEntry("upcoming", MaterialTheme.colors.primary)
+      LegendEntry("completed", MaterialTheme.colors.secondary)
+      LegendEntry(
+        "last viewed",
+        MaterialTheme.colors.background,
+        outlineColor = MaterialTheme.colors.primaryVariant
+      )
+      LegendEntry("rest day", MaterialTheme.colors.primary, alpha = 0.35f)
+    }
+  }
+}
+
+@Composable
+private fun LegendEntry(
+  label: String,
+  color: Color,
+  alpha: Float = 1f,
+  outlineColor: Color? = null
+) {
+  Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+    Box(
+      Modifier
+        .size(11.dp)
+        .alpha(alpha)
+        .background(color, RoundedCornerShape(3.dp))
+        .let { if (outlineColor != null) it.border(3.dp, outlineColor, RoundedCornerShape(3.dp)) else it }
+    )
+    Text(label, fontSize = 11.sp)
+  }
+}
+
+@Composable
+private fun HideRestDaysRow(hideRestDays: Boolean, onToggle: (Boolean) -> Unit) {
+  Surface(
+    Modifier
+      .fillMaxWidth()
+      .padding(bottom = 12.dp),
+    shape = RoundedCornerShape(10.dp),
+    elevation = 1.dp
+  ) {
+    Row(
+      Modifier
+        .fillMaxWidth()
+        .padding(14.dp, 10.dp),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      // TODO localize
+      Text("Hide rest days", fontSize = 14.sp)
+      Switch(checked = hideRestDays, onCheckedChange = onToggle)
+    }
+  }
+}
+
+@Composable
+private fun WeekdayHeader() {
+  Row(Modifier.fillMaxWidth()) {
+    listOf("S", "M", "T", "W", "T", "F", "S").forEach { label ->
+      Text(
+        label,
+        Modifier
+          .weight(1f)
+          .padding(bottom = 6.dp),
+        textAlign = TextAlign.Center,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+      )
     }
   }
 }
@@ -121,42 +352,65 @@ class DayPropertiesPreviewParameterProvider : PreviewParameterProvider<DayProper
   )
 }
 
-@Preview(widthDp = 60, heightDp = 40)
+@Preview(widthDp = 60, heightDp = 52)
 @Composable
 fun PreviewCalendarDayButton(
   @PreviewParameter(DayPropertiesPreviewParameterProvider::class) properties: DayProperties
 ) {
   MaterialTheme(colors = Theme.darkColors) {
-    CalendarDayButton(1, properties) { }
+    CalendarDayCell(1, 1, properties) { }
   }
 }
 
 @Composable
-private fun CalendarDayButton(
-  day: Int,
+private fun OutOfRangeDayCell(dayOfMonth: Int) {
+  Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Text(
+      "$dayOfMonth",
+      fontSize = 13.sp,
+      color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.disabled)
+    )
+  }
+}
+
+@Composable
+private fun CalendarDayCell(
+  dayOfMonth: Int,
+  workoutDay: Int,
   properties: DayProperties,
-  navigateToDay: (Int) -> Unit
+  onClick: () -> Unit
 ) {
-  val borderColor =
-    if (properties.isCompletedDay) MaterialTheme.colors.secondaryVariant
-    else MaterialTheme.colors.primaryVariant
   val backgroundColor = when {
     properties.isLastViewedDay -> MaterialTheme.colors.background
     properties.isCompletedDay -> MaterialTheme.colors.secondary
     else -> MaterialTheme.colors.primary
   }
-  val contentColor =
-    if (properties.isRestDay) contentColorFor(backgroundColor).copy(alpha = ContentAlpha.disabled)
-    else contentColorFor(backgroundColor)
-  ConstrainedButton(
-    if (properties.isRestDay) "Rest" else String.format("%d", day),
-    if (properties.isRestDay) "Rest day $day" else "Day $day",
-    onClick = { navigateToDay(day) },
-    border = if (properties.isLastViewedDay) BorderStroke(6.dp, borderColor) else null,
-    colors = ButtonDefaults.buttonColors(
-      backgroundColor = backgroundColor,
-      contentColor = contentColor
-    ),
-    contentPadding = PaddingValues(1.dp)
-  )
+  val contentColor = contentColorFor(backgroundColor)
+  val border = if (properties.isLastViewedDay)
+    BorderStroke(3.dp, MaterialTheme.colors.primaryVariant) else null
+  val label = if (properties.isRestDay) "Rest day $workoutDay" else "Day $workoutDay"
+
+  Surface(
+    modifier = Modifier
+      .fillMaxSize()
+      .alpha(if (properties.isRestDay) 0.45f else 1f)
+      .clickable(onClickLabel = label, onClick = onClick),
+    shape = RoundedCornerShape(8.dp),
+    color = backgroundColor,
+    contentColor = contentColor,
+    border = border
+  ) {
+    Column(
+      Modifier.fillMaxSize(),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+      Text("$dayOfMonth", fontSize = 14.sp)
+      Text(
+        if (properties.isRestDay) "rest" else "day $workoutDay",
+        fontSize = 9.sp,
+        modifier = Modifier.alpha(0.8f)
+      )
+    }
+  }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Calendar.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Calendar.kt
@@ -177,8 +177,9 @@ fun WorkoutCalendar(
                 else base
               }
           ) {
+            val isToday = cellDate == today
             if (!inRange) {
-              OutOfRangeDayCell(cellDate.dayOfMonth)
+              OutOfRangeDayCell(cellDate.dayOfMonth, isToday = isToday)
             } else if (hidden) {
               Box(Modifier.fillMaxSize())
             } else {
@@ -194,7 +195,8 @@ fun WorkoutCalendar(
                   isLastViewedDay = aligned && workoutDay == plan.lastViewedDay,
                   isRestDay = isRestDay
                 ),
-                selected = !aligned && cellDate == pickedDate
+                selected = !aligned && cellDate == pickedDate,
+                isToday = isToday
               )
             }
           }
@@ -403,12 +405,14 @@ fun PreviewCalendarDayButton(
 }
 
 @Composable
-private fun OutOfRangeDayCell(dayOfMonth: Int) {
+private fun OutOfRangeDayCell(dayOfMonth: Int, isToday: Boolean = false) {
   Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
     Text(
       "$dayOfMonth",
       fontSize = 13.sp,
-      color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.disabled)
+      color = if (isToday) Theme.goodAttention
+      else MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.disabled),
+      fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal
     )
   }
 }
@@ -418,7 +422,8 @@ private fun CalendarDayCell(
   dayOfMonth: Int,
   workoutDay: Int,
   properties: DayProperties,
-  selected: Boolean = false
+  selected: Boolean = false,
+  isToday: Boolean = false
 ) {
   // Last-viewed (aligned) and selected-as-start (unaligned) are mutually exclusive - one
   // outline style covers "this is the reference day" in either mode.
@@ -445,7 +450,12 @@ private fun CalendarDayCell(
       verticalArrangement = Arrangement.Center,
       horizontalAlignment = Alignment.CenterHorizontally
     ) {
-      Text("$dayOfMonth", fontSize = 14.sp)
+      Text(
+        "$dayOfMonth",
+        fontSize = 14.sp,
+        color = if (isToday) Theme.goodAttention else contentColor,
+        fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal
+      )
       Text(
         if (properties.isRestDay) "rest" else "day $workoutDay",
         fontSize = 9.sp,

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Calendar.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Calendar.kt
@@ -1,6 +1,9 @@
 package com.litus_animae.refitted.ui.compose.calendar
 
 import android.util.Log
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -26,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -73,7 +77,7 @@ fun PreviewCalendarUnaligned() {
       WorkoutPlan("test", 110, 1),
       emptyMap(),
       contentPadding = PaddingValues(0.dp),
-      onPickStartDate = {}
+      onSaveStartDate = {}
     ) {}
   }
 }
@@ -83,7 +87,7 @@ fun WorkoutCalendar(
   plan: WorkoutPlan,
   completedDays: Map<Int, Instant>,
   contentPadding: PaddingValues,
-  onPickStartDate: (() -> Unit)? = null,
+  onSaveStartDate: (LocalDate) -> Unit = {},
   navigateToDay: (Int) -> Unit,
 ) {
   LaunchedEffect(plan) {
@@ -94,7 +98,12 @@ fun WorkoutCalendar(
   // Epoch is the WorkoutPlan default and marks a plan as unaligned - see
   // WorkoutViewModel.alignToDayIfUnaligned/setStartDate.
   val aligned = plan.workoutStartDate.toEpochMilli() != 0L
-  val anchorDate = if (aligned) plan.workoutStartDate.atZone(zone).toLocalDate() else today
+
+  // Tentative start day while unaligned - the calendar itself is the picker here; only
+  // Save (via onSaveStartDate) persists it as plan.workoutStartDate.
+  var pickedEpochDay by rememberSaveable { mutableLongStateOf(today.toEpochDay()) }
+  val pickedDate = LocalDate.ofEpochDay(pickedEpochDay)
+  val anchorDate = if (aligned) plan.workoutStartDate.atZone(zone).toLocalDate() else pickedDate
 
   var displayedMonthKey by rememberSaveable {
     mutableIntStateOf(today.year * 12 + (today.monthValue - 1))
@@ -119,8 +128,14 @@ fun WorkoutCalendar(
       .padding(contentPadding)
       .padding(10.dp, 10.dp)
   ) {
-    if (onPickStartDate != null) {
-      item { StartDatePrompt(onPickStartDate) }
+    item {
+      AnimatedVisibility(visible = !aligned, exit = shrinkVertically() + fadeOut()) {
+        StartDatePickerBanner(
+          pickedDate,
+          onSave = { onSaveStartDate(pickedDate) },
+          modifier = Modifier.padding(bottom = 12.dp)
+        )
+      }
     }
     item {
       MonthNavRow(
@@ -136,35 +151,51 @@ fun WorkoutCalendar(
       Row(Modifier.fillMaxWidth()) {
         week.forEach { cellDate ->
           val workoutDay = ChronoUnit.DAYS.between(anchorDate, cellDate).toInt() + 1
-          val inRange = YearMonth.from(cellDate) == displayedMonth && workoutDay in 1..plan.totalDays
+          val inDisplayedMonth = YearMonth.from(cellDate) == displayedMonth
+          val inRange = inDisplayedMonth && workoutDay in 1..plan.totalDays
+          val isRestDay = inRange && plan.restDays.contains(workoutDay)
+          val hidden = isRestDay && hideRestDays
+          val onClick: (() -> Unit)? = when {
+            !aligned && inDisplayedMonth -> ({ pickedEpochDay = cellDate.toEpochDay() })
+            aligned && inRange && !hidden -> ({ navigateToDay(workoutDay) })
+            else -> null
+          }
+          val label = when {
+            !aligned && inDisplayedMonth ->
+              "Choose ${cellDate.format(DateTimeFormatter.ofPattern("MMM d"))} as start"
+            isRestDay -> "Rest day $workoutDay"
+            inRange -> "Day $workoutDay"
+            else -> null
+          }
           Box(
             Modifier
               .weight(1f)
               .height(52.dp)
               .padding(3.dp)
+              .let { base ->
+                if (onClick != null) base.clickable(onClickLabel = label, onClick = onClick)
+                else base
+              }
           ) {
             if (!inRange) {
               OutOfRangeDayCell(cellDate.dayOfMonth)
+            } else if (hidden) {
+              Box(Modifier.fillMaxSize())
             } else {
-              val isRestDay = plan.restDays.contains(workoutDay)
-              if (isRestDay && hideRestDays) {
-                Box(Modifier.fillMaxSize())
-              } else {
-                CalendarDayCell(
-                  cellDate.dayOfMonth,
-                  workoutDay,
-                  DayProperties(
-                    isCompletedDay = aligned && isDayComplete(
-                      workoutDay,
-                      completedDays,
-                      plan.workoutStartDate
-                    ),
-                    isLastViewedDay = workoutDay == plan.lastViewedDay,
-                    isRestDay = isRestDay
+              CalendarDayCell(
+                cellDate.dayOfMonth,
+                workoutDay,
+                DayProperties(
+                  isCompletedDay = aligned && isDayComplete(
+                    workoutDay,
+                    completedDays,
+                    plan.workoutStartDate
                   ),
-                  onClick = { navigateToDay(workoutDay) }
-                )
-              }
+                  isLastViewedDay = aligned && workoutDay == plan.lastViewedDay,
+                  isRestDay = isRestDay
+                ),
+                selected = !aligned && cellDate == pickedDate
+              )
             }
           }
         }
@@ -174,11 +205,13 @@ fun WorkoutCalendar(
 }
 
 @Composable
-private fun StartDatePrompt(onPickStartDate: () -> Unit) {
+private fun StartDatePickerBanner(
+  pickedDate: LocalDate,
+  onSave: () -> Unit,
+  modifier: Modifier = Modifier
+) {
   Surface(
-    Modifier
-      .fillMaxWidth()
-      .padding(bottom = 12.dp),
+    modifier.fillMaxWidth(),
     shape = RoundedCornerShape(10.dp),
     color = MaterialTheme.colors.primary,
     contentColor = MaterialTheme.colors.onPrimary,
@@ -186,11 +219,18 @@ private fun StartDatePrompt(onPickStartDate: () -> Unit) {
   ) {
     Column(Modifier.padding(14.dp)) {
       // TODO localize
-      Text("Pick the day you'll start this program", fontSize = 13.sp)
-      Spacer(Modifier.height(8.dp))
-      Button(onClick = onPickStartDate, modifier = Modifier.fillMaxWidth()) {
+      Text("Tap a day to choose your start", fontSize = 13.sp)
+      Spacer(Modifier.height(4.dp))
+      Text(
         // TODO localize
-        Text("Set start date")
+        "Start: ${pickedDate.format(DateTimeFormatter.ofPattern("EEE, MMM d"))}",
+        fontSize = 14.sp,
+        fontWeight = FontWeight.SemiBold
+      )
+      Spacer(Modifier.height(8.dp))
+      Button(onClick = onSave, modifier = Modifier.fillMaxWidth()) {
+        // TODO localize
+        Text("Save")
       }
     }
   }
@@ -358,7 +398,7 @@ fun PreviewCalendarDayButton(
   @PreviewParameter(DayPropertiesPreviewParameterProvider::class) properties: DayProperties
 ) {
   MaterialTheme(colors = Theme.darkColors) {
-    CalendarDayCell(1, 1, properties) { }
+    CalendarDayCell(1, 1, properties)
   }
 }
 
@@ -378,23 +418,23 @@ private fun CalendarDayCell(
   dayOfMonth: Int,
   workoutDay: Int,
   properties: DayProperties,
-  onClick: () -> Unit
+  selected: Boolean = false
 ) {
+  // Last-viewed (aligned) and selected-as-start (unaligned) are mutually exclusive - one
+  // outline style covers "this is the reference day" in either mode.
+  val highlighted = properties.isLastViewedDay || selected
   val backgroundColor = when {
-    properties.isLastViewedDay -> MaterialTheme.colors.background
+    highlighted -> MaterialTheme.colors.background
     properties.isCompletedDay -> MaterialTheme.colors.secondary
     else -> MaterialTheme.colors.primary
   }
   val contentColor = contentColorFor(backgroundColor)
-  val border = if (properties.isLastViewedDay)
-    BorderStroke(3.dp, MaterialTheme.colors.primaryVariant) else null
-  val label = if (properties.isRestDay) "Rest day $workoutDay" else "Day $workoutDay"
+  val border = if (highlighted) BorderStroke(3.dp, MaterialTheme.colors.primaryVariant) else null
 
   Surface(
     modifier = Modifier
       .fillMaxSize()
-      .alpha(if (properties.isRestDay) 0.45f else 1f)
-      .clickable(onClickLabel = label, onClick = onClick),
+      .alpha(if (properties.isRestDay) 0.45f else 1f),
     shape = RoundedCornerShape(8.dp),
     color = backgroundColor,
     contentColor = contentColor,

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Main.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Main.kt
@@ -1,5 +1,6 @@
 package com.litus_animae.refitted.ui.compose.calendar
 
+import android.app.DatePickerDialog
 import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
@@ -39,6 +40,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.credentials.CustomCredential
@@ -56,6 +58,7 @@ import com.litus_animae.refitted.ui.models.WorkoutViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @Composable
@@ -275,10 +278,29 @@ fun Calendar(
         Text("Open the menu to pick a workout")
       }
     } else {
+      val aligned = selectedWorkoutPlan!!.workoutStartDate.toEpochMilli() != 0L
+      var showStartDatePicker by remember { mutableStateOf(false) }
+      if (showStartDatePicker) {
+        val context = LocalContext.current
+        LaunchedEffect(Unit) {
+          val today = LocalDate.now()
+          DatePickerDialog(
+            context,
+            { _, year, month, dayOfMonth ->
+              workoutModel.setStartDate(selectedWorkoutPlan!!, LocalDate.of(year, month + 1, dayOfMonth))
+              showStartDatePicker = false
+            },
+            today.year, today.monthValue - 1, today.dayOfMonth
+          ).apply {
+            setOnCancelListener { showStartDatePicker = false }
+          }.show()
+        }
+      }
       WorkoutCalendar(
         selectedWorkoutPlan!!,
         completedDays,
-        contentPadding = contentPadding
+        contentPadding = contentPadding,
+        onPickStartDate = if (!aligned) ({ showStartDatePicker = true }) else null
       ) {
         navigateToWorkoutDay(selectedWorkoutPlan!!, it)
         workoutModel.setLastViewedDay(selectedWorkoutPlan!!, it)

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Main.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Main.kt
@@ -1,6 +1,5 @@
 package com.litus_animae.refitted.ui.compose.calendar
 
-import android.app.DatePickerDialog
 import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
@@ -40,7 +39,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.credentials.CustomCredential
@@ -58,7 +56,6 @@ import com.litus_animae.refitted.ui.models.WorkoutViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
-import java.time.LocalDate
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @Composable
@@ -278,29 +275,11 @@ fun Calendar(
         Text("Open the menu to pick a workout")
       }
     } else {
-      val aligned = selectedWorkoutPlan!!.workoutStartDate.toEpochMilli() != 0L
-      var showStartDatePicker by remember { mutableStateOf(false) }
-      if (showStartDatePicker) {
-        val context = LocalContext.current
-        LaunchedEffect(Unit) {
-          val today = LocalDate.now()
-          DatePickerDialog(
-            context,
-            { _, year, month, dayOfMonth ->
-              workoutModel.setStartDate(selectedWorkoutPlan!!, LocalDate.of(year, month + 1, dayOfMonth))
-              showStartDatePicker = false
-            },
-            today.year, today.monthValue - 1, today.dayOfMonth
-          ).apply {
-            setOnCancelListener { showStartDatePicker = false }
-          }.show()
-        }
-      }
       WorkoutCalendar(
         selectedWorkoutPlan!!,
         completedDays,
         contentPadding = contentPadding,
-        onPickStartDate = if (!aligned) ({ showStartDatePicker = true }) else null
+        onSaveStartDate = { workoutModel.setStartDate(selectedWorkoutPlan!!, it) }
       ) {
         navigateToWorkoutDay(selectedWorkoutPlan!!, it)
         workoutModel.setLastViewedDay(selectedWorkoutPlan!!, it)

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/CircularRestTimer.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/CircularRestTimer.kt
@@ -169,7 +169,7 @@ fun CircularRestTimer(
 
   val primaryColor = MaterialTheme.colors.primary
   val amberColor = Theme.timerAmber
-  val successColor = Theme.timerSuccess
+  val successColor = Theme.goodAttention
   val trackColor = Theme.timerTrack
 
   Column(

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
@@ -128,7 +128,8 @@ fun Exercise(
         onStartEditWeight = {
           sheetWeight = it
           scaffoldScope.launch { sheetState.show() }
-        })
+        },
+        onSetSaved = { workoutModel.alignToDayIfUnaligned(loadedWorkoutPlan, day.toIntOrNull() ?: 1) })
     }
   }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -57,7 +57,8 @@ fun PagerExerciseView(
   setHistoryList: (Flow<PagingData<SetRecord>>) -> Unit,
   setContextMenu: (@Composable RowScope.() -> Unit) -> Unit,
   onAlternateChange: (Int) -> Unit,
-  onStartEditWeight: (Weight) -> Unit
+  onStartEditWeight: (Weight) -> Unit,
+  onSetSaved: () -> Unit = {}
 ) {
   val allRecords by model.records.collectAsState(initial = emptyList())
   val setRecords = recordsByExerciseId(allRecords = allRecords)
@@ -126,6 +127,7 @@ fun PagerExerciseView(
           model.saveExercise(
             SetRecord(savedRecord.weight, savedRecord.reps, savedRecord.set)
           )
+          onSetSaved()
           // Superset auto-advance
           instruction?.offsetToNextSuperSet?.let { offset ->
             val isChallengeSet = exerciseSet!!.sets < 0

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/util/Theme.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/util/Theme.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.graphics.Color
 object Theme {
 
   val timerAmber = Color(0xFFFFB300)   // warning/almost-done arc colour
-  val timerSuccess = Color(0xFF2E7D32)   // finish blink colour
+  val goodAttention = Color(0xFF2E7D32)   // draws the eye for a positive reason — timer finish blink, today marker
   val timerTrack = Color(0x1F000000)   // muted track behind the arc — both palettes use a white surface/background
 
   val darkColors = Colors(

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/WorkoutViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/WorkoutViewModel.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
@@ -151,13 +152,32 @@ class WorkoutViewModel @Inject constructor(
     }
   }
 
-  fun resetWorkoutCompletion(workout: WorkoutPlan) {
+  private fun writeStartDate(workout: WorkoutPlan, startDate: Instant) {
     viewModelScope.launch(Dispatchers.IO) {
-      log.d(TAG, "Setting start date for plan $workout")
-      val now = Instant.now()
-      savedStateHandle[selectedPlanStartDate] = now.toEpochMilli()
-      workoutPlanRepo.setWorkoutStartDate(workout, now)
+      log.d(TAG, "Setting start date $startDate for plan $workout")
+      savedStateHandle[selectedPlanStartDate] = startDate.toEpochMilli()
+      workoutPlanRepo.setWorkoutStartDate(workout, startDate)
     }
+  }
+
+  // Epoch marks a plan as not yet aligned to a real calendar date - see WorkoutCalendar.
+  private val unaligned = Instant.ofEpochMilli(0)
+
+  fun resetWorkoutCompletion(workout: WorkoutPlan) {
+    writeStartDate(workout, unaligned)
+  }
+
+  // No-op once aligned, so this is safe to call on every set save.
+  fun alignToDayIfUnaligned(workout: WorkoutPlan?, day: Int) {
+    if (workout == null || workout.workoutStartDate != unaligned) return
+    val zone = ZoneId.systemDefault()
+    val anchor = LocalDate.now(zone).minusDays((day - 1).toLong()).atStartOfDay(zone).toInstant()
+    writeStartDate(workout, anchor)
+  }
+
+  // date may be in the future or past - explicit picks aren't limited to "starting today".
+  fun setStartDate(workout: WorkoutPlan, date: LocalDate) {
+    writeStartDate(workout, date.atStartOfDay(ZoneId.systemDefault()).toInstant())
   }
 
   var workoutError: String? by mutableStateOf(null)

--- a/ui/src/main/res/values/changelog.xml
+++ b/ui/src/main/res/values/changelog.xml
@@ -2,6 +2,8 @@
 <resources>
     <string name="changelog_version_header">**</string>
     <string-array name="changelog">
+        <item>**v1.3.1</item>
+        <item>Calendar now aligns to real dates</item>
         <item>**v1.3.0</item>
         <item>Updated Exercise UI</item>
     </string-array>


### PR DESCRIPTION
## Summary
- `WorkoutCalendar` now renders an actual month grid (weekday header, prev/next nav, legend, hide-rest-days toggle) instead of an abstract 1..N day count, projecting workout days off `workoutStartDate`.
- `workoutStartDate` epoch is the "unaligned" sentinel (already the domain default). While unaligned, the calendar itself is the start-date picker: tapping any day previews it as day 1 with the grid re-projecting live, and a Save banner confirms it (animating away once saved). Logging a first set also auto-aligns to today as a fallback. "Reset workout" clears back to unaligned.
- Today's cell is marked in bold green (`Theme.goodAttention`, renamed from `timerSuccess` since it's no longer timer-specific) regardless of its workout state.

## Test plan
- [x] `./gradlew :ui:compileDebugKotlin` — clean, no warnings
- [x] `./gradlew :ui:testDebugUnitTest` — passes (no calendar unit tests exist)
- [ ] Manual on-device: pick a fresh workout, confirm picker banner + live preview, Save, verify alignment persists; Reset workout returns to picker; logging a set on an unaligned plan auto-aligns to today

🤖 Generated with [Claude Code](https://claude.com/claude-code)