### PR TITLE
Add BYO (build-your-own) custom workout plans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,5 +329,12 @@ All three components share the same AWS DynamoDB backend for data storage.
 - Avoid fully qualified class names in code. Prefer file imports and use renames in the import syntax
 - Keep modules focused: domain logic in `:data`, persistence in `:room`, UI in `:ui`, etc.
 - Repository implementations in `:app` bridge multiple data sources (Room + DynamoDB)
-- Prefer succinct commit messages over long ones — a short message that explains what's not obvious from the diff beats a detailed one
 - Do not add comments explaining what code does when the code is self-explanatory. Only comment non-obvious *why* (a hidden constraint, a workaround, a subtle invariant) — never restate the *what*. Prefer putting that *why* in the commit message over a code comment when it's about the change itself rather than a lasting property of the code
+
+## Commit Conventions
+
+- One commit = one digestible, self-contained change, isolated by locus (module/file area) when possible. Never land a mega-commit that interleaves unrelated areas — it can't be reviewed in logical chunks.
+- Split a feature into tiers before writing code, and commit tier by tier. Tiers normally follow the architecture: domain/data models (`:data`), then persistence (`:room`/`:app` repositories), then UI (`:ui`). Going UI-first against dummy data is fine when the backend isn't ready yet — just keep each tier its own commit either way.
+- Each commit should build on its own — avoid a commit that only compiles once a later commit lands.
+- Prefer succinct commit messages over long ones — a short message that explains what's not obvious from the diff beats a detailed one.
+- Do not add a `Claude-Session` link or similar session-tracking trailer to commit messages unless explicitly asked. A `Co-Authored-By` trailer is fine.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
         compileSdk = 37
         targetSdk = 37
         versionCode = 3726002
-        versionName = "1.3.1-SNAPSHOT"
+        versionName = "1.4.0-SNAPSHOT"
         testInstrumentationRunner = "com.litus_animae.refitted.HiltTestRunner"
 
         javaCompileOptions {

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/ExerciseSetMapping.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/ExerciseSetMapping.kt
@@ -1,0 +1,30 @@
+package com.litus_animae.refitted.data.room
+
+import com.litus_animae.refitted.data.models.ExerciseSet
+import com.litus_animae.refitted.room.ExerciseDao
+import com.litus_animae.refitted.room.entities.RoomExerciseSet
+import kotlinx.coroutines.flow.map
+
+/**
+ * Builds the domain [ExerciseSet], resolving its [Exercise][com.litus_animae.refitted.data.models.Exercise]
+ * as a live Room-backed flow rather than [RoomExerciseSet.toDomain]'s `flowOf(null)`. Shared by
+ * [ExerciseSetPager] (network-backed days) and [RoomCacheExerciseRepository] (custom, local-only days).
+ */
+internal fun buildExerciseSet(exerciseDao: ExerciseDao, roomSet: RoomExerciseSet): ExerciseSet =
+  ExerciseSet(
+    workout = roomSet.workout,
+    day = roomSet.day,
+    step = roomSet.step,
+    name = roomSet.name,
+    note = roomSet.note,
+    reps = roomSet.reps,
+    sets = roomSet.sets,
+    isToFailure = roomSet.isToFailure,
+    rest = roomSet.rest,
+    repsUnit = roomSet.repsUnit,
+    repsRange = roomSet.repsRange,
+    timeLimit = roomSet.timeLimit,
+    timeLimitUnit = roomSet.timeLimitUnit,
+    repsSequence = roomSet.repsSequence,
+    exercise = exerciseDao.getExercise(roomSet.name, roomSet.workout).map { it?.toDomain() }
+  )

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/ExerciseSetPager.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/ExerciseSetPager.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map as flowMap
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.withContext
 
@@ -73,24 +72,7 @@ class ExerciseSetPager(
   }.flow.mapLatest {
     it.map { step ->
       val roomSet = exerciseDao.loadExerciseSet(dayAndWorkout.day, dayAndWorkout.workoutId, step)!!
-      val exercise = exerciseDao.getExercise(roomSet.name, roomSet.workout).flowMap { it?.toDomain() }
-      ExerciseSet(
-        workout = roomSet.workout,
-        day = roomSet.day,
-        step = roomSet.step,
-        name = roomSet.name,
-        note = roomSet.note,
-        reps = roomSet.reps,
-        sets = roomSet.sets,
-        isToFailure = roomSet.isToFailure,
-        rest = roomSet.rest,
-        repsUnit = roomSet.repsUnit,
-        repsRange = roomSet.repsRange,
-        timeLimit = roomSet.timeLimit,
-        timeLimitUnit = roomSet.timeLimitUnit,
-        repsSequence = roomSet.repsSequence,
-        exercise = exercise
-      )
+      buildExerciseSet(exerciseDao, roomSet)
     }
   }.flowOn(Dispatchers.IO)
 

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/ExerciseSetPager.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/ExerciseSetPager.kt
@@ -37,19 +37,9 @@ class ExerciseSetPager(
       Log.d(TAG, "initializing")
       val (day, workout) = dayAndWorkout
       return withContext(Dispatchers.IO) {
-        val localStepCount = exerciseDao.loadSteps(day, workout).size
-        if (localStepCount == 0) return@withContext InitializeAction.LAUNCH_INITIAL_REFRESH
-        // A non-empty cache isn't necessarily a complete one - e.g. the app was killed mid-load
-        // after storing only some of the day's sets. Compare against the network's real count
-        // rather than trusting "any rows at all" as "fully loaded".
-        val remoteStepCount = try {
-          networkService.getExerciseSets(dayAndWorkout).size
-        } catch (ex: Throwable) {
-          log.e(TAG, "initialize: couldn't verify cache completeness, keeping cached data", ex)
-          return@withContext InitializeAction.SKIP_INITIAL_REFRESH
-        }
-        if (localStepCount < remoteStepCount) InitializeAction.LAUNCH_INITIAL_REFRESH
-        else InitializeAction.SKIP_INITIAL_REFRESH
+        if (exerciseDao.loadSteps(day, workout).isNotEmpty())
+          InitializeAction.SKIP_INITIAL_REFRESH
+        else InitializeAction.LAUNCH_INITIAL_REFRESH
       }
     }
 

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/ExerciseSetPager.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/ExerciseSetPager.kt
@@ -37,9 +37,19 @@ class ExerciseSetPager(
       Log.d(TAG, "initializing")
       val (day, workout) = dayAndWorkout
       return withContext(Dispatchers.IO) {
-        if (exerciseDao.loadSteps(day, workout).isNotEmpty())
-          InitializeAction.SKIP_INITIAL_REFRESH
-        else InitializeAction.LAUNCH_INITIAL_REFRESH
+        val localStepCount = exerciseDao.loadSteps(day, workout).size
+        if (localStepCount == 0) return@withContext InitializeAction.LAUNCH_INITIAL_REFRESH
+        // A non-empty cache isn't necessarily a complete one - e.g. the app was killed mid-load
+        // after storing only some of the day's sets. Compare against the network's real count
+        // rather than trusting "any rows at all" as "fully loaded".
+        val remoteStepCount = try {
+          networkService.getExerciseSets(dayAndWorkout).size
+        } catch (ex: Throwable) {
+          log.e(TAG, "initialize: couldn't verify cache completeness, keeping cached data", ex)
+          return@withContext InitializeAction.SKIP_INITIAL_REFRESH
+        }
+        if (localStepCount < remoteStepCount) InitializeAction.LAUNCH_INITIAL_REFRESH
+        else InitializeAction.SKIP_INITIAL_REFRESH
       }
     }
 

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -4,6 +4,7 @@ import androidx.paging.AsyncPagingDataDiffer
 import androidx.paging.LoadState
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import androidx.paging.map
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListUpdateCallback
@@ -16,6 +17,8 @@ import com.litus_animae.refitted.data.models.ExerciseSet
 import com.litus_animae.refitted.data.models.Record
 import com.litus_animae.refitted.data.models.SetRecord
 import com.litus_animae.refitted.room.RefittedRoomProvider
+import com.litus_animae.refitted.room.entities.RoomExercise
+import com.litus_animae.refitted.room.entities.RoomExerciseSet
 import com.litus_animae.refitted.room.entities.RoomSetRecord
 import com.litus_animae.refitted.util.LogUtil
 import com.litus_animae.refitted.util.progressiveZipWithPrevious
@@ -30,7 +33,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -114,20 +119,42 @@ class RoomCacheExerciseRepository @Inject constructor(
   override suspend fun loadExercises(day: String, workoutId: String) {
     _exercisesAreLoading.emit(true)
     log.i(TAG, "loadExercises: updating to workout $workoutId, day $day")
-    val mediator =
-      ExerciseSetPager(DayAndWorkout(day, workoutId), roomProvider, networkService, log)
+    val isCustom = withContext(Dispatchers.IO) {
+      refittedRoom.getWorkoutPlanDao().getByName(workoutId)?.isCustom == true
+    }
+    val pagingData = if (isCustom) {
+      log.i(TAG, "loadExercises: $workoutId is a custom plan, paginating from Room only")
+      customExercisePagingData(day, workoutId)
+    } else {
+      ExerciseSetPager(DayAndWorkout(day, workoutId), roomProvider, networkService, log).pagingData
+    }
     coroutineScope {
 
-      launch { mediator.pagingData.collectLatest { pagingDataDiffer.submitData(it) } }
+      launch { pagingData.collectLatest { pagingDataDiffer.submitData(it) } }
 
       launch {
-        mediator.pagingData.collectLatest {
+        pagingData.collectLatest {
           pagingDataDiffer.loadStateFlow.collect {
             _exercisesAreLoading.emit(it.refresh is LoadState.Loading)
           }
         }
       }
     }
+  }
+
+  // Custom plans have no network-authored content, so this paginates straight from Room with no
+  // RemoteMediator - a pull-to-refresh can then never reach the network and wipe locally-added
+  // exercises via ExerciseDao.storeExercisesAndSets.
+  private fun customExercisePagingData(day: String, workoutId: String): Flow<PagingData<ExerciseSet>> {
+    val exerciseDao = refittedRoom.getExerciseDao()
+    return Pager(PagingConfig(20)) {
+      exerciseDao.getStepsPages(day, workoutId)
+    }.flow.mapLatest { pagingData ->
+      pagingData.map { step ->
+        val roomSet = exerciseDao.loadExerciseSet(day, workoutId, step)!!
+        buildExerciseSet(exerciseDao, roomSet)
+      }
+    }.flowOn(Dispatchers.IO)
   }
 
   override val records =
@@ -149,6 +176,40 @@ class RoomCacheExerciseRepository @Inject constructor(
 
   override fun loadWorkoutRecords(workoutId: String) {
     currentWorkout.value = workoutId
+  }
+
+  override suspend fun addCustomExercise(workout: String, day: String, exerciseName: String) {
+    withContext(Dispatchers.IO) {
+      val exerciseDao = refittedRoom.getExerciseDao()
+      val nextStep = exerciseDao.getMaxPrimaryStep(day, workout) + 1
+      // Reusing the exercise name as its Room id lets the same custom exercise, added on
+      // different days of the same plan, share one records history - same convention as
+      // admin-authored content (RoomExercise keyed by workout + exercise id).
+      val exerciseId = "custom_$exerciseName"
+      log.d(TAG, "adding custom exercise $exerciseId to $workout day $day, step $nextStep")
+      exerciseDao.storeExerciseAndSet(
+        RoomExercise(workout = workout, id = exerciseId),
+        RoomExerciseSet(
+          workout = workout,
+          day = day,
+          step = nextStep.toString(),
+          primaryStep = nextStep,
+          superSetStep = null,
+          alternateStep = null,
+          name = exerciseId,
+          note = "",
+          reps = -1,
+          sets = -1,
+          isToFailure = false,
+          rest = 90,
+          repsUnit = "",
+          repsRange = 0,
+          timeLimit = null,
+          timeLimitUnit = null,
+          repsSequence = emptyList()
+        )
+      )
+    }
   }
 
   fun getRecordsForLoadedExercises(

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -213,6 +213,21 @@ class RoomCacheExerciseRepository @Inject constructor(
     }
   }
 
+  override suspend fun updateCustomExerciseSet(
+    workout: String,
+    day: String,
+    step: String,
+    sets: Int,
+    reps: Int,
+    rest: Int
+  ) {
+    withContext(Dispatchers.IO) {
+      val exerciseDao = refittedRoom.getExerciseDao()
+      val existing = exerciseDao.loadExerciseSet(day, workout, step) ?: return@withContext
+      exerciseDao.storeExerciseSet(existing.copy(sets = sets, reps = reps, rest = rest))
+    }
+  }
+
   override fun exercisesByMuscle(muscle: String): Flow<List<Exercise>> {
     val exerciseDao = refittedRoom.getExerciseDao()
     val prefixQueries = MuscleGroup.prefixesFor(muscle).map { prefix ->

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -78,11 +78,16 @@ class RoomCacheExerciseRepository @Inject constructor(
   private val pagingDataDiffer = AsyncPagingDataDiffer(
     diffCallback = object : DiffUtil.ItemCallback<ExerciseSet>() {
       override fun areItemsTheSame(oldItem: ExerciseSet, newItem: ExerciseSet): Boolean {
-        return oldItem == newItem
+        return oldItem.id == newItem.id
       }
 
+      // Room hands back a fresh `exercise: Flow<Exercise?>` on every query, so full data-class
+      // equality here is nearly always false across a reload even when nothing user-visible
+      // changed - that's fine, it just means onChanged fires a bit more than strictly needed,
+      // which is harmless (unlike areItemsTheSame returning false, which reads as a delete+
+      // insert and makes the item visibly vanish and reappear).
       override fun areContentsTheSame(oldItem: ExerciseSet, newItem: ExerciseSet): Boolean {
-        return areItemsTheSame(oldItem, newItem)
+        return oldItem == newItem
       }
 
     },

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -284,6 +284,20 @@ class RoomCacheExerciseRepository @Inject constructor(
     }
   }
 
+  override suspend fun updateCustomExerciseSetNote(workout: String, day: String, step: String, note: String) {
+    exerciseState.update { current ->
+      current.map { set ->
+        if (set.workout == workout && set.day == day && set.step == step) set.copy(note = note)
+        else set
+      }
+    }
+    withContext(Dispatchers.IO) {
+      val exerciseDao = refittedRoom.getExerciseDao()
+      val existing = exerciseDao.loadExerciseSet(day, workout, step) ?: return@withContext
+      exerciseDao.storeExerciseSet(existing.copy(note = note))
+    }
+  }
+
   override fun exercisesByMuscle(muscle: String): Flow<List<Exercise>> {
     val exerciseDao = refittedRoom.getExerciseDao()
     val prefixQueries = MuscleGroup.prefixesFor(muscle).map { prefix ->

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -28,12 +28,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -137,9 +139,20 @@ class RoomCacheExerciseRepository @Inject constructor(
 
       launch {
         pagingData.collectLatest {
-          pagingDataDiffer.loadStateFlow.collect {
-            _exercisesAreLoading.emit(it.refresh is LoadState.Loading)
-          }
+          pagingDataDiffer.loadStateFlow
+            .map { it.refresh is LoadState.Loading }
+            .distinctUntilChanged()
+            .collectLatest { isLoading ->
+              if (isLoading) {
+                // A single-set edit (rest/target steppers) invalidates the same PagingSource
+                // and reloads in a few ms - debounce so that blip never reaches the spinner;
+                // a genuinely slow load (first open, network refresh) still shows it.
+                delay(LOADING_INDICATOR_DEBOUNCE_MILLIS)
+                _exercisesAreLoading.emit(true)
+              } else {
+                _exercisesAreLoading.emit(false)
+              }
+            }
         }
       }
     }
@@ -365,5 +378,6 @@ class RoomCacheExerciseRepository @Inject constructor(
 
   companion object {
     private const val TAG = "RoomCacheExerciseRepository"
+    private const val LOADING_INDICATOR_DEBOUNCE_MILLIS = 250L
   }
 }

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -273,6 +273,17 @@ class RoomCacheExerciseRepository @Inject constructor(
     }
   }
 
+  override suspend fun deleteCustomExerciseSet(workout: String, day: String, step: String) {
+    // Optimistic, same reasoning as updateCustomExerciseSet - the delete below still lands on
+    // the observed table and would eventually reload the list regardless.
+    exerciseState.update { current ->
+      current.filterNot { it.workout == workout && it.day == day && it.step == step }
+    }
+    withContext(Dispatchers.IO) {
+      refittedRoom.getExerciseDao().deleteExerciseSet(day, workout, step)
+    }
+  }
+
   override fun exercisesByMuscle(muscle: String): Flow<List<Exercise>> {
     val exerciseDao = refittedRoom.getExerciseDao()
     val prefixQueries = MuscleGroup.prefixesFor(muscle).map { prefix ->

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.lang.Integer.min
@@ -221,10 +222,31 @@ class RoomCacheExerciseRepository @Inject constructor(
     reps: Int,
     rest: Int
   ) {
+    // Optimistic: the write below still lands on the `exerciseset` table Room's PagingSource
+    // observes, so it'll eventually trigger a reload regardless - patching here means the UI
+    // reflects the edit immediately instead of waiting on that round-trip.
+    applyOptimisticSetUpdate(workout, day, step, sets, reps, rest)
     withContext(Dispatchers.IO) {
       val exerciseDao = refittedRoom.getExerciseDao()
       val existing = exerciseDao.loadExerciseSet(day, workout, step) ?: return@withContext
       exerciseDao.storeExerciseSet(existing.copy(sets = sets, reps = reps, rest = rest))
+    }
+  }
+
+  private fun applyOptimisticSetUpdate(
+    workout: String,
+    day: String,
+    step: String,
+    sets: Int,
+    reps: Int,
+    rest: Int
+  ) {
+    exerciseState.update { current ->
+      current.map { set ->
+        if (set.workout == workout && set.day == day && set.step == step) {
+          set.copy(sets = sets, reps = reps, rest = rest)
+        } else set
+      }
     }
   }
 

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -194,7 +195,12 @@ class RoomCacheExerciseRepository @Inject constructor(
     currentWorkout.value = workoutId
   }
 
-  override suspend fun addCustomExercise(workout: String, day: String, exerciseId: String) {
+  override suspend fun addCustomExercise(
+    workout: String,
+    day: String,
+    exerciseId: String,
+    description: String?
+  ) {
     withContext(Dispatchers.IO) {
       val exerciseDao = refittedRoom.getExerciseDao()
       val nextStep = exerciseDao.getMaxPrimaryStep(day, workout) + 1
@@ -202,8 +208,12 @@ class RoomCacheExerciseRepository @Inject constructor(
       // one records history across every day/plan it's added to - same convention as
       // admin-authored content (RoomExercise keyed by workout + exercise id).
       log.d(TAG, "adding custom exercise $exerciseId to $workout day $day, step $nextStep")
+      // storeExercise REPLACEs the whole row - a blank incoming description would otherwise wipe
+      // out a description this id/workout pair already has (e.g. re-adding after a delete).
+      val resolvedDescription = description?.takeIf { it.isNotBlank() }
+        ?: exerciseDao.getExercise(exerciseId, workout).first()?.description
       exerciseDao.storeExerciseAndSet(
-        RoomExercise(workout = workout, id = exerciseId),
+        RoomExercise(workout = workout, id = exerciseId, description = resolvedDescription),
         RoomExerciseSet(
           workout = workout,
           day = day,

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -220,7 +220,9 @@ class RoomCacheExerciseRepository @Inject constructor(
 
   override suspend fun loadRemoteExercisesByMuscle(workout: String, muscle: String): List<Exercise> {
     return withContext(Dispatchers.IO) {
-      networkService.getExercisesByMuscle(workout, muscle)
+      val exercises = networkService.getExercisesByMuscle(workout, muscle)
+      refittedRoom.getExerciseDao().storeExercises(exercises.map { RoomExercise.fromDomain(it) })
+      exercises
     }
   }
 

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -15,6 +15,7 @@ import com.litus_animae.refitted.data.models.Exercise
 import com.litus_animae.refitted.data.models.ExerciseCompletionRecord
 import com.litus_animae.refitted.data.models.ExerciseRecord
 import com.litus_animae.refitted.data.models.ExerciseSet
+import com.litus_animae.refitted.data.models.MuscleGroup
 import com.litus_animae.refitted.data.models.Record
 import com.litus_animae.refitted.data.models.SetRecord
 import com.litus_animae.refitted.room.RefittedRoomProvider
@@ -213,14 +214,22 @@ class RoomCacheExerciseRepository @Inject constructor(
   }
 
   override fun exercisesByMuscle(muscle: String): Flow<List<Exercise>> {
-    return refittedRoom.getExerciseDao().getExercisesByMusclePrefix("${muscle}_")
-      .map { roomExercises -> roomExercises.map { it.toDomain() } }
-      .flowOn(Dispatchers.IO)
+    val exerciseDao = refittedRoom.getExerciseDao()
+    val prefixQueries = MuscleGroup.prefixesFor(muscle).map { prefix ->
+      exerciseDao.getExercisesByMusclePrefix("${prefix}_")
+    }
+    return combine(prefixQueries) { resultsByPrefix ->
+      resultsByPrefix.flatMap { it }
+        .distinctBy { it.workout to it.id }
+        .map { it.toDomain() }
+    }.flowOn(Dispatchers.IO)
   }
 
   override suspend fun loadRemoteExercisesByMuscle(workout: String, muscle: String): List<Exercise> {
     return withContext(Dispatchers.IO) {
-      val exercises = networkService.getExercisesByMuscle(workout, muscle)
+      val exercises = MuscleGroup.prefixesFor(muscle)
+        .flatMap { prefix -> networkService.getExercisesByMuscle(workout, prefix) }
+        .distinctBy { it.id }
       refittedRoom.getExerciseDao().storeExercises(exercises.map { RoomExercise.fromDomain(it) })
       exercises
     }

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.ListUpdateCallback
 import com.litus_animae.refitted.data.ExerciseRepository
 import com.litus_animae.refitted.data.network.ExerciseSetNetworkService
 import com.litus_animae.refitted.data.models.DayAndWorkout
+import com.litus_animae.refitted.data.models.Exercise
 import com.litus_animae.refitted.data.models.ExerciseCompletionRecord
 import com.litus_animae.refitted.data.models.ExerciseRecord
 import com.litus_animae.refitted.data.models.ExerciseSet
@@ -178,14 +179,13 @@ class RoomCacheExerciseRepository @Inject constructor(
     currentWorkout.value = workoutId
   }
 
-  override suspend fun addCustomExercise(workout: String, day: String, exerciseName: String) {
+  override suspend fun addCustomExercise(workout: String, day: String, exerciseId: String) {
     withContext(Dispatchers.IO) {
       val exerciseDao = refittedRoom.getExerciseDao()
       val nextStep = exerciseDao.getMaxPrimaryStep(day, workout) + 1
-      // Reusing the exercise name as its Room id lets the same custom exercise, added on
-      // different days of the same plan, share one records history - same convention as
+      // Reusing an existing catalog exercise's id (rather than minting a new one) lets it share
+      // one records history across every day/plan it's added to - same convention as
       // admin-authored content (RoomExercise keyed by workout + exercise id).
-      val exerciseId = "custom_$exerciseName"
       log.d(TAG, "adding custom exercise $exerciseId to $workout day $day, step $nextStep")
       exerciseDao.storeExerciseAndSet(
         RoomExercise(workout = workout, id = exerciseId),
@@ -209,6 +209,18 @@ class RoomCacheExerciseRepository @Inject constructor(
           repsSequence = emptyList()
         )
       )
+    }
+  }
+
+  override fun exercisesByMuscle(muscle: String): Flow<List<Exercise>> {
+    return refittedRoom.getExerciseDao().getExercisesByMusclePrefix("${muscle}_")
+      .map { roomExercises -> roomExercises.map { it.toDomain() } }
+      .flowOn(Dispatchers.IO)
+  }
+
+  override suspend fun loadRemoteExercisesByMuscle(workout: String, muscle: String): List<Exercise> {
+    return withContext(Dispatchers.IO) {
+      networkService.getExercisesByMuscle(workout, muscle)
     }
   }
 

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -243,16 +243,19 @@ class RoomCacheExerciseRepository @Inject constructor(
     step: String,
     sets: Int,
     reps: Int,
-    rest: Int
+    rest: Int,
+    repsRange: Int
   ) {
     // Optimistic: the write below still lands on the `exerciseset` table Room's PagingSource
     // observes, so it'll eventually trigger a reload regardless - patching here means the UI
     // reflects the edit immediately instead of waiting on that round-trip.
-    applyOptimisticSetUpdate(workout, day, step, sets, reps, rest)
+    applyOptimisticSetUpdate(workout, day, step, sets, reps, rest, repsRange)
     withContext(Dispatchers.IO) {
       val exerciseDao = refittedRoom.getExerciseDao()
       val existing = exerciseDao.loadExerciseSet(day, workout, step) ?: return@withContext
-      exerciseDao.storeExerciseSet(existing.copy(sets = sets, reps = reps, rest = rest))
+      exerciseDao.storeExerciseSet(
+        existing.copy(sets = sets, reps = reps, rest = rest, repsRange = repsRange)
+      )
     }
   }
 
@@ -262,12 +265,13 @@ class RoomCacheExerciseRepository @Inject constructor(
     step: String,
     sets: Int,
     reps: Int,
-    rest: Int
+    rest: Int,
+    repsRange: Int
   ) {
     exerciseState.update { current ->
       current.map { set ->
         if (set.workout == workout && set.day == day && set.step == step) {
-          set.copy(sets = sets, reps = reps, rest = rest)
+          set.copy(sets = sets, reps = reps, rest = rest, repsRange = repsRange)
         } else set
       }
     }

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepository.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 import javax.inject.Inject
 
 class RoomCacheWorkoutPlanRepository @Inject constructor(
@@ -52,5 +54,58 @@ class RoomCacheWorkoutPlanRepository @Inject constructor(
 
     override suspend fun setWorkoutGlobalAlternate(workoutPlan: WorkoutPlan, index: Int) {
         return workoutPlanDao.update(RoomWorkoutPlan.fromDomain(workoutPlan.copy(globalAlternate = index)))
+    }
+
+    override suspend fun createCustomPlan(name: String): WorkoutPlan {
+        // Self-authored plans start "today" - there's no admin-defined day one to align to.
+        val startOfToday = LocalDate.now(ZoneId.systemDefault()).atStartOfDay(ZoneId.systemDefault()).toInstant()
+        val plan = RoomWorkoutPlan(
+            workout = name,
+            totalDays = 0,
+            workoutStartDate = startOfToday,
+            isCustom = true
+        )
+        workoutPlanDao.insertAll(listOf(plan))
+        return plan.toDomain()
+    }
+
+    override suspend fun addDayToCustomPlan(workoutPlan: WorkoutPlan): Int {
+        val currentPlan = workoutPlanDao.getByName(workoutPlan.workout)
+            ?: RoomWorkoutPlan.fromDomain(workoutPlan)
+        val newDay = currentPlan.totalDays + 1
+        workoutPlanDao.update(currentPlan.copy(totalDays = newDay))
+        return newDay
+    }
+
+    override suspend fun copyCustomDay(workoutPlan: WorkoutPlan, fromDay: Int, toDay: Int?): Int {
+        val exerciseDao = database.getExerciseDao()
+        val currentPlan = workoutPlanDao.getByName(workoutPlan.workout)
+            ?: RoomWorkoutPlan.fromDomain(workoutPlan)
+        val newDay = toDay ?: (currentPlan.totalDays + 1)
+
+        val sourceSets = exerciseDao.loadDayExerciseSets(fromDay.toString(), workoutPlan.workout)
+        // Targets come from what was actually completed, not the source day's (possibly still
+        // open, sets = -1) definition - that's the point of "copy day".
+        val completedByTargetSet = exerciseDao
+            .loadDaySetRecords(workoutPlan.workout, fromDay.toString())
+            .groupBy { it.targetSet }
+
+        if (toDay != null) {
+            exerciseDao.clearDay(newDay.toString(), workoutPlan.workout)
+        }
+        val copiedSets = sourceSets.map { source ->
+            val completed = completedByTargetSet["$fromDay.${source.step}"]
+            if (completed.isNullOrEmpty()) {
+                source.copy(day = newDay.toString())
+            } else {
+                source.copy(day = newDay.toString(), sets = completed.size, reps = completed.last().reps)
+            }
+        }
+        exerciseDao.storeExerciseSets(copiedSets)
+
+        if (newDay > currentPlan.totalDays) {
+            workoutPlanDao.update(currentPlan.copy(totalDays = newDay))
+        }
+        return newDay
     }
 }

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepository.kt
@@ -44,6 +44,8 @@ class RoomCacheWorkoutPlanRepository @Inject constructor(
         return workoutPlanDao.planByName(name).map { it?.toDomain() }
     }
 
+    override val accessibleWorkoutNames: Flow<List<String>> = workoutPlanDao.getServerWorkoutNames()
+
     override suspend fun setWorkoutLastViewedDay(workoutPlan: WorkoutPlan, day: Int) {
         return workoutPlanDao.update(RoomWorkoutPlan.fromDomain(workoutPlan.copy(lastViewedDay = day)))
     }

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepository.kt
@@ -77,11 +77,21 @@ class RoomCacheWorkoutPlanRepository @Inject constructor(
         return newDay
     }
 
-    override suspend fun copyCustomDay(workoutPlan: WorkoutPlan, fromDay: Int, toDay: Int?): Int {
+    override suspend fun addRestDayToCustomPlan(workoutPlan: WorkoutPlan): Int {
+        val currentPlan = workoutPlanDao.getByName(workoutPlan.workout)
+            ?: RoomWorkoutPlan.fromDomain(workoutPlan)
+        val newDay = currentPlan.totalDays + 1
+        workoutPlanDao.update(
+            currentPlan.copy(totalDays = newDay, restDays = currentPlan.restDays + newDay)
+        )
+        return newDay
+    }
+
+    override suspend fun copyCustomDay(workoutPlan: WorkoutPlan, fromDay: Int): Int {
         val exerciseDao = database.getExerciseDao()
         val currentPlan = workoutPlanDao.getByName(workoutPlan.workout)
             ?: RoomWorkoutPlan.fromDomain(workoutPlan)
-        val newDay = toDay ?: (currentPlan.totalDays + 1)
+        val newDay = currentPlan.totalDays + 1
 
         val sourceSets = exerciseDao.loadDayExerciseSets(fromDay.toString(), workoutPlan.workout)
         // Targets come from what was actually completed, not the source day's (possibly still
@@ -90,9 +100,6 @@ class RoomCacheWorkoutPlanRepository @Inject constructor(
             .loadDaySetRecords(workoutPlan.workout, fromDay.toString())
             .groupBy { it.targetSet }
 
-        if (toDay != null) {
-            exerciseDao.clearDay(newDay.toString(), workoutPlan.workout)
-        }
         val copiedSets = sourceSets.map { source ->
             val completed = completedByTargetSet["$fromDay.${source.step}"]
             if (completed.isNullOrEmpty()) {
@@ -103,9 +110,21 @@ class RoomCacheWorkoutPlanRepository @Inject constructor(
         }
         exerciseDao.storeExerciseSets(copiedSets)
 
-        if (newDay > currentPlan.totalDays) {
-            workoutPlanDao.update(currentPlan.copy(totalDays = newDay))
-        }
+        workoutPlanDao.update(currentPlan.copy(totalDays = newDay))
         return newDay
+    }
+
+    override suspend fun clearCustomDay(workoutPlan: WorkoutPlan, day: Int) {
+        database.getExerciseDao().clearDay(day.toString(), workoutPlan.workout)
+    }
+
+    override suspend fun setCustomDayRest(workoutPlan: WorkoutPlan, day: Int, isRest: Boolean) {
+        val currentPlan = workoutPlanDao.getByName(workoutPlan.workout)
+            ?: RoomWorkoutPlan.fromDomain(workoutPlan)
+        val newRestDays = if (isRest) currentPlan.restDays + day else currentPlan.restDays - day
+        workoutPlanDao.update(currentPlan.copy(restDays = newRestDays))
+        if (isRest) {
+            database.getExerciseDao().clearDay(day.toString(), workoutPlan.workout)
+        }
     }
 }

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/WorkoutPlanRemoteMediator.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/WorkoutPlanRemoteMediator.kt
@@ -55,7 +55,7 @@ class WorkoutPlanRemoteMediator(
     val plans: List<WorkoutPlan> = networkService.getWorkoutPlans()
     database.withTransaction {
       val currentPlansByName = workoutPlanDao.getAll().map { it.toDomain() }.associateBy { it.workout }
-      workoutPlanDao.clearAll()
+      workoutPlanDao.clearServerPlans()
       val upsertPlans = plans.map { newPlan ->
         val existingPlan = currentPlansByName[newPlan.workout] ?: return@map RoomWorkoutPlan.fromDomain(newPlan)
         RoomWorkoutPlan.fromDomain(existingPlan.copy(

--- a/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
+++ b/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.litus_animae.refitted.data.models.Exercise
 import com.litus_animae.refitted.data.models.ExerciseSet
 import com.litus_animae.refitted.data.models.Record
 import com.litus_animae.refitted.data.models.SetRecord
+import com.litus_animae.refitted.room.entities.RoomExercise
 import com.litus_animae.refitted.room.entities.RoomExerciseSet
 import com.litus_animae.refitted.room.entities.RoomSetRecord
 import com.litus_animae.refitted.room.RefittedRoom
@@ -18,6 +19,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.emptyFlow
@@ -332,6 +334,50 @@ class RoomCacheExerciseRepositoryTest {
 
       // Then
       coVerify { exerciseDao.storeExerciseRecord(RoomSetRecord.fromDomain(newRecord)) }
+    }
+  }
+
+  @Nested
+  @DisplayName("addCustomExercise")
+  inner class AddCustomExercise {
+    @Test
+    fun `adds an open set at the next step`() = runTest {
+      // Given
+      coEvery { exerciseDao.getMaxPrimaryStep("2", workoutName) } returns 2
+      val storedExercise = slot<RoomExercise>()
+      val storedSet = slot<RoomExerciseSet>()
+      coEvery {
+        exerciseDao.storeExerciseAndSet(capture(storedExercise), capture(storedSet))
+      } returns Unit
+
+      // When
+      subject.addCustomExercise(workoutName, "2", "Push-Up")
+
+      // Then
+      assertThat(storedExercise.captured).isEqualTo(RoomExercise(workout = workoutName, id = "custom_Push-Up"))
+      assertThat(storedSet.captured.day).isEqualTo("2")
+      assertThat(storedSet.captured.step).isEqualTo("3")
+      assertThat(storedSet.captured.primaryStep).isEqualTo(3)
+      assertThat(storedSet.captured.name).isEqualTo("custom_Push-Up")
+      // No set limit yet - targets fill in as the user logs, same convention as challenge sets
+      assertThat(storedSet.captured.sets).isEqualTo(-1)
+      assertThat(storedSet.captured.reps).isEqualTo(-1)
+      assertThat(storedSet.captured.rest).isEqualTo(90)
+    }
+
+    @Test
+    fun `starts at step 1 for an empty day`() = runTest {
+      // Given
+      coEvery { exerciseDao.getMaxPrimaryStep("1", workoutName) } returns 0
+      val storedSet = slot<RoomExerciseSet>()
+      coEvery { exerciseDao.storeExerciseAndSet(any(), capture(storedSet)) } returns Unit
+
+      // When
+      subject.addCustomExercise(workoutName, "1", "Push-Up")
+
+      // Then
+      assertThat(storedSet.captured.step).isEqualTo("1")
+      assertThat(storedSet.captured.primaryStep).isEqualTo(1)
     }
   }
 }

--- a/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
+++ b/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
@@ -344,6 +344,7 @@ class RoomCacheExerciseRepositoryTest {
     fun `adds an open set at the next step`() = runTest {
       // Given
       coEvery { exerciseDao.getMaxPrimaryStep("2", workoutName) } returns 2
+      coEvery { exerciseDao.getExercise("Chest_Push-Up", workoutName) } returns flowOf(null)
       val storedExercise = slot<RoomExercise>()
       val storedSet = slot<RoomExerciseSet>()
       coEvery {
@@ -370,6 +371,7 @@ class RoomCacheExerciseRepositoryTest {
     fun `starts at step 1 for an empty day`() = runTest {
       // Given
       coEvery { exerciseDao.getMaxPrimaryStep("1", workoutName) } returns 0
+      coEvery { exerciseDao.getExercise("Chest_Push-Up", workoutName) } returns flowOf(null)
       val storedSet = slot<RoomExerciseSet>()
       coEvery { exerciseDao.storeExerciseAndSet(any(), capture(storedSet)) } returns Unit
 
@@ -379,6 +381,36 @@ class RoomCacheExerciseRepositoryTest {
       // Then
       assertThat(storedSet.captured.step).isEqualTo("1")
       assertThat(storedSet.captured.primaryStep).isEqualTo(1)
+    }
+
+    @Test
+    fun `carries the source exercise's description across`() = runTest {
+      // Given
+      coEvery { exerciseDao.getMaxPrimaryStep("2", workoutName) } returns 0
+      val storedExercise = slot<RoomExercise>()
+      coEvery { exerciseDao.storeExerciseAndSet(capture(storedExercise), any()) } returns Unit
+
+      // When
+      subject.addCustomExercise(workoutName, "2", "Chest_Push-Up", description = "Keep your core tight")
+
+      // Then
+      assertThat(storedExercise.captured.description).isEqualTo("Keep your core tight")
+    }
+
+    @Test
+    fun `falls back to the existing stored description when none is passed`() = runTest {
+      // Given - e.g. re-adding an exercise the picker didn't have a cached description for
+      coEvery { exerciseDao.getMaxPrimaryStep("2", workoutName) } returns 0
+      coEvery { exerciseDao.getExercise("Chest_Push-Up", workoutName) } returns
+        flowOf(RoomExercise(workout = workoutName, id = "Chest_Push-Up", description = "Existing description"))
+      val storedExercise = slot<RoomExercise>()
+      coEvery { exerciseDao.storeExerciseAndSet(capture(storedExercise), any()) } returns Unit
+
+      // When
+      subject.addCustomExercise(workoutName, "2", "Chest_Push-Up", description = null)
+
+      // Then - never clobbered by a blank incoming description
+      assertThat(storedExercise.captured.description).isEqualTo("Existing description")
     }
   }
 

--- a/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
+++ b/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
@@ -464,6 +464,37 @@ class RoomCacheExerciseRepositoryTest {
   }
 
   @Nested
+  @DisplayName("updateCustomExerciseSetNote")
+  inner class UpdateCustomExerciseSetNote {
+    @Test
+    fun `overwrites the existing set's note, keeping other fields`() = runTest {
+      // Given
+      coEvery { exerciseDao.loadExerciseSet("2", workoutName, "3") } returns simpleRoomSet.copy(day = "2", step = "3")
+      val storedSet = slot<RoomExerciseSet>()
+      coEvery { exerciseDao.storeExerciseSet(capture(storedSet)) } returns Unit
+
+      // When
+      subject.updateCustomExerciseSetNote(workoutName, "2", "3", note = "Keep elbows tucked")
+
+      // Then
+      assertThat(storedSet.captured.note).isEqualTo("Keep elbows tucked")
+      assertThat(storedSet.captured.reps).isEqualTo(simpleRoomSet.reps)
+    }
+
+    @Test
+    fun `does nothing when the set doesn't exist`() = runTest {
+      // Given
+      coEvery { exerciseDao.loadExerciseSet("2", workoutName, "3") } returns null
+
+      // When
+      subject.updateCustomExerciseSetNote(workoutName, "2", "3", note = "Keep elbows tucked")
+
+      // Then
+      coVerify(exactly = 0) { exerciseDao.storeExerciseSet(any()) }
+    }
+  }
+
+  @Nested
   @DisplayName("exercisesByMuscle")
   inner class ExercisesByMuscle {
     @Test

--- a/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
+++ b/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
@@ -425,12 +425,13 @@ class RoomCacheExerciseRepositoryTest {
       coEvery { exerciseDao.storeExerciseSet(capture(storedSet)) } returns Unit
 
       // When
-      subject.updateCustomExerciseSet(workoutName, "2", "3", sets = 4, reps = 12, rest = 45)
+      subject.updateCustomExerciseSet(workoutName, "2", "3", sets = 4, reps = 12, rest = 45, repsRange = 2)
 
       // Then
       assertThat(storedSet.captured.sets).isEqualTo(4)
       assertThat(storedSet.captured.reps).isEqualTo(12)
       assertThat(storedSet.captured.rest).isEqualTo(45)
+      assertThat(storedSet.captured.repsRange).isEqualTo(2)
       assertThat(storedSet.captured.name).isEqualTo(simpleRoomSet.name)
     }
 
@@ -440,7 +441,7 @@ class RoomCacheExerciseRepositoryTest {
       coEvery { exerciseDao.loadExerciseSet("2", workoutName, "3") } returns null
 
       // When
-      subject.updateCustomExerciseSet(workoutName, "2", "3", sets = 4, reps = 12, rest = 45)
+      subject.updateCustomExerciseSet(workoutName, "2", "3", sets = 4, reps = 12, rest = 45, repsRange = 0)
 
       // Then
       coVerify(exactly = 0) { exerciseDao.storeExerciseSet(any()) }

--- a/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
+++ b/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
@@ -383,6 +383,39 @@ class RoomCacheExerciseRepositoryTest {
   }
 
   @Nested
+  @DisplayName("updateCustomExerciseSet")
+  inner class UpdateCustomExerciseSet {
+    @Test
+    fun `overwrites the existing set's targets, keeping other fields`() = runTest {
+      // Given
+      coEvery { exerciseDao.loadExerciseSet("2", workoutName, "3") } returns simpleRoomSet.copy(day = "2", step = "3")
+      val storedSet = slot<RoomExerciseSet>()
+      coEvery { exerciseDao.storeExerciseSet(capture(storedSet)) } returns Unit
+
+      // When
+      subject.updateCustomExerciseSet(workoutName, "2", "3", sets = 4, reps = 12, rest = 45)
+
+      // Then
+      assertThat(storedSet.captured.sets).isEqualTo(4)
+      assertThat(storedSet.captured.reps).isEqualTo(12)
+      assertThat(storedSet.captured.rest).isEqualTo(45)
+      assertThat(storedSet.captured.name).isEqualTo(simpleRoomSet.name)
+    }
+
+    @Test
+    fun `does nothing when the set doesn't exist`() = runTest {
+      // Given
+      coEvery { exerciseDao.loadExerciseSet("2", workoutName, "3") } returns null
+
+      // When
+      subject.updateCustomExerciseSet(workoutName, "2", "3", sets = 4, reps = 12, rest = 45)
+
+      // Then
+      coVerify(exactly = 0) { exerciseDao.storeExerciseSet(any()) }
+    }
+  }
+
+  @Nested
   @DisplayName("exercisesByMuscle")
   inner class ExercisesByMuscle {
     @Test

--- a/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
+++ b/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
@@ -386,14 +386,32 @@ class RoomCacheExerciseRepositoryTest {
   @DisplayName("exercisesByMuscle")
   inner class ExercisesByMuscle {
     @Test
-    fun `queries by the muscle-group id prefix and maps to domain`() = runTest {
-      // Given
+    fun `queries every prefix mapped to the muscle group, including Compound, and merges results`() = runTest {
+      // Given - "Chest" maps to just itself, but every category also queries the shared
+      // Compound bucket (see MuscleGroup.prefixesFor)
       val roomExercise = RoomExercise(workout = workoutName, id = "Chest_Push-Up")
+      val compoundExercise = RoomExercise(workout = workoutName, id = "Compound_Burpees")
       coEvery { exerciseDao.getExercisesByMusclePrefix("Chest_") } returns flowOf(listOf(roomExercise))
+      coEvery { exerciseDao.getExercisesByMusclePrefix("Compound_") } returns flowOf(listOf(compoundExercise))
 
       // When / Then
       subject.exercisesByMuscle("Chest").test {
-        assertThat(awaitItem()).containsExactly(roomExercise.toDomain())
+        assertThat(awaitItem()).containsExactly(roomExercise.toDomain(), compoundExercise.toDomain())
+        awaitComplete()
+      }
+    }
+
+    @Test
+    fun `queries every stored spelling variant for a multi-prefix category`() = runTest {
+      // Given - "Quads" also covers the "Quadricep" spelling some admin programs use
+      val quadsExercise = RoomExercise(workout = workoutName, id = "Quads_Barbell Squats")
+      coEvery { exerciseDao.getExercisesByMusclePrefix("Quads_") } returns flowOf(listOf(quadsExercise))
+      coEvery { exerciseDao.getExercisesByMusclePrefix("Quadricep_") } returns flowOf(emptyList())
+      coEvery { exerciseDao.getExercisesByMusclePrefix("Compound_") } returns flowOf(emptyList())
+
+      // When / Then
+      subject.exercisesByMuscle("Quads").test {
+        assertThat(awaitItem()).containsExactly(quadsExercise.toDomain())
         awaitComplete()
       }
     }
@@ -403,16 +421,24 @@ class RoomCacheExerciseRepositoryTest {
   @DisplayName("loadRemoteExercisesByMuscle")
   inner class LoadRemoteExercisesByMuscle {
     @Test
-    fun `delegates to the network service`() = runTest {
+    fun `fans out to every mapped prefix, caches results, and merges them`() = runTest {
       // Given
       val remoteExercise = Exercise(workoutName, "Chest_Cable Fly")
+      val compoundExercise = Exercise(workoutName, "Compound_Burpees")
       coEvery { networkService.getExercisesByMuscle(workoutName, "Chest") } returns listOf(remoteExercise)
+      coEvery { networkService.getExercisesByMuscle(workoutName, "Compound") } returns listOf(compoundExercise)
+      coEvery { exerciseDao.storeExercises(any()) } returns Unit
 
       // When
       val result = subject.loadRemoteExercisesByMuscle(workoutName, "Chest")
 
       // Then
-      assertThat(result).containsExactly(remoteExercise)
+      assertThat(result).containsExactly(remoteExercise, compoundExercise)
+      coVerify {
+        exerciseDao.storeExercises(
+          listOf(RoomExercise.fromDomain(remoteExercise), RoomExercise.fromDomain(compoundExercise))
+        )
+      }
     }
   }
 }

--- a/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
+++ b/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
@@ -351,14 +351,15 @@ class RoomCacheExerciseRepositoryTest {
       } returns Unit
 
       // When
-      subject.addCustomExercise(workoutName, "2", "Push-Up")
+      subject.addCustomExercise(workoutName, "2", "Chest_Push-Up")
 
-      // Then
-      assertThat(storedExercise.captured).isEqualTo(RoomExercise(workout = workoutName, id = "custom_Push-Up"))
+      // Then - the id is stored as-is, whether it's a fresh "{muscleGroup}_{name}" id or an
+      // existing catalog exercise's id being reused for shared record history.
+      assertThat(storedExercise.captured).isEqualTo(RoomExercise(workout = workoutName, id = "Chest_Push-Up"))
       assertThat(storedSet.captured.day).isEqualTo("2")
       assertThat(storedSet.captured.step).isEqualTo("3")
       assertThat(storedSet.captured.primaryStep).isEqualTo(3)
-      assertThat(storedSet.captured.name).isEqualTo("custom_Push-Up")
+      assertThat(storedSet.captured.name).isEqualTo("Chest_Push-Up")
       // No set limit yet - targets fill in as the user logs, same convention as challenge sets
       assertThat(storedSet.captured.sets).isEqualTo(-1)
       assertThat(storedSet.captured.reps).isEqualTo(-1)
@@ -373,11 +374,45 @@ class RoomCacheExerciseRepositoryTest {
       coEvery { exerciseDao.storeExerciseAndSet(any(), capture(storedSet)) } returns Unit
 
       // When
-      subject.addCustomExercise(workoutName, "1", "Push-Up")
+      subject.addCustomExercise(workoutName, "1", "Chest_Push-Up")
 
       // Then
       assertThat(storedSet.captured.step).isEqualTo("1")
       assertThat(storedSet.captured.primaryStep).isEqualTo(1)
+    }
+  }
+
+  @Nested
+  @DisplayName("exercisesByMuscle")
+  inner class ExercisesByMuscle {
+    @Test
+    fun `queries by the muscle-group id prefix and maps to domain`() = runTest {
+      // Given
+      val roomExercise = RoomExercise(workout = workoutName, id = "Chest_Push-Up")
+      coEvery { exerciseDao.getExercisesByMusclePrefix("Chest_") } returns flowOf(listOf(roomExercise))
+
+      // When / Then
+      subject.exercisesByMuscle("Chest").test {
+        assertThat(awaitItem()).containsExactly(roomExercise.toDomain())
+        awaitComplete()
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("loadRemoteExercisesByMuscle")
+  inner class LoadRemoteExercisesByMuscle {
+    @Test
+    fun `delegates to the network service`() = runTest {
+      // Given
+      val remoteExercise = Exercise(workoutName, "Chest_Cable Fly")
+      coEvery { networkService.getExercisesByMuscle(workoutName, "Chest") } returns listOf(remoteExercise)
+
+      // When
+      val result = subject.loadRemoteExercisesByMuscle(workoutName, "Chest")
+
+      // Then
+      assertThat(result).containsExactly(remoteExercise)
     }
   }
 }

--- a/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
+++ b/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
@@ -448,6 +448,22 @@ class RoomCacheExerciseRepositoryTest {
   }
 
   @Nested
+  @DisplayName("deleteCustomExerciseSet")
+  inner class DeleteCustomExerciseSet {
+    @Test
+    fun `deletes the set by day, workout, and step`() = runTest {
+      // Given
+      coEvery { exerciseDao.deleteExerciseSet("2", workoutName, "3") } returns Unit
+
+      // When
+      subject.deleteCustomExerciseSet(workoutName, "2", "3")
+
+      // Then
+      coVerify { exerciseDao.deleteExerciseSet("2", workoutName, "3") }
+    }
+  }
+
+  @Nested
   @DisplayName("exercisesByMuscle")
   inner class ExercisesByMuscle {
     @Test

--- a/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepositoryTest.kt
+++ b/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepositoryTest.kt
@@ -1,0 +1,189 @@
+package com.litus_animae.refitted.data.room
+
+import com.google.common.truth.Truth.assertThat
+import com.litus_animae.refitted.data.models.WorkoutPlan
+import com.litus_animae.refitted.data.network.WorkoutPlanNetworkService
+import com.litus_animae.refitted.room.ExerciseDao
+import com.litus_animae.refitted.room.RefittedRoom
+import com.litus_animae.refitted.room.RefittedRoomProvider
+import com.litus_animae.refitted.room.WorkoutPlanDao
+import com.litus_animae.refitted.room.entities.RoomExerciseSet
+import com.litus_animae.refitted.room.entities.RoomSetRecord
+import com.litus_animae.refitted.room.entities.RoomWorkoutPlan
+import com.litus_animae.refitted.util.LogUtil
+import com.litus_animae.refitted.util.TestLogUtil
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+@ExperimentalCoroutinesApi
+class RoomCacheWorkoutPlanRepositoryTest {
+
+  private lateinit var subject: RoomCacheWorkoutPlanRepository
+
+  private val roomProvider: RefittedRoomProvider = mockk()
+  private val networkService: WorkoutPlanNetworkService = mockk()
+  private val roomDatabase: RefittedRoom = mockk()
+  private val workoutPlanDao: WorkoutPlanDao = mockk()
+  private val exerciseDao: ExerciseDao = mockk()
+  private val log: LogUtil = TestLogUtil
+
+  private val workoutName = "My Custom Plan"
+
+  @BeforeEach
+  fun setUp() {
+    every { roomProvider.refittedRoom } returns roomDatabase
+    every { roomDatabase.getWorkoutPlanDao() } returns workoutPlanDao
+    every { roomDatabase.getExerciseDao() } returns exerciseDao
+    every { workoutPlanDao.update(any()) } returns Unit
+
+    subject = RoomCacheWorkoutPlanRepository(roomProvider, networkService, log)
+  }
+
+  @Nested
+  @DisplayName("createCustomPlan")
+  inner class CreateCustomPlan {
+    @Test
+    fun `inserts an already-aligned custom plan and returns it`() = runTest {
+      // Given
+      val inserted = slot<List<RoomWorkoutPlan>>()
+      coEvery { workoutPlanDao.insertAll(capture(inserted)) } returns Unit
+
+      // When
+      val result = subject.createCustomPlan(workoutName)
+
+      // Then
+      assertThat(result.workout).isEqualTo(workoutName)
+      assertThat(result.isCustom).isTrue()
+      assertThat(result.totalDays).isEqualTo(0)
+      // Aligned means non-epoch, unlike an admin plan awaiting a start-date pick
+      assertThat(result.workoutStartDate).isNotEqualTo(Instant.ofEpochMilli(0))
+      assertThat(inserted.captured).containsExactly(RoomWorkoutPlan.fromDomain(result))
+    }
+  }
+
+  @Nested
+  @DisplayName("addDayToCustomPlan")
+  inner class AddDayToCustomPlan {
+    @Test
+    fun `increments totalDays and persists it`() = runTest {
+      // Given
+      val existingPlan = RoomWorkoutPlan(workout = workoutName, totalDays = 2, isCustom = true)
+      coEvery { workoutPlanDao.getByName(workoutName) } returns existingPlan
+
+      // When
+      val newDay = subject.addDayToCustomPlan(existingPlan.toDomain())
+
+      // Then
+      assertThat(newDay).isEqualTo(3)
+      coVerify { workoutPlanDao.update(existingPlan.copy(totalDays = 3)) }
+    }
+
+    @Test
+    fun `falls back to the passed-in plan when it isn't in the DB yet`() = runTest {
+      // Given
+      coEvery { workoutPlanDao.getByName(workoutName) } returns null
+      val plan = WorkoutPlan(workoutName, totalDays = 1, isCustom = true)
+
+      // When
+      val newDay = subject.addDayToCustomPlan(plan)
+
+      // Then
+      assertThat(newDay).isEqualTo(2)
+    }
+  }
+
+  @Nested
+  @DisplayName("copyCustomDay")
+  inner class CopyCustomDay {
+    private val sourceExercise = RoomExerciseSet(
+      workout = workoutName,
+      day = "1",
+      step = "1",
+      primaryStep = 1,
+      superSetStep = null,
+      alternateStep = null,
+      name = "custom_Push-Up",
+      note = "",
+      reps = -1,
+      sets = -1,
+      isToFailure = false,
+      rest = 90,
+      repsUnit = "",
+      repsRange = 0,
+      timeLimit = null,
+      timeLimitUnit = null,
+      repsSequence = emptyList()
+    )
+
+    @Test
+    fun `appends a new day with targets derived from completed sets`() = runTest {
+      // Given
+      val existingPlan = RoomWorkoutPlan(workout = workoutName, totalDays = 2, isCustom = true)
+      coEvery { workoutPlanDao.getByName(workoutName) } returns existingPlan
+      coEvery { exerciseDao.loadDayExerciseSets("1", workoutName) } returns listOf(sourceExercise)
+      coEvery { exerciseDao.loadDaySetRecords(workoutName, "1") } returns listOf(
+        RoomSetRecord(25.0, 9, workoutName, "1.1", Instant.ofEpochMilli(1), "custom_Push-Up"),
+        RoomSetRecord(25.0, 8, workoutName, "1.1", Instant.ofEpochMilli(2), "custom_Push-Up")
+      )
+      val stored = slot<List<RoomExerciseSet>>()
+      coEvery { exerciseDao.storeExerciseSets(capture(stored)) } returns Unit
+
+      // When
+      val newDay = subject.copyCustomDay(existingPlan.toDomain(), fromDay = 1, toDay = null)
+
+      // Then - a new day 3, with sets/reps filled from what was actually completed
+      assertThat(newDay).isEqualTo(3)
+      assertThat(stored.captured).containsExactly(
+        sourceExercise.copy(day = "3", sets = 2, reps = 8)
+      )
+      coVerify(exactly = 0) { exerciseDao.clearDay(any(), any()) }
+      coVerify { workoutPlanDao.update(existingPlan.copy(totalDays = 3)) }
+    }
+
+    @Test
+    fun `copies as still-open sets when nothing was completed`() = runTest {
+      // Given
+      val existingPlan = RoomWorkoutPlan(workout = workoutName, totalDays = 2, isCustom = true)
+      coEvery { workoutPlanDao.getByName(workoutName) } returns existingPlan
+      coEvery { exerciseDao.loadDayExerciseSets("1", workoutName) } returns listOf(sourceExercise)
+      coEvery { exerciseDao.loadDaySetRecords(workoutName, "1") } returns emptyList()
+      val stored = slot<List<RoomExerciseSet>>()
+      coEvery { exerciseDao.storeExerciseSets(capture(stored)) } returns Unit
+
+      // When
+      subject.copyCustomDay(existingPlan.toDomain(), fromDay = 1, toDay = null)
+
+      // Then
+      assertThat(stored.captured).containsExactly(sourceExercise.copy(day = "3"))
+    }
+
+    @Test
+    fun `overwrites an existing day and leaves totalDays unchanged`() = runTest {
+      // Given
+      val existingPlan = RoomWorkoutPlan(workout = workoutName, totalDays = 3, isCustom = true)
+      coEvery { workoutPlanDao.getByName(workoutName) } returns existingPlan
+      coEvery { exerciseDao.loadDayExerciseSets("1", workoutName) } returns listOf(sourceExercise)
+      coEvery { exerciseDao.loadDaySetRecords(workoutName, "1") } returns emptyList()
+      coEvery { exerciseDao.clearDay("2", workoutName) } returns Unit
+      coEvery { exerciseDao.storeExerciseSets(any()) } returns Unit
+
+      // When
+      val newDay = subject.copyCustomDay(existingPlan.toDomain(), fromDay = 1, toDay = 2)
+
+      // Then
+      assertThat(newDay).isEqualTo(2)
+      coVerify { exerciseDao.clearDay("2", workoutName) }
+      coVerify(exactly = 0) { workoutPlanDao.update(any()) }
+    }
+  }
+}

--- a/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepositoryTest.kt
+++ b/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepositoryTest.kt
@@ -18,6 +18,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -45,6 +46,7 @@ class RoomCacheWorkoutPlanRepositoryTest {
     every { roomDatabase.getWorkoutPlanDao() } returns workoutPlanDao
     every { roomDatabase.getExerciseDao() } returns exerciseDao
     every { workoutPlanDao.update(any()) } returns Unit
+    every { workoutPlanDao.getServerWorkoutNames() } returns emptyFlow()
 
     subject = RoomCacheWorkoutPlanRepository(roomProvider, networkService, log)
   }
@@ -139,13 +141,14 @@ class RoomCacheWorkoutPlanRepositoryTest {
       coEvery { exerciseDao.storeExerciseSets(capture(stored)) } returns Unit
 
       // When
-      val newDay = subject.copyCustomDay(existingPlan.toDomain(), fromDay = 1, toDay = null)
+      val newDay = subject.copyCustomDay(existingPlan.toDomain(), fromDay = 1)
 
       // Then - a new day 3, with sets/reps filled from what was actually completed
       assertThat(newDay).isEqualTo(3)
       assertThat(stored.captured).containsExactly(
         sourceExercise.copy(day = "3", sets = 2, reps = 8)
       )
+      // Copy is append-only - it must never touch an existing day's rows.
       coVerify(exactly = 0) { exerciseDao.clearDay(any(), any()) }
       coVerify { workoutPlanDao.update(existingPlan.copy(totalDays = 3)) }
     }
@@ -161,29 +164,81 @@ class RoomCacheWorkoutPlanRepositoryTest {
       coEvery { exerciseDao.storeExerciseSets(capture(stored)) } returns Unit
 
       // When
-      subject.copyCustomDay(existingPlan.toDomain(), fromDay = 1, toDay = null)
+      subject.copyCustomDay(existingPlan.toDomain(), fromDay = 1)
 
       // Then
       assertThat(stored.captured).containsExactly(sourceExercise.copy(day = "3"))
     }
+  }
 
+  @Nested
+  @DisplayName("addRestDayToCustomPlan")
+  inner class AddRestDayToCustomPlan {
     @Test
-    fun `overwrites an existing day and leaves totalDays unchanged`() = runTest {
+    fun `appends a new day and marks it as rest`() = runTest {
       // Given
-      val existingPlan = RoomWorkoutPlan(workout = workoutName, totalDays = 3, isCustom = true)
+      val existingPlan = RoomWorkoutPlan(workout = workoutName, totalDays = 2, isCustom = true)
       coEvery { workoutPlanDao.getByName(workoutName) } returns existingPlan
-      coEvery { exerciseDao.loadDayExerciseSets("1", workoutName) } returns listOf(sourceExercise)
-      coEvery { exerciseDao.loadDaySetRecords(workoutName, "1") } returns emptyList()
-      coEvery { exerciseDao.clearDay("2", workoutName) } returns Unit
-      coEvery { exerciseDao.storeExerciseSets(any()) } returns Unit
 
       // When
-      val newDay = subject.copyCustomDay(existingPlan.toDomain(), fromDay = 1, toDay = 2)
+      val newDay = subject.addRestDayToCustomPlan(existingPlan.toDomain())
 
       // Then
-      assertThat(newDay).isEqualTo(2)
+      assertThat(newDay).isEqualTo(3)
+      coVerify { workoutPlanDao.update(existingPlan.copy(totalDays = 3, restDays = listOf(3))) }
+    }
+  }
+
+  @Nested
+  @DisplayName("clearCustomDay")
+  inner class ClearCustomDay {
+    @Test
+    fun `deletes the day's exercises without touching totalDays or restDays`() = runTest {
+      // Given
+      coEvery { exerciseDao.clearDay("2", workoutName) } returns Unit
+      val plan = WorkoutPlan(workoutName, totalDays = 3, isCustom = true)
+
+      // When
+      subject.clearCustomDay(plan, day = 2)
+
+      // Then
       coVerify { exerciseDao.clearDay("2", workoutName) }
       coVerify(exactly = 0) { workoutPlanDao.update(any()) }
+    }
+  }
+
+  @Nested
+  @DisplayName("setCustomDayRest")
+  inner class SetCustomDayRest {
+    @Test
+    fun `marking a day as rest adds it to restDays and clears its exercises`() = runTest {
+      // Given
+      val existingPlan =
+        RoomWorkoutPlan(workout = workoutName, totalDays = 3, isCustom = true, restDays = emptyList())
+      coEvery { workoutPlanDao.getByName(workoutName) } returns existingPlan
+      coEvery { exerciseDao.clearDay("2", workoutName) } returns Unit
+
+      // When
+      subject.setCustomDayRest(existingPlan.toDomain(), day = 2, isRest = true)
+
+      // Then
+      coVerify { workoutPlanDao.update(existingPlan.copy(restDays = listOf(2))) }
+      coVerify { exerciseDao.clearDay("2", workoutName) }
+    }
+
+    @Test
+    fun `removing rest drops the day from restDays without touching exercises`() = runTest {
+      // Given
+      val existingPlan =
+        RoomWorkoutPlan(workout = workoutName, totalDays = 3, isCustom = true, restDays = listOf(2))
+      coEvery { workoutPlanDao.getByName(workoutName) } returns existingPlan
+
+      // When
+      subject.setCustomDayRest(existingPlan.toDomain(), day = 2, isRest = false)
+
+      // Then
+      coVerify { workoutPlanDao.update(existingPlan.copy(restDays = emptyList())) }
+      coVerify(exactly = 0) { exerciseDao.clearDay(any(), any()) }
     }
   }
 }

--- a/data/CLAUDE.md
+++ b/data/CLAUDE.md
@@ -12,7 +12,10 @@ Pure Kotlin domain layer defining business models and repository interfaces with
 
 ## Important Files
 
-- `models/Exercise.kt` - Exercise definitions
+- `models/Exercise.kt` - Exercise definitions. `id` encodes `{muscleGroup}_{name}`; `name` and
+  `muscleGroup` are parsed from it (no separate stored field). Custom (BYO) exercises follow the
+  same scheme, using the muscle group selected when the exercise was added, so they're queryable
+  by muscle-group prefix the same way as admin content.
 - `models/ExerciseSet.kt` - Exercise sets with step parsing logic (computed properties: `isSuperSet`, `primaryStep`, `superStep`, `alternateTag`)
 - `models/ExerciseRecord.kt` - Aggregates set + records + pagination hints
 - `models/Record.kt` - Historical performance with volume calculation

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
@@ -16,6 +16,11 @@ interface ExerciseRepository {
   fun refreshExercises()
   suspend fun storeSetRecord(record: SetRecord)
   fun loadWorkoutRecords(workoutId: String)
+
+  /**
+   * Adds a user-authored exercise to a custom plan's day, as an open (no set limit) set.
+   */
+  suspend fun addCustomExercise(workout: String, day: String, exerciseName: String)
   val exercises: Flow<List<ExerciseSet>>
   val exercisesAreLoading: StateFlow<Boolean>
   val records: Flow<List<ExerciseRecord>>

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
@@ -1,5 +1,6 @@
 package com.litus_animae.refitted.data
 
+import com.litus_animae.refitted.data.models.Exercise
 import com.litus_animae.refitted.data.models.ExerciseCompletionRecord
 import com.litus_animae.refitted.data.models.ExerciseRecord
 import com.litus_animae.refitted.data.models.ExerciseSet
@@ -18,11 +19,25 @@ interface ExerciseRepository {
   fun loadWorkoutRecords(workoutId: String)
 
   /**
-   * Adds a user-authored exercise to a custom plan's day, as an open (no set limit) set.
+   * Adds an exercise to a custom plan's day, as an open (no set limit) set. [exerciseId] should
+   * be an existing catalog exercise's id to share its record history, or a fresh
+   * "{muscleGroup}_{name}" id for a user-authored exercise.
    */
-  suspend fun addCustomExercise(workout: String, day: String, exerciseName: String)
+  suspend fun addCustomExercise(workout: String, day: String, exerciseId: String)
   val exercises: Flow<List<ExerciseSet>>
   val exercisesAreLoading: StateFlow<Boolean>
   val records: Flow<List<ExerciseRecord>>
   val workoutRecords: Flow<List<ExerciseCompletionRecord>>
+
+  /**
+   * Locally-synced exercises for [muscle] (the id's muscle-group prefix), across every workout
+   * that has been opened locally.
+   */
+  fun exercisesByMuscle(muscle: String): Flow<List<Exercise>>
+
+  /**
+   * On-demand remote lookup of [workout]'s exercises for [muscle] - not persisted locally, purely
+   * for browsing in the add-exercise picker.
+   */
+  suspend fun loadRemoteExercisesByMuscle(workout: String, muscle: String): List<Exercise>
 }

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
@@ -39,6 +39,12 @@ interface ExerciseRepository {
    * later recovers its history. No-op if the set doesn't exist.
    */
   suspend fun deleteCustomExerciseSet(workout: String, day: String, step: String)
+
+  /**
+   * Updates a custom (BYO) exercise set's free-text instructions in place, keyed by
+   * [workout]/[day]/[step]. No-op if the set doesn't exist.
+   */
+  suspend fun updateCustomExerciseSetNote(workout: String, day: String, step: String, note: String)
   val exercises: Flow<List<ExerciseSet>>
   val exercisesAreLoading: StateFlow<Boolean>
   val records: Flow<List<ExerciseRecord>>

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
@@ -24,6 +24,12 @@ interface ExerciseRepository {
    * "{muscleGroup}_{name}" id for a user-authored exercise.
    */
   suspend fun addCustomExercise(workout: String, day: String, exerciseId: String)
+
+  /**
+   * Updates a custom (BYO) exercise set's prescription - target [sets], [reps], and [rest] - in
+   * place, keyed by [workout]/[day]/[step]. No-op if the set doesn't exist (e.g. admin content).
+   */
+  suspend fun updateCustomExerciseSet(workout: String, day: String, step: String, sets: Int, reps: Int, rest: Int)
   val exercises: Flow<List<ExerciseSet>>
   val exercisesAreLoading: StateFlow<Boolean>
   val records: Flow<List<ExerciseRecord>>

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
@@ -28,10 +28,19 @@ interface ExerciseRepository {
   suspend fun addCustomExercise(workout: String, day: String, exerciseId: String, description: String? = null)
 
   /**
-   * Updates a custom (BYO) exercise set's prescription - target [sets], [reps], and [rest] - in
-   * place, keyed by [workout]/[day]/[step]. No-op if the set doesn't exist (e.g. admin content).
+   * Updates a custom (BYO) exercise set's prescription - target [sets], [reps], [rest], and
+   * [repsRange] (an offset above [reps]; e.g. reps=10/repsRange=2 prescribes "10-12") - in place,
+   * keyed by [workout]/[day]/[step]. No-op if the set doesn't exist (e.g. admin content).
    */
-  suspend fun updateCustomExerciseSet(workout: String, day: String, step: String, sets: Int, reps: Int, rest: Int)
+  suspend fun updateCustomExerciseSet(
+    workout: String,
+    day: String,
+    step: String,
+    sets: Int,
+    reps: Int,
+    rest: Int,
+    repsRange: Int
+  )
 
   /**
    * Deletes a single custom exercise set, keyed by [workout]/[day]/[step]. Leaves the shared

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
@@ -32,6 +32,13 @@ interface ExerciseRepository {
    * place, keyed by [workout]/[day]/[step]. No-op if the set doesn't exist (e.g. admin content).
    */
   suspend fun updateCustomExerciseSet(workout: String, day: String, step: String, sets: Int, reps: Int, rest: Int)
+
+  /**
+   * Deletes a single custom exercise set, keyed by [workout]/[day]/[step]. Leaves the shared
+   * `Exercise` row and any completed `SetRecord` history in place - re-adding the same exercise
+   * later recovers its history. No-op if the set doesn't exist.
+   */
+  suspend fun deleteCustomExerciseSet(workout: String, day: String, step: String)
   val exercises: Flow<List<ExerciseSet>>
   val exercisesAreLoading: StateFlow<Boolean>
   val records: Flow<List<ExerciseRecord>>

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
@@ -21,9 +21,11 @@ interface ExerciseRepository {
   /**
    * Adds an exercise to a custom plan's day, as an open (no set limit) set. [exerciseId] should
    * be an existing catalog exercise's id to share its record history, or a fresh
-   * "{muscleGroup}_{name}" id for a user-authored exercise.
+   * "{muscleGroup}_{name}" id for a user-authored exercise. [description] carries over the source
+   * exercise's instructions, if any - a null/blank value never overwrites an existing description
+   * already stored for this id under [workout].
    */
-  suspend fun addCustomExercise(workout: String, day: String, exerciseId: String)
+  suspend fun addCustomExercise(workout: String, day: String, exerciseId: String, description: String? = null)
 
   /**
    * Updates a custom (BYO) exercise set's prescription - target [sets], [reps], and [rest] - in

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/WorkoutPlanRepository.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/WorkoutPlanRepository.kt
@@ -15,4 +15,20 @@ interface WorkoutPlanRepository {
   suspend fun setWorkoutLastViewedDay(workoutPlan: WorkoutPlan, day: Int)
   suspend fun setWorkoutStartDate(workoutPlan: WorkoutPlan, startDate: Instant)
   suspend fun setWorkoutGlobalAlternate(workoutPlan: WorkoutPlan, index: Int)
+
+  /**
+   * Creates a new empty, user-authored workout plan, already aligned to today.
+   */
+  suspend fun createCustomPlan(name: String): WorkoutPlan
+
+  /**
+   * Appends a new empty day to a custom plan and returns its day number.
+   */
+  suspend fun addDayToCustomPlan(workoutPlan: WorkoutPlan): Int
+
+  /**
+   * Copies [fromDay]'s exercises - with targets derived from completed sets - into [toDay].
+   * A null [toDay] appends a new day. Returns the day number written to.
+   */
+  suspend fun copyCustomDay(workoutPlan: WorkoutPlan, fromDay: Int, toDay: Int?): Int
 }

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/WorkoutPlanRepository.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/WorkoutPlanRepository.kt
@@ -12,6 +12,12 @@ import java.time.Instant
 interface WorkoutPlanRepository {
   val workouts: Flow<PagingData<WorkoutPlan>>
   fun workoutByName(name: String): Flow<WorkoutPlan?>
+
+  /**
+   * Names of admin-authored plans the user has access to - used by the add-exercise picker to
+   * list which workouts' exercises can be browsed by muscle group.
+   */
+  val accessibleWorkoutNames: Flow<List<String>>
   suspend fun setWorkoutLastViewedDay(workoutPlan: WorkoutPlan, day: Int)
   suspend fun setWorkoutStartDate(workoutPlan: WorkoutPlan, startDate: Instant)
   suspend fun setWorkoutGlobalAlternate(workoutPlan: WorkoutPlan, index: Int)

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/WorkoutPlanRepository.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/WorkoutPlanRepository.kt
@@ -27,8 +27,25 @@ interface WorkoutPlanRepository {
   suspend fun addDayToCustomPlan(workoutPlan: WorkoutPlan): Int
 
   /**
-   * Copies [fromDay]'s exercises - with targets derived from completed sets - into [toDay].
-   * A null [toDay] appends a new day. Returns the day number written to.
+   * Appends a new rest day to a custom plan and returns its day number.
    */
-  suspend fun copyCustomDay(workoutPlan: WorkoutPlan, fromDay: Int, toDay: Int?): Int
+  suspend fun addRestDayToCustomPlan(workoutPlan: WorkoutPlan): Int
+
+  /**
+   * Copies [fromDay]'s exercises - with targets derived from completed sets - into a newly
+   * appended day. Returns the day number written to.
+   */
+  suspend fun copyCustomDay(workoutPlan: WorkoutPlan, fromDay: Int): Int
+
+  /**
+   * Deletes all exercises on [day] of a custom plan, leaving the day slot (and its number) in
+   * place, empty.
+   */
+  suspend fun clearCustomDay(workoutPlan: WorkoutPlan, day: Int)
+
+  /**
+   * Marks or unmarks [day] of a custom plan as a rest day. Marking a day as rest also clears its
+   * exercises.
+   */
+  suspend fun setCustomDayRest(workoutPlan: WorkoutPlan, day: Int, isRest: Boolean)
 }

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/models/Exercise.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/models/Exercise.kt
@@ -3,6 +3,10 @@ package com.litus_animae.refitted.data.models
 /**
  * Domain model representing an exercise.
  * Pure domain object with no persistence or serialization concerns.
+ *
+ * [id] encodes "{muscleGroup}_{name}" - the muscle group prefix isn't a separate stored field,
+ * it's parsed out of the id (see [muscleGroup]). This lets exercises be queried by muscle group
+ * via a begins_with/LIKE prefix match without a schema change.
  */
 data class Exercise(
   val workout: String,
@@ -11,13 +15,23 @@ data class Exercise(
 ) {
   /**
    * Extracts the exercise name from the ID.
-   * ID format is typically "{prefix}_{name}"
+   * ID format is typically "{muscleGroup}_{name}"
    */
   val name: String?
     get() = if (id.isEmpty() || !id.contains("_")) {
       null
     } else {
       id.split("_", limit = 2)[1]
+    }
+
+  /**
+   * Extracts the muscle group from the ID - the prefix before the first "_".
+   */
+  val muscleGroup: String?
+    get() = if (id.isEmpty() || !id.contains("_")) {
+      null
+    } else {
+      id.split("_", limit = 2)[0]
     }
 
   /**

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/models/MuscleGroup.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/models/MuscleGroup.kt
@@ -1,0 +1,40 @@
+package com.litus_animae.refitted.data.models
+
+/**
+ * A user-facing muscle-group category and the stored exercise-id prefixes it should query.
+ * Several categories map to more than one prefix because admin-authored workout programs use
+ * inconsistent spellings for the same muscle (e.g. "Quads" vs "Quadricep", "Bicep" vs "Biceps"),
+ * and "Back"/"External Rotator" turned out to be the same training focus as "Lats"/"Shoulders"
+ * under a different label - confirmed by surveying every admin program's stored exercise ids.
+ * "Forearms" and "Lower back" were dropped entirely: no admin program has ever stored an exercise
+ * under either prefix.
+ */
+enum class MuscleGroup(val displayName: String, private val prefixes: List<String>) {
+  CHEST("Chest", listOf("Chest")),
+  SHOULDERS("Shoulders", listOf("Shoulder", "External Rotator")),
+  BICEPS("Biceps", listOf("Bicep", "Biceps")),
+  TRICEPS("Triceps", listOf("Tricep")),
+  CORE("Core", listOf("Core")),
+  TRAPS("Traps", listOf("Traps")),
+  LATS("Lats", listOf("Lats", "Back")),
+  GLUTES("Glutes", listOf("Glutes")),
+  HAMSTRINGS("Hamstrings", listOf("Hamstrings", "Hamstring")),
+  QUADS("Quads", listOf("Quads", "Quadricep")),
+  CALVES("Calves", listOf("Calf")),
+  LEGS("Legs", listOf("Leg")),
+  AGILITY("Agility", listOf("Agility", "Rope"));
+
+  companion object {
+    // Admin programs use "Compound" as a cross-category label for full-body complexes/circuits
+    // rather than a muscle, so every category's query also includes it.
+    private const val COMPOUND_PREFIX = "Compound"
+
+    fun displayNames(): List<String> = entries.map { it.displayName }
+
+    /** Stored exercise-id prefixes to query for [displayName], including the shared Compound bucket. */
+    fun prefixesFor(displayName: String): List<String> {
+      val group = entries.find { it.displayName == displayName }
+      return (group?.prefixes ?: listOf(displayName)) + COMPOUND_PREFIX
+    }
+  }
+}

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/models/WorkoutPlan.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/models/WorkoutPlan.kt
@@ -14,7 +14,8 @@ data class WorkoutPlan(
   val restDays: List<Int> = emptyList(),
   val description: String = "",
   val globalAlternateLabels: List<String> = emptyList(),
-  val globalAlternate: Int? = null
+  val globalAlternate: Int? = null,
+  val isCustom: Boolean = false
 )
 
 /**

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/network/ExerciseSetNetworkService.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/network/ExerciseSetNetworkService.kt
@@ -18,4 +18,10 @@ data class NetworkExerciseSet(
  */
 interface ExerciseSetNetworkService {
   suspend fun getExerciseSets(dayAndWorkout: DayAndWorkout): List<NetworkExerciseSet>
+
+  /**
+   * Exercises belonging to [workout] whose id starts with "$muscle_" - see
+   * [com.litus_animae.refitted.data.models.Exercise] for the id's muscle-group prefix scheme.
+   */
+  suspend fun getExercisesByMuscle(workout: String, muscle: String): List<Exercise>
 }

--- a/dynamo/src/main/kotlin/com/litus_animae/refitted/dynamo/DynamoExerciseSetNetworkService.kt
+++ b/dynamo/src/main/kotlin/com/litus_animae/refitted/dynamo/DynamoExerciseSetNetworkService.kt
@@ -70,6 +70,19 @@ class DynamoExerciseSetNetworkService @Inject constructor(
     }
   }
 
+  override suspend fun getExercisesByMuscle(workout: String, muscle: String): List<Exercise> {
+    return withContext(Dispatchers.IO) {
+      val db = dynamo.getDb()
+      log.i(TAG, "Querying exercises for muscle group $muscle in workout $workout")
+      db.queryReverseIndex(
+        DynamoExercise::class.java,
+        DynamoExercise(workout = workout),
+        "${muscle}_",
+        ComparisonOperator.BEGINS_WITH
+      ).map { it.toDomain() }
+    }
+  }
+
   companion object {
     private const val TAG = "DynamoExerciseSetNetworkService"
   }

--- a/room/schemas/com.litus_animae.refitted.room.RefittedRoom/13.json
+++ b/room/schemas/com.litus_animae.refitted.room.RefittedRoom/13.json
@@ -1,0 +1,320 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "91c714c643efbd72a6180c4631b11c42",
+    "entities": [
+      {
+        "tableName": "Exercise",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`exercise_workout` TEXT NOT NULL, `exercise_name` TEXT NOT NULL, `description` TEXT, PRIMARY KEY(`exercise_name`, `exercise_workout`))",
+        "fields": [
+          {
+            "fieldPath": "workout",
+            "columnName": "exercise_workout",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "exercise_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "exercise_name",
+            "exercise_workout"
+          ]
+        }
+      },
+      {
+        "tableName": "exerciseset",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`workout` TEXT NOT NULL, `day` TEXT NOT NULL, `step` TEXT NOT NULL, `primaryStep` INTEGER NOT NULL, `superSetStep` INTEGER, `alternateStep` TEXT, `name` TEXT NOT NULL, `note` TEXT NOT NULL, `reps` INTEGER NOT NULL, `sets` INTEGER NOT NULL, `toFailure` INTEGER NOT NULL, `rest` INTEGER NOT NULL, `repsUnit` TEXT NOT NULL, `repsRange` INTEGER NOT NULL, `timeLimit` INTEGER, `timeLimitUnit` TEXT, `repsSequence` TEXT NOT NULL, PRIMARY KEY(`day`, `step`, `workout`), FOREIGN KEY(`name`, `workout`) REFERENCES `Exercise`(`exercise_name`, `exercise_workout`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "workout",
+            "columnName": "workout",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "day",
+            "columnName": "day",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "step",
+            "columnName": "step",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryStep",
+            "columnName": "primaryStep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "superSetStep",
+            "columnName": "superSetStep",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alternateStep",
+            "columnName": "alternateStep",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reps",
+            "columnName": "reps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sets",
+            "columnName": "sets",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isToFailure",
+            "columnName": "toFailure",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rest",
+            "columnName": "rest",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repsUnit",
+            "columnName": "repsUnit",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repsRange",
+            "columnName": "repsRange",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeLimit",
+            "columnName": "timeLimit",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeLimitUnit",
+            "columnName": "timeLimitUnit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repsSequence",
+            "columnName": "repsSequence",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day",
+            "step",
+            "workout"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exerciseset_name_workout",
+            "unique": false,
+            "columnNames": [
+              "name",
+              "workout"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exerciseset_name_workout` ON `${TABLE_NAME}` (`name`, `workout`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Exercise",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "name",
+              "workout"
+            ],
+            "referencedColumns": [
+              "exercise_name",
+              "exercise_workout"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "SetRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`weight` REAL NOT NULL, `reps` INTEGER NOT NULL, `workout` TEXT NOT NULL, `target_set` TEXT NOT NULL, `completed` INTEGER NOT NULL, `exercise` TEXT NOT NULL, PRIMARY KEY(`exercise`, `completed`))",
+        "fields": [
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reps",
+            "columnName": "reps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workout",
+            "columnName": "workout",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetSet",
+            "columnName": "target_set",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exercise",
+            "columnName": "exercise",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "exercise",
+            "completed"
+          ]
+        }
+      },
+      {
+        "tableName": "workouts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`workout` TEXT NOT NULL, `totalDays` INTEGER NOT NULL, `lastViewedDay` INTEGER NOT NULL, `workoutStartDate` INTEGER NOT NULL, `restDays` TEXT NOT NULL, `description` TEXT NOT NULL, `globalAlternateLabels` TEXT NOT NULL, `globalAlternate` INTEGER, `isCustom` INTEGER NOT NULL, PRIMARY KEY(`workout`))",
+        "fields": [
+          {
+            "fieldPath": "workout",
+            "columnName": "workout",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalDays",
+            "columnName": "totalDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastViewedDay",
+            "columnName": "lastViewedDay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workoutStartDate",
+            "columnName": "workoutStartDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restDays",
+            "columnName": "restDays",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "globalAlternateLabels",
+            "columnName": "globalAlternateLabels",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "globalAlternate",
+            "columnName": "globalAlternate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isCustom",
+            "columnName": "isCustom",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "workout"
+          ]
+        }
+      },
+      {
+        "tableName": "SavedState",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '91c714c643efbd72a6180c4631b11c42')"
+    ]
+  }
+}

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/ExerciseDao.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/ExerciseDao.kt
@@ -40,6 +40,19 @@ interface ExerciseDao {
   @Query("select * from exerciseset where day = :day and workout = :workout and step = :step")
   suspend fun loadExerciseSet(day: String, workout: String, step: String): RoomExerciseSet?
 
+  @Query("select * from exerciseset where day = :day and workout = :workout order by primaryStep")
+  suspend fun loadDayExerciseSets(day: String, workout: String): List<RoomExerciseSet>
+
+  /**
+   * Highest [RoomExerciseSet.primaryStep] used on [day], or 0 if the day has no exercises yet -
+   * used to pick the next step when a custom exercise is added.
+   */
+  @Query("select coalesce(max(primaryStep), 0) from exerciseset where day = :day and workout = :workout")
+  suspend fun getMaxPrimaryStep(day: String, workout: String): Int
+
+  @Query("delete from exerciseset where day = :day and workout = :workout")
+  suspend fun clearDay(day: String, workout: String)
+
   @Query("select * from exercise where exercise_name = :name and exercise_workout = :workout")
   fun getExercise(name: String, workout: String): Flow<RoomExercise?>
 
@@ -97,6 +110,13 @@ interface ExerciseDao {
 
   @Insert
   suspend fun storeExerciseRecord(exerciseRecord: RoomSetRecord)
+
+  /**
+   * All records logged against target sets belonging to [day] (target_set ids are
+   * "$day.$step") - used to derive copy-day targets from what was actually completed.
+   */
+  @Query("select * from setrecord where workout = :workout and target_set like (:day || '.%') order by completed")
+  suspend fun loadDaySetRecords(workout: String, day: String): List<RoomSetRecord>
 
   @Query(
     "select max(completed) as latest_completion, target_set from setrecord " +

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/ExerciseDao.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/ExerciseDao.kt
@@ -56,6 +56,13 @@ interface ExerciseDao {
   @Query("select * from exercise where exercise_name = :name and exercise_workout = :workout")
   fun getExercise(name: String, workout: String): Flow<RoomExercise?>
 
+  /**
+   * Locally-synced exercises whose id starts with [prefix] (pass "$muscleGroup_") - the muscle
+   * group is encoded as the id's prefix, see [com.litus_animae.refitted.data.models.Exercise].
+   */
+  @Query("select * from exercise where exercise_name like :prefix || '%' order by exercise_workout, exercise_name")
+  fun getExercisesByMusclePrefix(prefix: String): Flow<List<RoomExercise>>
+
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun storeExercise(exercise: RoomExercise)
 

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/ExerciseDao.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/ExerciseDao.kt
@@ -53,6 +53,14 @@ interface ExerciseDao {
   @Query("delete from exerciseset where day = :day and workout = :workout")
   suspend fun clearDay(day: String, workout: String)
 
+  /**
+   * Deletes a single exercise set. Leaves gaps in [RoomExerciseSet.primaryStep] rather than
+   * renumbering - completed [RoomSetRecord]s are keyed by the literal "day.step" string with no
+   * FK back to exerciseset, so shifting steps would orphan their history.
+   */
+  @Query("delete from exerciseset where day = :day and workout = :workout and step = :step")
+  suspend fun deleteExerciseSet(day: String, workout: String, step: String)
+
   @Query("select * from exercise where exercise_name = :name and exercise_workout = :workout")
   fun getExercise(name: String, workout: String): Flow<RoomExercise?>
 

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/RefittedRoom.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/RefittedRoom.kt
@@ -9,7 +9,7 @@ import com.litus_animae.refitted.room.entities.*
 
 @Database(
   entities = [RoomExercise::class, RoomExerciseSet::class, RoomSetRecord::class, RoomWorkoutPlan::class, RoomSavedState::class],
-  version = 12
+  version = 13
 )
 @TypeConverters(Converters::class)
 abstract class RefittedRoom : RoomDatabase() {
@@ -196,6 +196,15 @@ abstract class RefittedRoom : RoomDatabase() {
         db.execSQL(
           "ALTER TABLE `exerciseset` " +
             "ADD COLUMN `repsSequence` TEXT NOT NULL DEFAULT ''"
+        )
+      }
+    }
+
+    val MIGRATION_12_13: Migration = object : Migration(12, 13) {
+      override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+          "ALTER TABLE `workouts` " +
+            "ADD COLUMN `isCustom` INTEGER NOT NULL DEFAULT 0"
         )
       }
     }

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/RefittedRoomProviderLive.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/RefittedRoomProviderLive.kt
@@ -31,7 +31,8 @@ class RefittedRoomProviderLive @Inject constructor(
         RefittedRoom.MIGRATION_8_9,
         RefittedRoom.MIGRATION_9_10,
         RefittedRoom.MIGRATION_10_11,
-        RefittedRoom.MIGRATION_11_12
+        RefittedRoom.MIGRATION_11_12,
+        RefittedRoom.MIGRATION_12_13
       )
       .build()
   }

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/WorkoutPlanDao.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/WorkoutPlanDao.kt
@@ -13,7 +13,7 @@ interface WorkoutPlanDao {
     @Update
     fun update(workoutPlan: RoomWorkoutPlan)
 
-    @Query("SELECT * FROM workouts")
+    @Query("SELECT * FROM workouts ORDER BY isCustom ASC, workout ASC")
     fun pagingSource(): PagingSource<Int, RoomWorkoutPlan>
 
     @Query("SELECT * FROM workouts")
@@ -22,6 +22,16 @@ interface WorkoutPlanDao {
     @Query("SELECT * FROM workouts where `workout` = :name")
     fun planByName(name: String): Flow<RoomWorkoutPlan?>
 
+    @Query("SELECT * FROM workouts where `workout` = :name")
+    suspend fun getByName(name: String): RoomWorkoutPlan?
+
     @Query("DELETE FROM workouts")
     suspend fun clearAll()
+
+    /**
+     * Clears only admin-authored plans, leaving user-created (`isCustom`) plans untouched -
+     * used before re-inserting the server's plan list on refresh.
+     */
+    @Query("DELETE FROM workouts where `isCustom` = 0")
+    suspend fun clearServerPlans()
 }

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/WorkoutPlanDao.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/WorkoutPlanDao.kt
@@ -25,6 +25,14 @@ interface WorkoutPlanDao {
     @Query("SELECT * FROM workouts where `workout` = :name")
     suspend fun getByName(name: String): RoomWorkoutPlan?
 
+    /**
+     * Names of admin-authored plans the user has synced access to - the plan list itself is
+     * synced in full on refresh (unlike per-day exercise content), so this doesn't require an
+     * extra network round-trip.
+     */
+    @Query("SELECT workout FROM workouts where `isCustom` = 0 ORDER BY workout ASC")
+    fun getServerWorkoutNames(): Flow<List<String>>
+
     @Query("DELETE FROM workouts")
     suspend fun clearAll()
 

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/entities/RoomWorkoutPlan.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/entities/RoomWorkoutPlan.kt
@@ -19,7 +19,8 @@ data class RoomWorkoutPlan(
     val restDays: List<Int> = emptyList(),
     val description: String = "",
     val globalAlternateLabels: List<String> = emptyList(),
-    val globalAlternate: Int? = null
+    val globalAlternate: Int? = null,
+    val isCustom: Boolean = false
 ) {
     /**
      * Convert Room entity to domain model
@@ -32,7 +33,8 @@ data class RoomWorkoutPlan(
         restDays = restDays,
         description = description,
         globalAlternateLabels = globalAlternateLabels,
-        globalAlternate = globalAlternate
+        globalAlternate = globalAlternate,
+        isCustom = isCustom
     )
 
     companion object {
@@ -47,7 +49,8 @@ data class RoomWorkoutPlan(
             restDays = workoutPlan.restDays,
             description = workoutPlan.description,
             globalAlternateLabels = workoutPlan.globalAlternateLabels,
-            globalAlternate = workoutPlan.globalAlternate
+            globalAlternate = workoutPlan.globalAlternate,
+            isCustom = workoutPlan.isCustom
         )
     }
 }

--- a/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
+++ b/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
@@ -33,6 +33,10 @@ class InMemoryExerciseRepository(
         TODO("Not yet implemented")
     }
 
+    override suspend fun addCustomExercise(workout: String, day: String, exerciseName: String) {
+        TODO("Not yet implemented")
+    }
+
     override val exercises: Flow<List<ExerciseSet>> = exerciseList
     override val exercisesAreLoading: StateFlow<Boolean>
         get() = TODO("Not yet implemented")

--- a/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
+++ b/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
@@ -49,6 +49,10 @@ class InMemoryExerciseRepository(
         TODO("Not yet implemented")
     }
 
+    override suspend fun deleteCustomExerciseSet(workout: String, day: String, step: String) {
+        TODO("Not yet implemented")
+    }
+
     override val exercises: Flow<List<ExerciseSet>> = exerciseList
     override val exercisesAreLoading: StateFlow<Boolean>
         get() = TODO("Not yet implemented")

--- a/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
+++ b/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
@@ -1,6 +1,7 @@
 package com.litus_animae.refitted.data
 
 import com.litus_animae.refitted.data.ExerciseRepository
+import com.litus_animae.refitted.data.models.Exercise
 import com.litus_animae.refitted.data.models.ExerciseCompletionRecord
 import com.litus_animae.refitted.data.models.ExerciseRecord
 import com.litus_animae.refitted.data.models.ExerciseSet
@@ -33,7 +34,7 @@ class InMemoryExerciseRepository(
         TODO("Not yet implemented")
     }
 
-    override suspend fun addCustomExercise(workout: String, day: String, exerciseName: String) {
+    override suspend fun addCustomExercise(workout: String, day: String, exerciseId: String) {
         TODO("Not yet implemented")
     }
 
@@ -43,4 +44,12 @@ class InMemoryExerciseRepository(
     override val records: Flow<List<ExerciseRecord>> = recordList
     override val workoutRecords: Flow<List<ExerciseCompletionRecord>>
         get() = TODO("Not yet implemented")
+
+    override fun exercisesByMuscle(muscle: String): Flow<List<Exercise>> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun loadRemoteExercisesByMuscle(workout: String, muscle: String): List<Exercise> {
+        TODO("Not yet implemented")
+    }
 }

--- a/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
+++ b/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
@@ -34,7 +34,7 @@ class InMemoryExerciseRepository(
         TODO("Not yet implemented")
     }
 
-    override suspend fun addCustomExercise(workout: String, day: String, exerciseId: String) {
+    override suspend fun addCustomExercise(workout: String, day: String, exerciseId: String, description: String?) {
         TODO("Not yet implemented")
     }
 

--- a/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
+++ b/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
@@ -53,6 +53,10 @@ class InMemoryExerciseRepository(
         TODO("Not yet implemented")
     }
 
+    override suspend fun updateCustomExerciseSetNote(workout: String, day: String, step: String, note: String) {
+        TODO("Not yet implemented")
+    }
+
     override val exercises: Flow<List<ExerciseSet>> = exerciseList
     override val exercisesAreLoading: StateFlow<Boolean>
         get() = TODO("Not yet implemented")

--- a/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
+++ b/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
@@ -38,6 +38,17 @@ class InMemoryExerciseRepository(
         TODO("Not yet implemented")
     }
 
+    override suspend fun updateCustomExerciseSet(
+        workout: String,
+        day: String,
+        step: String,
+        sets: Int,
+        reps: Int,
+        rest: Int
+    ) {
+        TODO("Not yet implemented")
+    }
+
     override val exercises: Flow<List<ExerciseSet>> = exerciseList
     override val exercisesAreLoading: StateFlow<Boolean>
         get() = TODO("Not yet implemented")

--- a/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
+++ b/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
@@ -44,7 +44,8 @@ class InMemoryExerciseRepository(
         step: String,
         sets: Int,
         reps: Int,
-        rest: Int
+        rest: Int,
+        repsRange: Int
     ) {
         TODO("Not yet implemented")
     }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.litus_animae.refitted.ui.compose.calendar.Calendar
 import com.litus_animae.refitted.ui.compose.exercise.Exercise
+import com.litus_animae.refitted.ui.compose.exercise.add.AddExercisePicker
 import com.litus_animae.refitted.ui.models.ExerciseViewModel
 import com.litus_animae.refitted.ui.models.UserViewModel
 import com.litus_animae.refitted.data.models.WorkoutPlan
@@ -39,7 +40,24 @@ fun Top() {
           day = day,
           workoutId = workoutId,
           exerciseModel = exerciseModel,
-          workoutModel = workoutModel
+          workoutModel = workoutModel,
+          onAddExercise = { controller.navigate("add-exercise/$workoutId/$day") }
+        )
+      } else {
+        controller.navigate("calendar")
+      }
+    }
+    composable("add-exercise/{workout}/{day}") {
+      val exerciseModel: ExerciseViewModel = hiltViewModel(it)
+      val workoutId = it.arguments?.getString("workout")
+      val day = it.arguments?.getString("day")
+      if (workoutId != null && day != null) {
+        AddExercisePicker(
+          onExercisePicked = { name ->
+            exerciseModel.addExercise(workoutId, day, name)
+            controller.popBackStack()
+          },
+          onClose = { controller.popBackStack() }
         )
       } else {
         controller.navigate("calendar")

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
@@ -98,7 +98,7 @@ fun Top() {
           loadingWorkouts = exerciseModel.loadingWorkouts,
           onLoadWorkout = { workout -> exerciseModel.loadRemoteExercises(workout, muscle) },
           onPick = { exercise ->
-            exerciseModel.addExercise(workoutId, day, exercise.id)
+            exerciseModel.addExercise(workoutId, day, exercise.id, exercise.description)
             controller.getBackStackEntry("exercise/{workout}/{day}/{editing}")
               .savedStateHandle["justAddedExercise"] = exercise.name
             // Pop the whole add-exercise sub-flow at once, back to the day screen.

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
@@ -1,7 +1,9 @@
 package com.litus_animae.refitted.ui.compose
 
+import android.net.Uri
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
@@ -9,7 +11,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.litus_animae.refitted.ui.compose.calendar.Calendar
 import com.litus_animae.refitted.ui.compose.exercise.Exercise
-import com.litus_animae.refitted.ui.compose.exercise.add.AddExercisePicker
+import com.litus_animae.refitted.ui.compose.exercise.add.ExercisePickerList
+import com.litus_animae.refitted.ui.compose.exercise.add.MuscleGroupPickerScreen
 import com.litus_animae.refitted.ui.models.ExerciseViewModel
 import com.litus_animae.refitted.ui.models.UserViewModel
 import com.litus_animae.refitted.data.models.WorkoutPlan
@@ -35,29 +38,54 @@ fun Top() {
       val workoutModel: WorkoutViewModel = hiltViewModel(it)
       val workoutId = it.arguments?.getString("workout")
       val day = it.arguments?.getString("day")
+      // Consumed once per return to this destination - set by the add-exercise flow below
+      // just before popping back here, so the pager can land on it instead of page 0.
+      val scrollToExerciseName = remember(it) {
+        it.savedStateHandle.remove<String>("justAddedExercise")
+      }
       if (workoutId != null && day != null) {
         Exercise(
           day = day,
           workoutId = workoutId,
           exerciseModel = exerciseModel,
           workoutModel = workoutModel,
-          onAddExercise = { controller.navigate("add-exercise/$workoutId/$day") }
+          onAddExercise = { controller.navigate("add-exercise/$workoutId/$day") },
+          scrollToExerciseName = scrollToExerciseName
         )
       } else {
         controller.navigate("calendar")
       }
     }
     composable("add-exercise/{workout}/{day}") {
-      val exerciseModel: ExerciseViewModel = hiltViewModel(it)
       val workoutId = it.arguments?.getString("workout")
       val day = it.arguments?.getString("day")
       if (workoutId != null && day != null) {
-        AddExercisePicker(
-          onExercisePicked = { name ->
-            exerciseModel.addExercise(workoutId, day, name)
-            controller.popBackStack()
+        MuscleGroupPickerScreen(
+          onContinue = { muscle ->
+            controller.navigate("add-exercise/$workoutId/$day/${Uri.encode(muscle)}")
           },
           onClose = { controller.popBackStack() }
+        )
+      } else {
+        controller.navigate("calendar")
+      }
+    }
+    composable("add-exercise/{workout}/{day}/{muscle}") {
+      val exerciseModel: ExerciseViewModel = hiltViewModel(it)
+      val workoutId = it.arguments?.getString("workout")
+      val day = it.arguments?.getString("day")
+      val muscle = it.arguments?.getString("muscle")?.let(Uri::decode)
+      if (workoutId != null && day != null && muscle != null) {
+        ExercisePickerList(
+          muscle = muscle,
+          onPick = { name ->
+            exerciseModel.addExercise(workoutId, day, name)
+            controller.getBackStackEntry("exercise/{workout}/{day}")
+              .savedStateHandle["justAddedExercise"] = name
+            // Pop the whole add-exercise sub-flow at once, back to the day screen.
+            controller.popBackStack("exercise/{workout}/{day}", inclusive = false)
+          },
+          onBack = { controller.popBackStack() }
         )
       } else {
         controller.navigate("calendar")

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
@@ -31,15 +31,18 @@ fun Top() {
     composable("calendar") {
       val workoutModel: WorkoutViewModel = hiltViewModel(it)
       val userModel: UserViewModel = hiltViewModel(it)
-      val navigateToWorkoutDay: (WorkoutPlan, Int) -> Unit =
-        { wp, day -> controller.navigate("exercise/${wp.workout}/$day") }
+      val navigateToWorkoutDay: (WorkoutPlan, Int, Boolean) -> Unit =
+        { wp, day, editing -> controller.navigate("exercise/${wp.workout}/$day/$editing") }
       Calendar(Modifier.fillMaxSize(), navigateToWorkoutDay, workoutModel, userModel)
     }
-    composable("exercise/{workout}/{day}") {
+    // "editing" gates the add-exercise affordance - only reachable from the edit-mode calendar
+    // (Calendar.kt's DayEditDialog), so a plan can't be built up by tapping into a day normally.
+    composable("exercise/{workout}/{day}/{editing}") {
       val exerciseModel: ExerciseViewModel = hiltViewModel(it)
       val workoutModel: WorkoutViewModel = hiltViewModel(it)
       val workoutId = it.arguments?.getString("workout")
       val day = it.arguments?.getString("day")
+      val editing = it.arguments?.getString("editing")?.toBoolean() == true
       // Consumed once per return to this destination - set by the add-exercise flow below
       // just before popping back here, so the pager can land on it instead of page 0.
       val scrollToExerciseName = remember(it) {
@@ -49,6 +52,7 @@ fun Top() {
         Exercise(
           day = day,
           workoutId = workoutId,
+          editing = editing,
           exerciseModel = exerciseModel,
           workoutModel = workoutModel,
           onAddExercise = { controller.navigate("add-exercise/$workoutId/$day") },
@@ -84,18 +88,21 @@ fun Top() {
           .collectAsStateWithLifecycle(initialValue = emptyList())
         ExercisePickerList(
           muscle = muscle,
-          currentWorkoutId = workoutId,
-          localExercisesByWorkout = localExercises.groupBy { it.workout },
+          // Exclude the plan being built itself - a custom plan is assembled from admin
+          // content, so any local rows under its own name just duplicate an admin section.
+          localExercisesByWorkout = localExercises
+            .filter { it.workout != workoutId }
+            .groupBy { it.workout },
           accessibleWorkoutNames = accessibleWorkoutNames,
           remoteExercisesByWorkout = exerciseModel.remoteExercisesByWorkout,
           loadingWorkouts = exerciseModel.loadingWorkouts,
           onLoadWorkout = { workout -> exerciseModel.loadRemoteExercises(workout, muscle) },
           onPick = { exercise ->
             exerciseModel.addExercise(workoutId, day, exercise.id)
-            controller.getBackStackEntry("exercise/{workout}/{day}")
+            controller.getBackStackEntry("exercise/{workout}/{day}/{editing}")
               .savedStateHandle["justAddedExercise"] = exercise.name
             // Pop the whole add-exercise sub-flow at once, back to the day screen.
-            controller.popBackStack("exercise/{workout}/{day}", inclusive = false)
+            controller.popBackStack("exercise/{workout}/{day}/{editing}", inclusive = false)
           },
           onBack = { controller.popBackStack() }
         )

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
@@ -3,9 +3,11 @@ package com.litus_animae.refitted.ui.compose
 import android.net.Uri
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -76,12 +78,22 @@ fun Top() {
       val day = it.arguments?.getString("day")
       val muscle = it.arguments?.getString("muscle")?.let(Uri::decode)
       if (workoutId != null && day != null && muscle != null) {
+        val localExercises by remember(muscle) { exerciseModel.exercisesByMuscle(muscle) }
+          .collectAsStateWithLifecycle(initialValue = emptyList())
+        val accessibleWorkoutNames by exerciseModel.accessibleWorkoutNames
+          .collectAsStateWithLifecycle(initialValue = emptyList())
         ExercisePickerList(
           muscle = muscle,
-          onPick = { name ->
-            exerciseModel.addExercise(workoutId, day, name)
+          currentWorkoutId = workoutId,
+          localExercisesByWorkout = localExercises.groupBy { it.workout },
+          accessibleWorkoutNames = accessibleWorkoutNames,
+          remoteExercisesByWorkout = exerciseModel.remoteExercisesByWorkout,
+          loadingWorkouts = exerciseModel.loadingWorkouts,
+          onLoadWorkout = { workout -> exerciseModel.loadRemoteExercises(workout, muscle) },
+          onPick = { exercise ->
+            exerciseModel.addExercise(workoutId, day, exercise.id)
             controller.getBackStackEntry("exercise/{workout}/{day}")
-              .savedStateHandle["justAddedExercise"] = name
+              .savedStateHandle["justAddedExercise"] = exercise.name
             // Pop the whole add-exercise sub-flow at once, back to the day screen.
             controller.popBackStack("exercise/{workout}/{day}", inclusive = false)
           },

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Calendar.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Calendar.kt
@@ -5,9 +5,11 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -82,12 +84,14 @@ fun PreviewCalendarUnaligned() {
   }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun WorkoutCalendar(
   plan: WorkoutPlan,
   completedDays: Map<Int, Instant>,
   contentPadding: PaddingValues,
   onSaveStartDate: (LocalDate) -> Unit = {},
+  onCopyDay: (fromDay: Int, toDay: Int?) -> Unit = { _, _ -> },
   navigateToDay: (Int) -> Unit,
 ) {
   LaunchedEffect(plan) {
@@ -113,6 +117,8 @@ fun WorkoutCalendar(
   }
 
   var hideRestDays by rememberSaveable { mutableStateOf(false) }
+  // Long-pressed day awaiting the copy-day dialog - custom plans only (see onLongClick below).
+  var copyDaySource by rememberSaveable { mutableStateOf<Int?>(null) }
 
   val firstOfMonth = displayedMonth.atDay(1)
   // Sunday-first grid: ISO Sunday (7) should wrap to 0 leading cells, not 7.
@@ -160,6 +166,9 @@ fun WorkoutCalendar(
             aligned && inRange && !hidden -> ({ navigateToDay(workoutDay) })
             else -> null
           }
+          val onLongClick: (() -> Unit)? =
+            if (plan.isCustom && aligned && inRange && !hidden) ({ copyDaySource = workoutDay })
+            else null
           val label = when {
             !aligned && inDisplayedMonth ->
               "Choose ${cellDate.format(DateTimeFormatter.ofPattern("MMM d"))} as start"
@@ -173,8 +182,17 @@ fun WorkoutCalendar(
               .height(52.dp)
               .padding(3.dp)
               .let { base ->
-                if (onClick != null) base.clickable(onClickLabel = label, onClick = onClick)
-                else base
+                when {
+                  onClick != null && onLongClick != null -> base.combinedClickable(
+                    onClickLabel = label,
+                    onClick = onClick,
+                    // TODO localize
+                    onLongClickLabel = "Copy day $workoutDay",
+                    onLongClick = onLongClick
+                  )
+                  onClick != null -> base.clickable(onClickLabel = label, onClick = onClick)
+                  else -> base
+                }
               }
           ) {
             val isToday = cellDate == today
@@ -203,6 +221,18 @@ fun WorkoutCalendar(
         }
       }
     }
+  }
+
+  copyDaySource?.let { fromDay ->
+    CopyDayDialog(
+      fromDay = fromDay,
+      totalDays = plan.totalDays,
+      onDismissRequest = { copyDaySource = null },
+      onCopy = { toDay ->
+        onCopyDay(fromDay, toDay)
+        copyDaySource = null
+      }
+    )
   }
 }
 

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Calendar.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Calendar.kt
@@ -164,22 +164,26 @@ fun WorkoutCalendar(
         week.forEach { cellDate ->
           val workoutDay = ChronoUnit.DAYS.between(anchorDate, cellDate).toInt() + 1
           val inDisplayedMonth = YearMonth.from(cellDate) == displayedMonth
-          val inRange = inDisplayedMonth && workoutDay in 1..plan.totalDays
-          val isRestDay = inRange && plan.restDays.contains(workoutDay)
+          // A plan day can fall in a leading/trailing cell that belongs to an adjacent month
+          // (e.g. June 29 shown at the top of July's grid) - it's still a real day of the
+          // plan and should be reachable without a month-nav round trip, just visually
+          // distinguished (see CalendarDayCell's dimmed param) from the displayed month.
+          val inPlanRange = workoutDay in 1..plan.totalDays
+          val isRestDay = inPlanRange && plan.restDays.contains(workoutDay)
           // Edit mode needs rest days visible to manage them, even with "hide rest days" on.
           val hidden = isRestDay && hideRestDays && !editMode
           val onClick: (() -> Unit)? = when {
             !aligned && inDisplayedMonth -> ({ pickedEpochDay = cellDate.toEpochDay() })
-            editMode && inRange && !hidden -> ({ editingDay = workoutDay })
-            aligned && inRange && !hidden -> ({ navigateToDay(workoutDay) })
+            editMode && inPlanRange && !hidden -> ({ editingDay = workoutDay })
+            aligned && inPlanRange && !hidden -> ({ navigateToDay(workoutDay) })
             else -> null
           }
           val label = when {
             !aligned && inDisplayedMonth ->
               "Choose ${cellDate.format(DateTimeFormatter.ofPattern("MMM d"))} as start"
-            editMode && inRange -> "Edit day $workoutDay"
+            editMode && inPlanRange -> "Edit day $workoutDay"
             isRestDay -> "Rest day $workoutDay"
-            inRange -> "Day $workoutDay"
+            inPlanRange -> "Day $workoutDay"
             else -> null
           }
           Box(
@@ -193,7 +197,7 @@ fun WorkoutCalendar(
               }
           ) {
             val isToday = cellDate == today
-            if (!inRange) {
+            if (!inPlanRange) {
               OutOfRangeDayCell(cellDate.dayOfMonth, isToday = isToday)
             } else if (hidden) {
               Box(Modifier.fillMaxSize())
@@ -211,7 +215,8 @@ fun WorkoutCalendar(
                   isRestDay = isRestDay
                 ),
                 selected = !aligned && cellDate == pickedDate,
-                isToday = isToday
+                isToday = isToday,
+                dimmed = !inDisplayedMonth
               )
             }
           }
@@ -475,7 +480,8 @@ private fun CalendarDayCell(
   workoutDay: Int,
   properties: DayProperties,
   selected: Boolean = false,
-  isToday: Boolean = false
+  isToday: Boolean = false,
+  dimmed: Boolean = false
 ) {
   // Last-viewed (aligned) and selected-as-start (unaligned) are mutually exclusive - one
   // outline style covers "this is the reference day" in either mode.
@@ -487,11 +493,15 @@ private fun CalendarDayCell(
   }
   val contentColor = contentColorFor(backgroundColor)
   val border = if (highlighted) BorderStroke(3.dp, MaterialTheme.colors.primaryVariant) else null
+  // Rest-day and adjacent-month dimming both fade the same surface - multiply rather than
+  // pick one, so a rest day that also falls outside the displayed month reads as both.
+  val restDayAlpha = if (properties.isRestDay) 0.45f else 1f
+  val monthAlpha = if (dimmed) 0.6f else 1f
 
   Surface(
     modifier = Modifier
       .fillMaxSize()
-      .alpha(if (properties.isRestDay) 0.45f else 1f),
+      .alpha(restDayAlpha * monthAlpha),
     shape = RoundedCornerShape(8.dp),
     color = backgroundColor,
     contentColor = contentColor,

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Calendar.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Calendar.kt
@@ -5,11 +5,9 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -84,14 +82,16 @@ fun PreviewCalendarUnaligned() {
   }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun WorkoutCalendar(
   plan: WorkoutPlan,
   completedDays: Map<Int, Instant>,
   contentPadding: PaddingValues,
+  editMode: Boolean = false,
+  onExitEdit: () -> Unit = {},
   onSaveStartDate: (LocalDate) -> Unit = {},
-  onCopyDay: (fromDay: Int, toDay: Int?) -> Unit = { _, _ -> },
+  onClearDay: (day: Int) -> Unit = {},
+  onSetDayRest: (day: Int, isRest: Boolean) -> Unit = { _, _ -> },
   navigateToDay: (Int) -> Unit,
 ) {
   LaunchedEffect(plan) {
@@ -117,8 +117,8 @@ fun WorkoutCalendar(
   }
 
   var hideRestDays by rememberSaveable { mutableStateOf(false) }
-  // Long-pressed day awaiting the copy-day dialog - custom plans only (see onLongClick below).
-  var copyDaySource by rememberSaveable { mutableStateOf<Int?>(null) }
+  // Tapped day awaiting the edit-actions dialog - edit mode only (see onClick below).
+  var editingDay by rememberSaveable { mutableStateOf<Int?>(null) }
 
   val firstOfMonth = displayedMonth.atDay(1)
   // Sunday-first grid: ISO Sunday (7) should wrap to 0 leading cells, not 7.
@@ -144,6 +144,11 @@ fun WorkoutCalendar(
       }
     }
     item {
+      AnimatedVisibility(visible = editMode, exit = shrinkVertically() + fadeOut()) {
+        EditModeBanner(onDone = onExitEdit, modifier = Modifier.padding(bottom = 12.dp))
+      }
+    }
+    item {
       MonthNavRow(
         displayedMonth,
         onPrevious = { displayedMonthKey -= 1 },
@@ -160,18 +165,18 @@ fun WorkoutCalendar(
           val inDisplayedMonth = YearMonth.from(cellDate) == displayedMonth
           val inRange = inDisplayedMonth && workoutDay in 1..plan.totalDays
           val isRestDay = inRange && plan.restDays.contains(workoutDay)
-          val hidden = isRestDay && hideRestDays
+          // Edit mode needs rest days visible to manage them, even with "hide rest days" on.
+          val hidden = isRestDay && hideRestDays && !editMode
           val onClick: (() -> Unit)? = when {
             !aligned && inDisplayedMonth -> ({ pickedEpochDay = cellDate.toEpochDay() })
+            editMode && inRange && !hidden -> ({ editingDay = workoutDay })
             aligned && inRange && !hidden -> ({ navigateToDay(workoutDay) })
             else -> null
           }
-          val onLongClick: (() -> Unit)? =
-            if (plan.isCustom && aligned && inRange && !hidden) ({ copyDaySource = workoutDay })
-            else null
           val label = when {
             !aligned && inDisplayedMonth ->
               "Choose ${cellDate.format(DateTimeFormatter.ofPattern("MMM d"))} as start"
+            editMode && inRange -> "Edit day $workoutDay"
             isRestDay -> "Rest day $workoutDay"
             inRange -> "Day $workoutDay"
             else -> null
@@ -182,17 +187,8 @@ fun WorkoutCalendar(
               .height(52.dp)
               .padding(3.dp)
               .let { base ->
-                when {
-                  onClick != null && onLongClick != null -> base.combinedClickable(
-                    onClickLabel = label,
-                    onClick = onClick,
-                    // TODO localize
-                    onLongClickLabel = "Copy day $workoutDay",
-                    onLongClick = onLongClick
-                  )
-                  onClick != null -> base.clickable(onClickLabel = label, onClick = onClick)
-                  else -> base
-                }
+                if (onClick != null) base.clickable(onClickLabel = label, onClick = onClick)
+                else base
               }
           ) {
             val isToday = cellDate == today
@@ -223,16 +219,40 @@ fun WorkoutCalendar(
     }
   }
 
-  copyDaySource?.let { fromDay ->
-    CopyDayDialog(
-      fromDay = fromDay,
-      totalDays = plan.totalDays,
-      onDismissRequest = { copyDaySource = null },
-      onCopy = { toDay ->
-        onCopyDay(fromDay, toDay)
-        copyDaySource = null
-      }
+  editingDay?.let { day ->
+    DayEditDialog(
+      day = day,
+      isRestDay = plan.restDays.contains(day),
+      onDismissRequest = { editingDay = null },
+      onClear = { onClearDay(day) },
+      onSetRest = { isRest -> onSetDayRest(day, isRest) }
     )
+  }
+}
+
+@Composable
+private fun EditModeBanner(onDone: () -> Unit, modifier: Modifier = Modifier) {
+  Surface(
+    modifier.fillMaxWidth(),
+    shape = RoundedCornerShape(10.dp),
+    color = MaterialTheme.colors.primary,
+    contentColor = MaterialTheme.colors.onPrimary,
+    elevation = 1.dp
+  ) {
+    Row(
+      Modifier
+        .fillMaxWidth()
+        .padding(14.dp),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      // TODO localize
+      Text("Editing plan — tap a day to change it", fontSize = 13.sp)
+      Button(onClick = onDone) {
+        // TODO localize
+        Text("Done")
+      }
+    }
   }
 }
 

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Calendar.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Calendar.kt
@@ -92,6 +92,7 @@ fun WorkoutCalendar(
   onSaveStartDate: (LocalDate) -> Unit = {},
   onClearDay: (day: Int) -> Unit = {},
   onSetDayRest: (day: Int, isRest: Boolean) -> Unit = { _, _ -> },
+  onEditDay: (day: Int) -> Unit = {},
   navigateToDay: (Int) -> Unit,
 ) {
   LaunchedEffect(plan) {
@@ -224,6 +225,7 @@ fun WorkoutCalendar(
       day = day,
       isRestDay = plan.restDays.contains(day),
       onDismissRequest = { editingDay = null },
+      onEditDay = { onEditDay(day) },
       onClear = { onClearDay(day) },
       onSetRest = { isRest -> onSetDayRest(day, isRest) }
     )

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/CustomPlanDialogs.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/CustomPlanDialogs.kt
@@ -1,0 +1,138 @@
+package com.litus_animae.refitted.ui.compose.calendar
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Button
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.RadioButton
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Name-only creation dialog for a custom plan (design 1b) - days and exercises are added
+ * afterward from the calendar, so there's nothing else to ask up front.
+ */
+@Composable
+fun NewCustomWorkoutDialog(
+  onDismissRequest: () -> Unit,
+  onCreate: (String) -> Unit
+) {
+  var name by rememberSaveable { mutableStateOf("") }
+  AlertDialog(
+    onDismissRequest = onDismissRequest,
+    // TODO localize
+    title = { Text("New Custom Workout") },
+    text = {
+      Column {
+        Text(
+          "Name your workout. You will add days and exercises from the calendar as you go.",
+          style = MaterialTheme.typography.body2
+        )
+        Spacer(Modifier.height(16.dp))
+        TextField(
+          value = name,
+          onValueChange = { name = it },
+          label = { Text("Name") },
+          singleLine = true,
+          modifier = Modifier.fillMaxWidth()
+        )
+      }
+    },
+    confirmButton = {
+      Button(onClick = { onCreate(name.trim()) }, enabled = name.isNotBlank()) {
+        Text("Create")
+      }
+    },
+    dismissButton = {
+      Button(onClick = onDismissRequest) { Text("Cancel") }
+    }
+  )
+}
+
+/**
+ * Copy-day dialog (design 1e, minus the per-exercise preview list and Move day). [onCopy]
+ * receives null to append a new day, or an existing day number to overwrite.
+ */
+@Composable
+fun CopyDayDialog(
+  fromDay: Int,
+  totalDays: Int,
+  onDismissRequest: () -> Unit,
+  onCopy: (toDay: Int?) -> Unit
+) {
+  var appendAsNewDay by rememberSaveable { mutableStateOf(true) }
+  var chosenDay by rememberSaveable { mutableIntStateOf(1.coerceAtMost(totalDays.coerceAtLeast(1))) }
+  val newDayNumber = totalDays + 1
+  AlertDialog(
+    onDismissRequest = onDismissRequest,
+    // TODO localize
+    title = { Text("Copy Day $fromDay") },
+    text = {
+      Column {
+        Text(
+          "Creates a new day with the same exercises. Set and rep targets come from the sets you completed.",
+          style = MaterialTheme.typography.body2
+        )
+        Spacer(Modifier.height(16.dp))
+        Row(
+          Modifier
+            .fillMaxWidth()
+            .clickable { appendAsNewDay = true },
+          verticalAlignment = Alignment.CenterVertically
+        ) {
+          RadioButton(selected = appendAsNewDay, onClick = { appendAsNewDay = true })
+          Text("Add as new day — Day $newDayNumber")
+        }
+        Row(
+          Modifier
+            .fillMaxWidth()
+            .clickable { appendAsNewDay = false },
+          verticalAlignment = Alignment.CenterVertically
+        ) {
+          RadioButton(selected = !appendAsNewDay, onClick = { appendAsNewDay = false })
+          Text("Choose a day…")
+        }
+        if (!appendAsNewDay && totalDays > 0) {
+          Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(
+              onClick = { chosenDay = (chosenDay - 1).coerceAtLeast(1) },
+              enabled = chosenDay > 1
+            ) { Icon(Icons.Default.Remove, "previous day") }
+            Text("Day $chosenDay", style = MaterialTheme.typography.subtitle1)
+            IconButton(
+              onClick = { chosenDay = (chosenDay + 1).coerceAtMost(totalDays) },
+              enabled = chosenDay < totalDays
+            ) { Icon(Icons.Default.Add, "next day") }
+          }
+        }
+      }
+    },
+    confirmButton = {
+      Button(onClick = { onCopy(if (appendAsNewDay) null else chosenDay) }) {
+        Text("Copy")
+      }
+    },
+    dismissButton = {
+      Button(onClick = onDismissRequest) { Text("Cancel") }
+    }
+  )
+}

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/CustomPlanDialogs.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/CustomPlanDialogs.kt
@@ -1,6 +1,7 @@
 package com.litus_animae.refitted.ui.compose.calendar
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,6 +13,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.icons.Icons
@@ -26,6 +28,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 
 /**
  * Name-only creation dialog for a custom plan (design 1b) - days and exercises are added
@@ -129,12 +132,19 @@ fun DayEditDialog(
   onClear: () -> Unit,
   onSetRest: (isRest: Boolean) -> Unit
 ) {
-  AlertDialog(
-    onDismissRequest = onDismissRequest,
-    // TODO localize
-    title = { Text("Day $day") },
-    text = {
-      Column {
+  // A plain Dialog+Surface instead of AlertDialog - this is really a compact action list, and
+  // AlertDialog's title/text/buttons scaffold (sized for a couple of lines of prose plus a
+  // button row) left a large empty gap below a short list of actions.
+  Dialog(onDismissRequest = onDismissRequest) {
+    Surface(shape = MaterialTheme.shapes.medium, elevation = 24.dp) {
+      Column(Modifier.padding(top = 20.dp, bottom = 8.dp)) {
+        // TODO localize
+        Text(
+          "Day $day",
+          style = MaterialTheme.typography.h6,
+          modifier = Modifier.padding(horizontal = 24.dp)
+        )
+        Spacer(Modifier.height(12.dp))
         if (isRestDay) {
           DayEditAction("Remove rest day") {
             onSetRest(false)
@@ -156,15 +166,20 @@ fun DayEditDialog(
             onDismissRequest()
           }
         }
-      }
-    },
-    confirmButton = {
-      Button(onClick = onDismissRequest) {
-        // TODO localize
-        Text("Close")
+        Row(
+          Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp, end = 8.dp),
+          horizontalArrangement = Arrangement.End
+        ) {
+          Button(onClick = onDismissRequest) {
+            // TODO localize
+            Text("Close")
+          }
+        }
       }
     }
-  )
+  }
 }
 
 @Composable
@@ -175,7 +190,7 @@ private fun DayEditAction(label: String, onClick: () -> Unit) {
     Modifier
       .fillMaxWidth()
       .clickable(onClick = onClick)
-      .padding(vertical = 12.dp),
+      .padding(horizontal = 24.dp, vertical = 14.dp),
     style = MaterialTheme.typography.body1
   )
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/CustomPlanDialogs.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/CustomPlanDialogs.kt
@@ -6,12 +6,12 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.RadioButton
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.icons.Icons
@@ -69,70 +69,106 @@ fun NewCustomWorkoutDialog(
 }
 
 /**
- * Copy-day dialog (design 1e, minus the per-exercise preview list and Move day). [onCopy]
- * receives null to append a new day, or an existing day number to overwrite.
+ * Copy-day dialog (design 1e, minus the per-exercise preview list, Move day, and the
+ * append/overwrite choice - copy is always non-destructive and always appends a new day). Lets
+ * the user pick which existing day to copy from.
  */
 @Composable
 fun CopyDayDialog(
-  fromDay: Int,
   totalDays: Int,
   onDismissRequest: () -> Unit,
-  onCopy: (toDay: Int?) -> Unit
+  onCopy: (fromDay: Int) -> Unit
 ) {
-  var appendAsNewDay by rememberSaveable { mutableStateOf(true) }
-  var chosenDay by rememberSaveable { mutableIntStateOf(1.coerceAtMost(totalDays.coerceAtLeast(1))) }
+  var fromDay by rememberSaveable { mutableIntStateOf(1.coerceAtMost(totalDays.coerceAtLeast(1))) }
   val newDayNumber = totalDays + 1
   AlertDialog(
     onDismissRequest = onDismissRequest,
     // TODO localize
-    title = { Text("Copy Day $fromDay") },
+    title = { Text("Copy a Day") },
     text = {
       Column {
         Text(
-          "Creates a new day with the same exercises. Set and rep targets come from the sets you completed.",
+          "Adds Day $newDayNumber with the same exercises as the day you pick below. Set and rep targets come from the sets you completed.",
           style = MaterialTheme.typography.body2
         )
         Spacer(Modifier.height(16.dp))
-        Row(
-          Modifier
-            .fillMaxWidth()
-            .clickable { appendAsNewDay = true },
-          verticalAlignment = Alignment.CenterVertically
-        ) {
-          RadioButton(selected = appendAsNewDay, onClick = { appendAsNewDay = true })
-          Text("Add as new day — Day $newDayNumber")
-        }
-        Row(
-          Modifier
-            .fillMaxWidth()
-            .clickable { appendAsNewDay = false },
-          verticalAlignment = Alignment.CenterVertically
-        ) {
-          RadioButton(selected = !appendAsNewDay, onClick = { appendAsNewDay = false })
-          Text("Choose a day…")
-        }
-        if (!appendAsNewDay && totalDays > 0) {
-          Row(verticalAlignment = Alignment.CenterVertically) {
-            IconButton(
-              onClick = { chosenDay = (chosenDay - 1).coerceAtLeast(1) },
-              enabled = chosenDay > 1
-            ) { Icon(Icons.Default.Remove, "previous day") }
-            Text("Day $chosenDay", style = MaterialTheme.typography.subtitle1)
-            IconButton(
-              onClick = { chosenDay = (chosenDay + 1).coerceAtMost(totalDays) },
-              enabled = chosenDay < totalDays
-            ) { Icon(Icons.Default.Add, "next day") }
-          }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+          IconButton(
+            onClick = { fromDay = (fromDay - 1).coerceAtLeast(1) },
+            enabled = fromDay > 1
+          ) { Icon(Icons.Default.Remove, "previous day") }
+          Text("Day $fromDay", style = MaterialTheme.typography.subtitle1)
+          IconButton(
+            onClick = { fromDay = (fromDay + 1).coerceAtMost(totalDays) },
+            enabled = fromDay < totalDays
+          ) { Icon(Icons.Default.Add, "next day") }
         }
       }
     },
     confirmButton = {
-      Button(onClick = { onCopy(if (appendAsNewDay) null else chosenDay) }) {
+      Button(onClick = { onCopy(fromDay) }) {
         Text("Copy")
       }
     },
     dismissButton = {
       Button(onClick = onDismissRequest) { Text("Cancel") }
     }
+  )
+}
+
+/**
+ * Per-day edit actions (edit mode only). Delete-with-renumber and move/reorder are deferred -
+ * both would renumber later days and misalign historical SetRecords keyed "day.step".
+ */
+@Composable
+fun DayEditDialog(
+  day: Int,
+  isRestDay: Boolean,
+  onDismissRequest: () -> Unit,
+  onClear: () -> Unit,
+  onSetRest: (isRest: Boolean) -> Unit
+) {
+  AlertDialog(
+    onDismissRequest = onDismissRequest,
+    // TODO localize
+    title = { Text("Day $day") },
+    text = {
+      Column {
+        if (isRestDay) {
+          DayEditAction("Remove rest day") {
+            onSetRest(false)
+            onDismissRequest()
+          }
+        } else {
+          DayEditAction("Clear contents") {
+            onClear()
+            onDismissRequest()
+          }
+          DayEditAction("Make rest day") {
+            onSetRest(true)
+            onDismissRequest()
+          }
+        }
+      }
+    },
+    confirmButton = {
+      Button(onClick = onDismissRequest) {
+        // TODO localize
+        Text("Close")
+      }
+    }
+  )
+}
+
+@Composable
+private fun DayEditAction(label: String, onClick: () -> Unit) {
+  Text(
+    // TODO localize
+    label,
+    Modifier
+      .fillMaxWidth()
+      .clickable(onClick = onClick)
+      .padding(vertical = 12.dp),
+    style = MaterialTheme.typography.body1
   )
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/CustomPlanDialogs.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/CustomPlanDialogs.kt
@@ -125,6 +125,7 @@ fun DayEditDialog(
   day: Int,
   isRestDay: Boolean,
   onDismissRequest: () -> Unit,
+  onEditDay: () -> Unit,
   onClear: () -> Unit,
   onSetRest: (isRest: Boolean) -> Unit
 ) {
@@ -140,6 +141,12 @@ fun DayEditDialog(
             onDismissRequest()
           }
         } else {
+          // Only way into the day screen with the add-exercise affordance enabled - see
+          // Exercise(editing=).
+          DayEditAction("Edit day") {
+            onEditDay()
+            onDismissRequest()
+          }
           DayEditAction("Clear contents") {
             onClear()
             onDismissRequest()

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Main.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Main.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.AlertDialog
 import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Button
 import androidx.compose.material.DropdownMenu
+import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -26,6 +27,7 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.rememberScaffoldState
@@ -67,6 +69,7 @@ fun Calendar(
 ) {
   val scaffoldState = rememberScaffoldState()
   val scaffoldScope = rememberCoroutineScope()
+  var showCreateCustomDialog by rememberSaveable { mutableStateOf(false) }
 
   val selectedWorkoutPlan by workoutModel.currentWorkout.collectAsState(
     initial = workoutModel.savedStateLastWorkoutPlan,
@@ -179,6 +182,14 @@ fun Calendar(
         }
       )
     },
+    floatingActionButton = {
+      if (selectedWorkoutPlan?.isCustom == true) {
+        FloatingActionButton(onClick = { workoutModel.addDay(selectedWorkoutPlan!!) }) {
+          // TODO localize
+          Icon(Icons.Default.Add, "add day")
+        }
+      }
+    },
     drawerShape = MaterialTheme.shapes.medium,
     drawerContent = {
       val workoutPlanPagingItems = workoutModel.workouts.collectAsLazyPagingItems()
@@ -203,11 +214,16 @@ fun Calendar(
         Modifier.weight(1f),
         lastRefresh,
         workoutPlanPagingItems,
-        workoutPlanError
-      ) {
-        scaffoldScope.launch { scaffoldState.drawerState.close() }
-        workoutModel.loadWorkoutDaysCompleted(it)
-      }
+        workoutPlanError,
+        onSelect = {
+          scaffoldScope.launch { scaffoldState.drawerState.close() }
+          workoutModel.loadWorkoutDaysCompleted(it)
+        },
+        onCreateCustom = {
+          scaffoldScope.launch { scaffoldState.drawerState.close() }
+          showCreateCustomDialog = true
+        }
+      )
       Row(
         Modifier
           .windowInsetsPadding(WindowInsets.navigationBars.union(WindowInsets.displayCutout))
@@ -279,11 +295,22 @@ fun Calendar(
         selectedWorkoutPlan!!,
         completedDays,
         contentPadding = contentPadding,
-        onSaveStartDate = { workoutModel.setStartDate(selectedWorkoutPlan!!, it) }
+        onSaveStartDate = { workoutModel.setStartDate(selectedWorkoutPlan!!, it) },
+        onCopyDay = { fromDay, toDay -> workoutModel.copyDay(selectedWorkoutPlan!!, fromDay, toDay) }
       ) {
         navigateToWorkoutDay(selectedWorkoutPlan!!, it)
         workoutModel.setLastViewedDay(selectedWorkoutPlan!!, it)
       }
     }
+  }
+
+  if (showCreateCustomDialog) {
+    NewCustomWorkoutDialog(
+      onDismissRequest = { showCreateCustomDialog = false },
+      onCreate = {
+        workoutModel.createCustomWorkout(it)
+        showCreateCustomDialog = false
+      }
+    )
   }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Main.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Main.kt
@@ -63,7 +63,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun Calendar(
   modifier: Modifier = Modifier,
-  navigateToWorkoutDay: (WorkoutPlan, Int) -> Unit,
+  navigateToWorkoutDay: (WorkoutPlan, Int, editing: Boolean) -> Unit,
   workoutModel: WorkoutViewModel = viewModel(),
   userModel: UserViewModel = viewModel()
 ) {
@@ -357,9 +357,13 @@ fun Calendar(
         onExitEdit = { editMode = false },
         onSaveStartDate = { workoutModel.setStartDate(selectedWorkoutPlan!!, it) },
         onClearDay = { day -> workoutModel.clearDay(selectedWorkoutPlan!!, day) },
-        onSetDayRest = { day, isRest -> workoutModel.setDayRest(selectedWorkoutPlan!!, day, isRest) }
+        onSetDayRest = { day, isRest -> workoutModel.setDayRest(selectedWorkoutPlan!!, day, isRest) },
+        onEditDay = { day ->
+          navigateToWorkoutDay(selectedWorkoutPlan!!, day, true)
+          workoutModel.setLastViewedDay(selectedWorkoutPlan!!, day)
+        }
       ) {
-        navigateToWorkoutDay(selectedWorkoutPlan!!, it)
+        navigateToWorkoutDay(selectedWorkoutPlan!!, it, false)
         workoutModel.setLastViewedDay(selectedWorkoutPlan!!, it)
       }
     }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Main.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Main.kt
@@ -70,11 +70,20 @@ fun Calendar(
   val scaffoldState = rememberScaffoldState()
   val scaffoldScope = rememberCoroutineScope()
   var showCreateCustomDialog by rememberSaveable { mutableStateOf(false) }
+  var showCopyDayDialog by rememberSaveable { mutableStateOf(false) }
+  var showAddMenu by rememberSaveable { mutableStateOf(false) }
+  var editMode by rememberSaveable { mutableStateOf(false) }
 
   val selectedWorkoutPlan by workoutModel.currentWorkout.collectAsState(
     initial = workoutModel.savedStateLastWorkoutPlan,
     Dispatchers.IO
   )
+  // A freshly created custom plan has nothing to "use" yet - land straight in edit mode.
+  LaunchedEffect(selectedWorkoutPlan?.workout) {
+    if (selectedWorkoutPlan?.isCustom == true && selectedWorkoutPlan?.totalDays == 0) {
+      editMode = true
+    }
+  }
   val savedSelectedPlanLoading = workoutModel.savedStateLoading
   val completedDaysLoading = workoutModel.completedDaysLoading
 
@@ -133,6 +142,18 @@ fun Calendar(
             DropdownMenu(
               expanded = expanded,
               onDismissRequest = { setExpanded(false) }) {
+              if (selectedWorkoutPlan?.isCustom == true && !editMode) {
+                Text(
+                  "Edit plan",
+                  Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                      editMode = true
+                      setExpanded(false)
+                    }
+                    .padding(start = 5.dp, end = 15.dp)
+                    .padding(vertical = 5.dp))
+              }
               Text(
                 "Reset workout",
                 Modifier
@@ -183,10 +204,47 @@ fun Calendar(
       )
     },
     floatingActionButton = {
-      if (selectedWorkoutPlan?.isCustom == true) {
-        FloatingActionButton(onClick = { workoutModel.addDay(selectedWorkoutPlan!!) }) {
+      if (selectedWorkoutPlan?.isCustom == true && editMode) {
+        FloatingActionButton(onClick = { showAddMenu = true }) {
           // TODO localize
-          Icon(Icons.Default.Add, "add day")
+          Icon(Icons.Default.Add, "add to plan")
+        }
+        DropdownMenu(expanded = showAddMenu, onDismissRequest = { showAddMenu = false }) {
+          Text(
+            // TODO localize
+            "New day",
+            Modifier
+              .fillMaxWidth()
+              .clickable {
+                workoutModel.addDay(selectedWorkoutPlan!!)
+                showAddMenu = false
+              }
+              .padding(start = 5.dp, end = 15.dp)
+              .padding(vertical = 5.dp))
+          if (selectedWorkoutPlan!!.totalDays > 0) {
+            Text(
+              // TODO localize
+              "Copy from…",
+              Modifier
+                .fillMaxWidth()
+                .clickable {
+                  showAddMenu = false
+                  showCopyDayDialog = true
+                }
+                .padding(start = 5.dp, end = 15.dp)
+                .padding(vertical = 5.dp))
+          }
+          Text(
+            // TODO localize
+            "Rest day",
+            Modifier
+              .fillMaxWidth()
+              .clickable {
+                workoutModel.addRestDay(selectedWorkoutPlan!!)
+                showAddMenu = false
+              }
+              .padding(start = 5.dp, end = 15.dp)
+              .padding(vertical = 5.dp))
         }
       }
     },
@@ -295,8 +353,11 @@ fun Calendar(
         selectedWorkoutPlan!!,
         completedDays,
         contentPadding = contentPadding,
+        editMode = editMode,
+        onExitEdit = { editMode = false },
         onSaveStartDate = { workoutModel.setStartDate(selectedWorkoutPlan!!, it) },
-        onCopyDay = { fromDay, toDay -> workoutModel.copyDay(selectedWorkoutPlan!!, fromDay, toDay) }
+        onClearDay = { day -> workoutModel.clearDay(selectedWorkoutPlan!!, day) },
+        onSetDayRest = { day, isRest -> workoutModel.setDayRest(selectedWorkoutPlan!!, day, isRest) }
       ) {
         navigateToWorkoutDay(selectedWorkoutPlan!!, it)
         workoutModel.setLastViewedDay(selectedWorkoutPlan!!, it)
@@ -310,6 +371,17 @@ fun Calendar(
       onCreate = {
         workoutModel.createCustomWorkout(it)
         showCreateCustomDialog = false
+      }
+    )
+  }
+
+  if (showCopyDayDialog && selectedWorkoutPlan != null) {
+    CopyDayDialog(
+      totalDays = selectedWorkoutPlan!!.totalDays,
+      onDismissRequest = { showCopyDayDialog = false },
+      onCopy = { fromDay ->
+        workoutModel.copyDay(selectedWorkoutPlan!!, fromDay)
+        showCopyDayDialog = false
       }
     )
   }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Main.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/Main.kt
@@ -2,6 +2,7 @@ package com.litus_animae.refitted.ui.compose.calendar
 
 import android.util.Log
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -17,6 +18,7 @@ import androidx.compose.material.AlertDialog
 import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Button
 import androidx.compose.material.DropdownMenu
+import androidx.compose.material.FabPosition
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -205,49 +207,55 @@ fun Calendar(
     },
     floatingActionButton = {
       if (selectedWorkoutPlan?.isCustom == true && editMode) {
-        FloatingActionButton(onClick = { showAddMenu = true }) {
-          // TODO localize
-          Icon(Icons.Default.Add, "add to plan")
-        }
-        DropdownMenu(expanded = showAddMenu, onDismissRequest = { showAddMenu = false }) {
-          Text(
+        // FAB + its menu need to share one layout node in this slot - as two loose siblings,
+        // Scaffold measured the slot's width from both and threw the FAB's End position off,
+        // rendering it on the left.
+        Box {
+          FloatingActionButton(onClick = { showAddMenu = true }) {
             // TODO localize
-            "New day",
-            Modifier
-              .fillMaxWidth()
-              .clickable {
-                workoutModel.addDay(selectedWorkoutPlan!!)
-                showAddMenu = false
-              }
-              .padding(start = 5.dp, end = 15.dp)
-              .padding(vertical = 5.dp))
-          if (selectedWorkoutPlan!!.totalDays > 0) {
+            Icon(Icons.Default.Add, "add to plan")
+          }
+          DropdownMenu(expanded = showAddMenu, onDismissRequest = { showAddMenu = false }) {
             Text(
               // TODO localize
-              "Copy from…",
+              "New day",
               Modifier
                 .fillMaxWidth()
                 .clickable {
+                  workoutModel.addDay(selectedWorkoutPlan!!)
                   showAddMenu = false
-                  showCopyDayDialog = true
+                }
+                .padding(start = 5.dp, end = 15.dp)
+                .padding(vertical = 5.dp))
+            if (selectedWorkoutPlan!!.totalDays > 0) {
+              Text(
+                // TODO localize
+                "Copy from…",
+                Modifier
+                  .fillMaxWidth()
+                  .clickable {
+                    showAddMenu = false
+                    showCopyDayDialog = true
+                  }
+                  .padding(start = 5.dp, end = 15.dp)
+                  .padding(vertical = 5.dp))
+            }
+            Text(
+              // TODO localize
+              "Rest day",
+              Modifier
+                .fillMaxWidth()
+                .clickable {
+                  workoutModel.addRestDay(selectedWorkoutPlan!!)
+                  showAddMenu = false
                 }
                 .padding(start = 5.dp, end = 15.dp)
                 .padding(vertical = 5.dp))
           }
-          Text(
-            // TODO localize
-            "Rest day",
-            Modifier
-              .fillMaxWidth()
-              .clickable {
-                workoutModel.addRestDay(selectedWorkoutPlan!!)
-                showAddMenu = false
-              }
-              .padding(start = 5.dp, end = 15.dp)
-              .padding(vertical = 5.dp))
         }
       }
     },
+    floatingActionButtonPosition = FabPosition.End,
     drawerShape = MaterialTheme.shapes.medium,
     drawerContent = {
       val workoutPlanPagingItems = workoutModel.workouts.collectAsLazyPagingItems()

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/WorkoutMenu.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/calendar/WorkoutMenu.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -40,7 +41,7 @@ fun WorkoutPlanPreview() {
     .collectAsLazyPagingItems()
   MaterialTheme(Theme.darkColors) {
     Column {
-      WorkoutPlanMenu(lastRefresh = "Refreshed At", plans = data, workoutPlanError = null) {}
+      WorkoutPlanMenu(lastRefresh = "Refreshed At", plans = data, workoutPlanError = null, onSelect = {})
     }
   }
 }
@@ -51,7 +52,8 @@ fun ColumnScope.WorkoutPlanMenu(
   lastRefresh: String,
   plans: LazyPagingItems<WorkoutPlan>,
   workoutPlanError: String?,
-  onSelect: (WorkoutPlan) -> Unit
+  onSelect: (WorkoutPlan) -> Unit,
+  onCreateCustom: () -> Unit = {}
 ) {
   LazyColumn(modifier) {
     item {
@@ -124,6 +126,19 @@ fun ColumnScope.WorkoutPlanMenu(
       ) { index ->
         val plan = plans[index]
         if (plan != null) {
+          // Custom plans sort after server plans (see WorkoutPlanDao.pagingSource) - this is
+          // the transition into that section, so it only ever renders once.
+          val previousPlan = if (index > 0) plans[index - 1] else null
+          if (plan.isCustom && previousPlan?.isCustom != true) {
+            // TODO localize
+            Text(
+              "CUSTOM WORKOUTS",
+              Modifier
+                .fillMaxWidth()
+                .padding(start = 10.dp, top = 18.dp, bottom = 4.dp),
+              style = MaterialTheme.typography.overline
+            )
+          }
           Text(
             plan.workout,
             Modifier
@@ -134,6 +149,25 @@ fun ColumnScope.WorkoutPlanMenu(
           )
           Divider()
         }
+      }
+      item {
+        Row(
+          Modifier
+            .fillMaxWidth()
+            .clickable { onCreateCustom() }
+            .padding(start = 10.dp, end = 10.dp, top = 15.dp, bottom = 15.dp),
+          verticalAlignment = Alignment.CenterVertically
+        ) {
+          Icon(Icons.Default.Add, "create your own", tint = MaterialTheme.colors.primary)
+          Spacer(Modifier.width(8.dp))
+          // TODO localize
+          Text(
+            "Create your own",
+            color = MaterialTheme.colors.primary,
+            style = MaterialTheme.typography.button
+          )
+        }
+        Divider()
       }
     }
   }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/CircularRestTimer.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/CircularRestTimer.kt
@@ -269,16 +269,18 @@ fun CircularRestTimer(
         horizontalArrangement = Arrangement.SpaceEvenly,
         verticalAlignment = Alignment.CenterVertically
       ) {
+        // Only ever shown in edit mode (see call site), so no upper bound here - the
+        // day-wide maxRestSeconds is purely a ring-fill reference, not an edit limit.
         IconButton(
-          onClick = { onAdjust((restSeconds - 5).coerceIn(0, maxRestSeconds)) },
+          onClick = { onAdjust((restSeconds - 5).coerceAtLeast(0)) },
           enabled = !isRunning && restSeconds > 0
         ) {
           Icon(Icons.Default.Remove, contentDescription = "decrease rest")
         }
         Text("${restSeconds}s", style = MaterialTheme.typography.body2)
         IconButton(
-          onClick = { onAdjust((restSeconds + 5).coerceIn(0, maxRestSeconds)) },
-          enabled = !isRunning && restSeconds < maxRestSeconds
+          onClick = { onAdjust(restSeconds + 5) },
+          enabled = !isRunning
         ) {
           Icon(Icons.Default.Add, contentDescription = "increase rest")
         }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/CircularRestTimer.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/CircularRestTimer.kt
@@ -55,9 +55,9 @@ import kotlin.math.min
 /**
  * A circular rest-timer ring.
  *
- * **Idle** (not resting): ring is filled in the primary colour up to the proportion
- * [restSeconds] / [maxRestSeconds], so rests are visually comparable across exercises
- * in the same workout day. A +/- control lets the user override the rest duration.
+ * **Idle** (not resting): ring is fully filled, representing [restSeconds] as a complete
+ * duration in its own right rather than scaled against any other exercise's rest. A +/-
+ * control lets the user override the rest duration.
  *
  * **Running** (resting): arc depletes clockwise; centre shows remaining seconds; goes
  * amber under 10 s. If [nextRestSeconds] is non-null a secondary note is shown so the
@@ -74,7 +74,6 @@ import kotlin.math.min
 @Composable
 fun CircularRestTimer(
   restSeconds: Int,
-  maxRestSeconds: Int,
   isRunning: Boolean,
   startedAt: Instant,
   modifier: Modifier = Modifier,
@@ -83,7 +82,9 @@ fun CircularRestTimer(
   onFinish: () -> Unit = {}
 ) {
   val durationMillis = restSeconds * 1000
-  val safeMax = maxRestSeconds.coerceAtLeast(1)
+  // Normalised against its own duration, not some other exercise's rest - a locked-in 45s
+  // rest fills the whole ring rather than a fraction of a day-wide maximum.
+  val safeMax = restSeconds.coerceAtLeast(1)
 
   // Recreate the animatable whenever a new timer starts (startedAt changes).
   // When already running on first composition, seek to the elapsed position immediately.
@@ -269,8 +270,7 @@ fun CircularRestTimer(
         horizontalArrangement = Arrangement.SpaceEvenly,
         verticalAlignment = Alignment.CenterVertically
       ) {
-        // Only ever shown in edit mode (see call site), so no upper bound here - the
-        // day-wide maxRestSeconds is purely a ring-fill reference, not an edit limit.
+        // Only ever shown in edit mode (see call site), so no upper bound here.
         IconButton(
           onClick = { onAdjust((restSeconds - 5).coerceAtLeast(0)) },
           enabled = !isRunning && restSeconds > 0
@@ -290,8 +290,8 @@ fun CircularRestTimer(
 }
 
 private class IdleFillRatioProvider : PreviewParameterProvider<Int> {
-  // restSeconds against a fixed 90s maxRestSeconds, to see the idle ring at
-  // a few different fill proportions
+  // The idle ring is always full regardless of restSeconds (normalised against itself) -
+  // these values just check rendering/text sizing at a few different durations.
   override val values: Sequence<Int> = sequenceOf(0, 20, 45, 90)
 }
 
@@ -304,7 +304,6 @@ fun PreviewCircularRestTimerIdle(
     Card(Modifier.fillMaxSize()) {
       CircularRestTimer(
         restSeconds = restSeconds,
-        maxRestSeconds = 90,
         isRunning = false,
         startedAt = Instant.now(),
         onAdjust = {}
@@ -330,7 +329,6 @@ fun PreviewCircularRestTimerInteractive() {
         Box(Modifier.size(220.dp)) {
           CircularRestTimer(
             restSeconds = restSeconds,
-            maxRestSeconds = 90,
             isRunning = running,
             startedAt = startedAt,
             nextRestSeconds = 60,

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/EditInstructionDialog.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/EditInstructionDialog.kt
@@ -1,0 +1,85 @@
+package com.litus_animae.refitted.ui.compose.exercise
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Button
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+/**
+ * Edit-mode dialog for a custom exercise's per-day instructions. [description] (the shared,
+ * per-workout `Exercise.description`) is shown read-only for context - it's edited nowhere in the
+ * app yet - while [initialNote] (the per-set `ExerciseSet.note`) is the only free-text field the
+ * user can change here.
+ */
+@Composable
+fun EditInstructionDialog(
+  exerciseName: String,
+  description: String?,
+  initialNote: String,
+  onDismissRequest: () -> Unit,
+  onSave: (String) -> Unit
+) {
+  var note by rememberSaveable(initialNote) { mutableStateOf(initialNote) }
+  AlertDialog(
+    onDismissRequest = onDismissRequest,
+    title = { Text(exerciseName) },
+    text = {
+      Column(Modifier.verticalScroll(rememberScrollState())) {
+        if (!description.isNullOrBlank()) {
+          CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+            Text(description, style = MaterialTheme.typography.body2)
+          }
+          Spacer(Modifier.height(16.dp))
+        }
+        // TODO localize
+        Text("Your notes", style = MaterialTheme.typography.overline)
+        OutlinedTextField(
+          value = note,
+          onValueChange = { note = it },
+          minLines = 3,
+          modifier = Modifier.fillMaxWidth()
+        )
+      }
+    },
+    confirmButton = {
+      // TODO localize
+      Button(onClick = { onSave(note) }) { Text("Save") }
+    },
+    dismissButton = {
+      // TODO localize
+      Button(onClick = onDismissRequest) { Text("Cancel") }
+    }
+  )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewEditInstructionDialog() {
+  MaterialTheme {
+    EditInstructionDialog(
+      exerciseName = "Barbell Bench Press",
+      description = "Lower the bar to your chest with control, then press back up.",
+      initialNote = "Use the safety bars set to chest height",
+      onDismissRequest = {},
+      onSave = {}
+    )
+  }
+}

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material.rememberScaffoldState
@@ -55,7 +56,8 @@ import kotlinx.coroutines.launch
 fun Exercise(
   day: String, workoutId: String,
   exerciseModel: ExerciseViewModel = viewModel(),
-  workoutModel: WorkoutViewModel = viewModel()
+  workoutModel: WorkoutViewModel = viewModel(),
+  onAddExercise: () -> Unit = {}
 ) {
   val title = stringResource(id = R.string.app_name)
   val dayWord = stringResource(id = R.string.day)
@@ -87,6 +89,12 @@ fun Exercise(
         ),
         backgroundColor = MaterialTheme.colors.primary,
         actions = {
+          if (loadedWorkoutPlan?.isCustom == true) {
+            IconButton(onAddExercise) {
+              // TODO localize
+              Icon(Icons.Default.Add, "add exercise")
+            }
+          }
           contextMenu()
         },
         navigationIcon = {
@@ -129,7 +137,8 @@ fun Exercise(
           sheetWeight = it
           scaffoldScope.launch { sheetState.show() }
         },
-        onSetSaved = { workoutModel.alignToDayIfUnaligned(loadedWorkoutPlan, day.toIntOrNull() ?: 1) })
+        onSetSaved = { workoutModel.alignToDayIfUnaligned(loadedWorkoutPlan, day.toIntOrNull() ?: 1) },
+        onAddExercise = onAddExercise)
     }
   }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun Exercise(
   day: String, workoutId: String,
+  editing: Boolean = false,
   exerciseModel: ExerciseViewModel = viewModel(),
   workoutModel: WorkoutViewModel = viewModel(),
   onAddExercise: () -> Unit = {},
@@ -90,7 +91,7 @@ fun Exercise(
         ),
         backgroundColor = MaterialTheme.colors.primary,
         actions = {
-          if (loadedWorkoutPlan?.isCustom == true) {
+          if (loadedWorkoutPlan?.isCustom == true && editing) {
             IconButton(onAddExercise) {
               // TODO localize
               Icon(Icons.Default.Add, "add exercise")
@@ -139,6 +140,7 @@ fun Exercise(
           scaffoldScope.launch { sheetState.show() }
         },
         onSetSaved = { workoutModel.alignToDayIfUnaligned(loadedWorkoutPlan, day.toIntOrNull() ?: 1) },
+        editing = editing,
         onAddExercise = onAddExercise,
         scrollToExerciseName = scrollToExerciseName)
     }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
@@ -57,7 +57,8 @@ fun Exercise(
   day: String, workoutId: String,
   exerciseModel: ExerciseViewModel = viewModel(),
   workoutModel: WorkoutViewModel = viewModel(),
-  onAddExercise: () -> Unit = {}
+  onAddExercise: () -> Unit = {},
+  scrollToExerciseName: String? = null
 ) {
   val title = stringResource(id = R.string.app_name)
   val dayWord = stringResource(id = R.string.day)
@@ -138,7 +139,8 @@ fun Exercise(
           scaffoldScope.launch { sheetState.show() }
         },
         onSetSaved = { workoutModel.alignToDayIfUnaligned(loadedWorkoutPlan, day.toIntOrNull() ?: 1) },
-        onAddExercise = onAddExercise)
+        onAddExercise = onAddExercise,
+        scrollToExerciseName = scrollToExerciseName)
     }
   }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -4,16 +4,27 @@ package com.litus_animae.refitted.ui.compose.exercise
 
 import android.content.res.Configuration
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.Button
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.FitnessCenter
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
@@ -21,6 +32,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -58,7 +70,8 @@ fun PagerExerciseView(
   setContextMenu: (@Composable RowScope.() -> Unit) -> Unit,
   onAlternateChange: (Int) -> Unit,
   onStartEditWeight: (Weight) -> Unit,
-  onSetSaved: () -> Unit = {}
+  onSetSaved: () -> Unit = {},
+  onAddExercise: () -> Unit = {}
 ) {
   val allRecords by model.records.collectAsState(initial = emptyList())
   val setRecords = recordsByExerciseId(allRecords = allRecords)
@@ -108,37 +121,77 @@ fun PagerExerciseView(
         .align(Alignment.TopCenter)
         .zIndex(100f)
     )
-    Column {
-      PagerDetailView(
-        instructions = instructions,
-        pagerState = pagerState,
-        activeSetWithRecord = currentSetRecord,
-        displayedPage = displayedPage,
-        globalAlternate = workoutPlan?.globalAlternate,
-        setRecords = setRecords,
-        maxRestSeconds = maxRestSeconds,
-        timerStateByExerciseId = model.timerStateByExerciseId,
-        restOverrideByExerciseId = model.restOverrideByExerciseId,
-        onTimerToggle = { id, running, restSecs -> model.setTimerRunning(id, running, restSecs) },
-        onRestOverrideChange = { id, secs -> model.setRestOverride(id, secs) },
-        onSave = { updatedRecord ->
-          val savedRecord = updatedRecord.copy(stored = true)
-          currentSetRecord!!.saveRecordInState(savedRecord)
-          model.saveExercise(
-            SetRecord(savedRecord.weight, savedRecord.reps, savedRecord.set)
-          )
-          onSetSaved()
-          // Superset auto-advance
-          instruction?.offsetToNextSuperSet?.let { offset ->
-            val isChallengeSet = exerciseSet!!.sets < 0
-            val isLastSet = currentSetRecord.numCompleted >= exerciseSet!!.sets - 1
-            val isLastExerciseInSuperset = offset <= 0
-            if (isChallengeSet || !isLastSet || !isLastExerciseInSuperset)
-              pagerState.requestScrollToPage(pagerState.settledPage + offset)
-          }
-        },
-        onStartEditWeight = onStartEditWeight
-      )
+    if (workoutPlan?.isCustom == true && instructions.isEmpty() && !isRefreshing) {
+      EmptyCustomDay(onAddExercise = onAddExercise)
+    } else {
+      Column {
+        PagerDetailView(
+          instructions = instructions,
+          pagerState = pagerState,
+          activeSetWithRecord = currentSetRecord,
+          displayedPage = displayedPage,
+          globalAlternate = workoutPlan?.globalAlternate,
+          setRecords = setRecords,
+          maxRestSeconds = maxRestSeconds,
+          timerStateByExerciseId = model.timerStateByExerciseId,
+          restOverrideByExerciseId = model.restOverrideByExerciseId,
+          onTimerToggle = { id, running, restSecs -> model.setTimerRunning(id, running, restSecs) },
+          onRestOverrideChange = { id, secs -> model.setRestOverride(id, secs) },
+          onSave = { updatedRecord ->
+            val savedRecord = updatedRecord.copy(stored = true)
+            currentSetRecord!!.saveRecordInState(savedRecord)
+            model.saveExercise(
+              SetRecord(savedRecord.weight, savedRecord.reps, savedRecord.set)
+            )
+            onSetSaved()
+            // Superset auto-advance
+            instruction?.offsetToNextSuperSet?.let { offset ->
+              val isChallengeSet = exerciseSet!!.sets < 0
+              val isLastSet = currentSetRecord.numCompleted >= exerciseSet!!.sets - 1
+              val isLastExerciseInSuperset = offset <= 0
+              if (isChallengeSet || !isLastSet || !isLastExerciseInSuperset)
+                pagerState.requestScrollToPage(pagerState.settledPage + offset)
+            }
+          },
+          onStartEditWeight = onStartEditWeight
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun EmptyCustomDay(onAddExercise: () -> Unit, modifier: Modifier = Modifier) {
+  Column(
+    modifier
+      .fillMaxSize()
+      .padding(32.dp),
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally
+  ) {
+    Icon(
+      Icons.Default.FitnessCenter,
+      // TODO localize
+      contentDescription = null,
+      modifier = Modifier.size(56.dp),
+      tint = MaterialTheme.colors.onSurface.copy(alpha = 0.26f)
+    )
+    Spacer(Modifier.height(12.dp))
+    // TODO localize
+    Text("No exercises yet", style = MaterialTheme.typography.h5, textAlign = TextAlign.Center)
+    Spacer(Modifier.height(8.dp))
+    Text(
+      // TODO localize
+      "Build this day as you train. There are no set limits the first time — targets fill in from what you complete.",
+      style = MaterialTheme.typography.body2,
+      textAlign = TextAlign.Center
+    )
+    Spacer(Modifier.height(16.dp))
+    Button(onClick = onAddExercise) {
+      Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+      Spacer(Modifier.width(8.dp))
+      // TODO localize
+      Text("Add exercise")
     }
   }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -154,6 +154,10 @@ fun PagerExerciseView(
           restOverrideByExerciseId = model.restOverrideByExerciseId,
           onTimerToggle = { id, running, restSecs -> model.setTimerRunning(id, running, restSecs) },
           onRestOverrideChange = { id, secs -> model.setRestOverride(id, secs) },
+          editing = editing,
+          onUpdateCustomTargets = { workout, day, step, sets, reps, rest ->
+            model.updateCustomExerciseSetTargets(workout, day, step, sets, reps, rest)
+          },
           onSave = { updatedRecord ->
             val savedRecord = updatedRecord.copy(stored = true)
             currentSetRecord!!.saveRecordInState(savedRecord)
@@ -236,7 +240,10 @@ fun PagerDetailView(
   onTimerToggle: (id: String, running: Boolean, restSeconds: Int) -> Unit = { _, _, _ -> },
   onRestOverrideChange: (id: String, seconds: Int) -> Unit = { _, _ -> },
   onSave: (Record) -> Unit,
-  onStartEditWeight: (Weight) -> Unit
+  onStartEditWeight: (Weight) -> Unit,
+  editing: Boolean = false,
+  onUpdateCustomTargets: (workout: String, day: String, step: String, sets: Int, reps: Int, rest: Int) -> Unit =
+    { _, _, _, _, _, _ -> }
 ) {
   val scope = rememberCoroutineScope()
   val exerciseSetId = activeSetWithRecord?.exerciseSet?.id
@@ -326,7 +333,18 @@ fun PagerDetailView(
           ) {
             { secs: Int -> onRestOverrideChange(exerciseSetId, secs) }
           } else null,
-          nextRestSeconds = nextRestSeconds
+          nextRestSeconds = nextRestSeconds,
+          editing = editing,
+          onUpdateCustomTargets = { sets, reps ->
+            onUpdateCustomTargets(
+              activeSetWithRecord.exerciseSet.workout,
+              activeSetWithRecord.exerciseSet.day,
+              activeSetWithRecord.exerciseSet.step,
+              sets,
+              reps,
+              activeSetWithRecord.exerciseSet.rest
+            )
+          }
         )
       }
     }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -343,7 +343,7 @@ fun PagerDetailView(
           } else null,
           nextRestSeconds = nextRestSeconds,
           editing = editing,
-          onUpdateCustomTargets = { sets, reps ->
+          onUpdateCustomTargets = { sets, reps, repsRange ->
             onUpdateCustomTargets(
               activeSetWithRecord.exerciseSet.workout,
               activeSetWithRecord.exerciseSet.day,
@@ -351,7 +351,7 @@ fun PagerDetailView(
               sets,
               reps,
               activeSetWithRecord.exerciseSet.rest,
-              activeSetWithRecord.exerciseSet.repsRange
+              repsRange
             )
           }
         )

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -149,9 +149,7 @@ fun PagerExerciseView(
           globalAlternate = workoutPlan?.globalAlternate,
           setRecords = setRecords,
           timerStateByExerciseId = model.timerStateByExerciseId,
-          restOverrideByExerciseId = model.restOverrideByExerciseId,
           onTimerToggle = { id, running, restSecs -> model.setTimerRunning(id, running, restSecs) },
-          onRestOverrideChange = { id, secs -> model.setRestOverride(id, secs) },
           editing = editing,
           onUpdateCustomTargets = { workout, day, step, sets, reps, rest ->
             model.updateCustomExerciseSetTargets(workout, day, step, sets, reps, rest)
@@ -233,9 +231,7 @@ fun PagerDetailView(
   globalAlternate: Int? = null,
   setRecords: Map<String, ExerciseSetWithRecord> = emptyMap(),
   timerStateByExerciseId: Map<String, ExerciseViewModel.TimerState> = emptyMap(),
-  restOverrideByExerciseId: Map<String, Int> = emptyMap(),
   onTimerToggle: (id: String, running: Boolean, restSeconds: Int) -> Unit = { _, _, _ -> },
-  onRestOverrideChange: (id: String, seconds: Int) -> Unit = { _, _ -> },
   onSave: (Record) -> Unit,
   onStartEditWeight: (Weight) -> Unit,
   editing: Boolean = false,
@@ -254,7 +250,7 @@ fun PagerDetailView(
   // Ring shows the running timer's rest duration; +/- controls apply to the settled exercise
   val ringRestSeconds = when {
     activeRunningTimerState != null -> activeRunningTimerState.restSeconds
-    exerciseSetId != null -> restOverrideByExerciseId[exerciseSetId] ?: activeSetWithRecord.exerciseSet.rest
+    exerciseSetId != null -> activeSetWithRecord.exerciseSet.rest
     else -> 0
   }
 
@@ -269,7 +265,7 @@ fun PagerDetailView(
   val nextRestSeconds = when {
     activeSetWithRecord?.exerciseIncomplete == false -> null
     isViewingDifferentExerciseThanRunning ->
-      exerciseSetId?.let { restOverrideByExerciseId[it] ?: activeSetWithRecord.exerciseSet.rest }
+      exerciseSetId?.let { activeSetWithRecord.exerciseSet.rest }
     displayedExerciseHasRecordToday -> ringRestSeconds
     else -> null
   }
@@ -314,16 +310,25 @@ fun PagerDetailView(
                 onTimerToggle(activeRunningEntry.key, false, 0)
               } else {
                 // Start a timer for the settled exercise
-                val restSecs = restOverrideByExerciseId[it] ?: activeSetWithRecord.exerciseSet.rest
-                onTimerToggle(it, true, restSecs)
+                onTimerToggle(it, true, activeSetWithRecord.exerciseSet.rest)
               }
             }
           },
           restOverride = ringRestSeconds,
           // Rest is freely adjustable in edit mode only - unconditionally, not gated on
-          // completion state. Outside edit mode the prescribed rest is fixed.
+          // completion state - and writes straight through to the persisted set, same path
+          // as the sets/reps target editor. Outside edit mode the prescribed rest is fixed.
           onRestOverrideChange = if (editing && exerciseSetId != null) {
-            { secs: Int -> onRestOverrideChange(exerciseSetId, secs) }
+            { secs: Int ->
+              onUpdateCustomTargets(
+                activeSetWithRecord.exerciseSet.workout,
+                activeSetWithRecord.exerciseSet.day,
+                activeSetWithRecord.exerciseSet.step,
+                activeSetWithRecord.exerciseSet.sets,
+                activeSetWithRecord.exerciseSet.reps,
+                secs
+              )
+            }
           } else null,
           nextRestSeconds = nextRestSeconds,
           editing = editing,

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -155,6 +155,9 @@ fun PagerExerciseView(
             model.updateCustomExerciseSetTargets(workout, day, step, sets, reps, rest)
           },
           onDeleteExercise = { workout, day, step -> model.deleteExercise(workout, day, step) },
+          onEditNote = { workout, day, step, note ->
+            model.updateCustomExerciseSetNote(workout, day, step, note)
+          },
           onSave = { updatedRecord ->
             val savedRecord = updatedRecord.copy(stored = true)
             currentSetRecord!!.saveRecordInState(savedRecord)
@@ -238,7 +241,8 @@ fun PagerDetailView(
   editing: Boolean = false,
   onUpdateCustomTargets: (workout: String, day: String, step: String, sets: Int, reps: Int, rest: Int) -> Unit =
     { _, _, _, _, _, _ -> },
-  onDeleteExercise: (workout: String, day: String, step: String) -> Unit = { _, _, _ -> }
+  onDeleteExercise: (workout: String, day: String, step: String) -> Unit = { _, _, _ -> },
+  onEditNote: (workout: String, day: String, step: String, note: String) -> Unit = { _, _, _, _ -> }
 ) {
   val scope = rememberCoroutineScope()
   val exerciseSetId = activeSetWithRecord?.exerciseSet?.id
@@ -283,7 +287,8 @@ fun PagerDetailView(
         alternateIndex = globalAlternate,
         setRecords = setRecords,
         editing = editing,
-        onDeleteExercise = { set -> onDeleteExercise(set.workout, set.day, set.step) }
+        onDeleteExercise = { set -> onDeleteExercise(set.workout, set.day, set.step) },
+        onEditNote = { set, note -> onEditNote(set.workout, set.day, set.step, note) }
       )
     },
     second = {

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -324,13 +324,9 @@ fun PagerDetailView(
           },
           maxRestSeconds = maxRestSeconds.coerceAtLeast(activeSetWithRecord.exerciseSet.rest),
           restOverride = ringRestSeconds,
-          // Open (custom) exercises' rest is adjustable until the first set lands - after
-          // that, whatever rest was used for set one is the established rest for the day,
-          // same as how reps/weight targets lock in once completed.
-          onRestOverrideChange = if (exerciseSetId != null &&
-            activeSetWithRecord.exerciseSet.sets < 0 &&
-            activeSetWithRecord.numCompleted == 0
-          ) {
+          // Rest is freely adjustable in edit mode only - unconditionally, not gated on
+          // completion state. Outside edit mode the prescribed rest is fixed.
+          onRestOverrideChange = if (editing && exerciseSetId != null) {
             { secs: Int -> onRestOverrideChange(exerciseSetId, secs) }
           } else null,
           nextRestSeconds = nextRestSeconds,

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -106,7 +106,6 @@ fun PagerExerciseView(
     ?.collectAsState(initial = null, Dispatchers.IO)
     ?: remember { mutableStateOf(null) }
   val isRefreshing by model.isLoading.collectAsStateWithLifecycle()
-  val maxRestSeconds by model.maxRestSeconds.collectAsState(initial = 0)
 
   val currentSetRecord = exerciseSet?.let { setRecords[it.id] }
 
@@ -149,7 +148,6 @@ fun PagerExerciseView(
           displayedPage = displayedPage,
           globalAlternate = workoutPlan?.globalAlternate,
           setRecords = setRecords,
-          maxRestSeconds = maxRestSeconds,
           timerStateByExerciseId = model.timerStateByExerciseId,
           restOverrideByExerciseId = model.restOverrideByExerciseId,
           onTimerToggle = { id, running, restSecs -> model.setTimerRunning(id, running, restSecs) },
@@ -234,7 +232,6 @@ fun PagerDetailView(
   /** Plan-wide alternate override for instructions with shared global alternate labels. */
   globalAlternate: Int? = null,
   setRecords: Map<String, ExerciseSetWithRecord> = emptyMap(),
-  maxRestSeconds: Int = 0,
   timerStateByExerciseId: Map<String, ExerciseViewModel.TimerState> = emptyMap(),
   restOverrideByExerciseId: Map<String, Int> = emptyMap(),
   onTimerToggle: (id: String, running: Boolean, restSeconds: Int) -> Unit = { _, _, _ -> },
@@ -322,7 +319,6 @@ fun PagerDetailView(
               }
             }
           },
-          maxRestSeconds = maxRestSeconds.coerceAtLeast(activeSetWithRecord.exerciseSet.rest),
           restOverride = ringRestSeconds,
           // Rest is freely adjustable in edit mode only - unconditionally, not gated on
           // completion state. Outside edit mode the prescribed rest is fixed.
@@ -373,7 +369,6 @@ private fun PreviewPagerDetailView(@PreviewParameter(ExampleExerciseProvider::cl
           setRecords = records,
           allSets = emptyFlow()
         ),
-        maxRestSeconds = 90,
         onSave = { },
         onStartEditWeight = {}
       )

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -71,13 +71,25 @@ fun PagerExerciseView(
   onAlternateChange: (Int) -> Unit,
   onStartEditWeight: (Weight) -> Unit,
   onSetSaved: () -> Unit = {},
-  onAddExercise: () -> Unit = {}
+  onAddExercise: () -> Unit = {},
+  scrollToExerciseName: String? = null
 ) {
   val allRecords by model.records.collectAsState(initial = emptyList())
   val setRecords = recordsByExerciseId(allRecords = allRecords)
 
   val instructions by model.exercises.collectAsState(initial = emptyList(), Dispatchers.IO)
   val pagerState = rememberPagerState(pageCount = { instructions.size })
+
+  // Land on an exercise just added from the add-exercise flow instead of wherever the pager
+  // otherwise starts - fires once the newly-inserted row has actually loaded.
+  LaunchedEffect(instructions, scrollToExerciseName) {
+    if (scrollToExerciseName != null) {
+      val targetIndex = instructions.indexOfFirst { instruction ->
+        instruction.sets.any { it.exerciseName == scrollToExerciseName }
+      }
+      if (targetIndex >= 0) pagerState.scrollToPage(targetIndex)
+    }
+  }
   // While a finger is down the index holds at the settled page — releasing is what
   // commits the change. Once released (fling included), targetPage knows the
   // destination immediately, so the bottom half doesn't wait out the coast animation.
@@ -102,7 +114,11 @@ fun PagerExerciseView(
     currentSetRecord?.allSets?.let { setHistoryList(it) }
   }
 
-  val showRefreshIndicator = isRefreshing || exerciseSet == null || currentSetRecord == null
+  // A genuinely empty day (no instructions, e.g. a fresh custom day) never resolves an
+  // exerciseSet/currentSetRecord - only treat those as "still loading" when there's an
+  // instruction they should eventually resolve against.
+  val showRefreshIndicator = isRefreshing ||
+    (instructions.isNotEmpty() && (exerciseSet == null || currentSetRecord == null))
   val pullRefreshState =
     rememberPullRefreshState(
       refreshing = showRefreshIndicator,
@@ -293,7 +309,15 @@ fun PagerDetailView(
           },
           maxRestSeconds = maxRestSeconds.coerceAtLeast(activeSetWithRecord.exerciseSet.rest),
           restOverride = ringRestSeconds,
-          onRestOverrideChange = null,   // rest adjustment not exposed in pager path for now
+          // Open (custom) exercises' rest is adjustable until the first set lands - after
+          // that, whatever rest was used for set one is the established rest for the day,
+          // same as how reps/weight targets lock in once completed.
+          onRestOverrideChange = if (exerciseSetId != null &&
+            activeSetWithRecord.exerciseSet.sets < 0 &&
+            activeSetWithRecord.numCompleted == 0
+          ) {
+            { secs: Int -> onRestOverrideChange(exerciseSetId, secs) }
+          } else null,
           nextRestSeconds = nextRestSeconds
         )
       }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -151,8 +151,8 @@ fun PagerExerciseView(
           timerStateByExerciseId = model.timerStateByExerciseId,
           onTimerToggle = { id, running, restSecs -> model.setTimerRunning(id, running, restSecs) },
           editing = editing,
-          onUpdateCustomTargets = { workout, day, step, sets, reps, rest ->
-            model.updateCustomExerciseSetTargets(workout, day, step, sets, reps, rest)
+          onUpdateCustomTargets = { workout, day, step, sets, reps, rest, repsRange ->
+            model.updateCustomExerciseSetTargets(workout, day, step, sets, reps, rest, repsRange)
           },
           onDeleteExercise = { workout, day, step -> model.deleteExercise(workout, day, step) },
           onEditNote = { workout, day, step, note ->
@@ -239,8 +239,9 @@ fun PagerDetailView(
   onSave: (Record) -> Unit,
   onStartEditWeight: (Weight) -> Unit,
   editing: Boolean = false,
-  onUpdateCustomTargets: (workout: String, day: String, step: String, sets: Int, reps: Int, rest: Int) -> Unit =
-    { _, _, _, _, _, _ -> },
+  onUpdateCustomTargets: (
+    workout: String, day: String, step: String, sets: Int, reps: Int, rest: Int, repsRange: Int
+  ) -> Unit = { _, _, _, _, _, _, _ -> },
   onDeleteExercise: (workout: String, day: String, step: String) -> Unit = { _, _, _ -> },
   onEditNote: (workout: String, day: String, step: String, note: String) -> Unit = { _, _, _, _ -> }
 ) {
@@ -335,7 +336,8 @@ fun PagerDetailView(
                 activeSetWithRecord.exerciseSet.step,
                 activeSetWithRecord.exerciseSet.sets,
                 activeSetWithRecord.exerciseSet.reps,
-                secs
+                secs,
+                activeSetWithRecord.exerciseSet.repsRange
               )
             }
           } else null,
@@ -348,7 +350,8 @@ fun PagerDetailView(
               activeSetWithRecord.exerciseSet.step,
               sets,
               reps,
-              activeSetWithRecord.exerciseSet.rest
+              activeSetWithRecord.exerciseSet.rest,
+              activeSetWithRecord.exerciseSet.repsRange
             )
           }
         )

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -154,6 +154,7 @@ fun PagerExerciseView(
           onUpdateCustomTargets = { workout, day, step, sets, reps, rest ->
             model.updateCustomExerciseSetTargets(workout, day, step, sets, reps, rest)
           },
+          onDeleteExercise = { workout, day, step -> model.deleteExercise(workout, day, step) },
           onSave = { updatedRecord ->
             val savedRecord = updatedRecord.copy(stored = true)
             currentSetRecord!!.saveRecordInState(savedRecord)
@@ -236,7 +237,8 @@ fun PagerDetailView(
   onStartEditWeight: (Weight) -> Unit,
   editing: Boolean = false,
   onUpdateCustomTargets: (workout: String, day: String, step: String, sets: Int, reps: Int, rest: Int) -> Unit =
-    { _, _, _, _, _, _ -> }
+    { _, _, _, _, _, _ -> },
+  onDeleteExercise: (workout: String, day: String, step: String) -> Unit = { _, _, _ -> }
 ) {
   val scope = rememberCoroutineScope()
   val exerciseSetId = activeSetWithRecord?.exerciseSet?.id
@@ -279,7 +281,9 @@ fun PagerDetailView(
         instructions = instructions,
         pagerState = pagerState,
         alternateIndex = globalAlternate,
-        setRecords = setRecords
+        setRecords = setRecords,
+        editing = editing,
+        onDeleteExercise = { set -> onDeleteExercise(set.workout, set.day, set.step) }
       )
     },
     second = {

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -82,13 +82,17 @@ fun PagerExerciseView(
   val pagerState = rememberPagerState(pageCount = { instructions.size })
 
   // Land on an exercise just added from the add-exercise flow instead of wherever the pager
-  // otherwise starts - fires once the newly-inserted row has actually loaded.
-  LaunchedEffect(instructions, scrollToExerciseName) {
-    if (scrollToExerciseName != null) {
-      val targetIndex = instructions.indexOfFirst { instruction ->
-        instruction.sets.any { it.exerciseName == scrollToExerciseName }
-      }
-      if (targetIndex >= 0) pagerState.scrollToPage(targetIndex)
+  // otherwise starts - fires once the newly-inserted row has actually loaded, then clears
+  // itself so later unrelated recompositions of `instructions` don't re-trigger the scroll.
+  var pendingScrollTarget by remember { mutableStateOf(scrollToExerciseName) }
+  LaunchedEffect(instructions, pendingScrollTarget) {
+    val target = pendingScrollTarget ?: return@LaunchedEffect
+    val targetIndex = instructions.indexOfFirst { instruction ->
+      instruction.sets.any { it.exerciseName == target }
+    }
+    if (targetIndex >= 0) {
+      pagerState.scrollToPage(targetIndex)
+      pendingScrollTarget = null
     }
   }
   // While a finger is down the index holds at the settled page — releasing is what

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -71,6 +71,7 @@ fun PagerExerciseView(
   onAlternateChange: (Int) -> Unit,
   onStartEditWeight: (Weight) -> Unit,
   onSetSaved: () -> Unit = {},
+  editing: Boolean = false,
   onAddExercise: () -> Unit = {},
   scrollToExerciseName: String? = null
 ) {
@@ -138,7 +139,7 @@ fun PagerExerciseView(
         .zIndex(100f)
     )
     if (workoutPlan?.isCustom == true && instructions.isEmpty() && !isRefreshing) {
-      EmptyCustomDay(onAddExercise = onAddExercise)
+      EmptyCustomDay(onAddExercise = if (editing) onAddExercise else null)
     } else {
       Column {
         PagerDetailView(
@@ -176,8 +177,10 @@ fun PagerExerciseView(
   }
 }
 
+// A null onAddExercise means this day was opened outside edit mode - exercises can only be added
+// from the edit-mode calendar, so the button (and its prompt) is left off entirely.
 @Composable
-private fun EmptyCustomDay(onAddExercise: () -> Unit, modifier: Modifier = Modifier) {
+private fun EmptyCustomDay(onAddExercise: (() -> Unit)?, modifier: Modifier = Modifier) {
   Column(
     modifier
       .fillMaxSize()
@@ -198,16 +201,21 @@ private fun EmptyCustomDay(onAddExercise: () -> Unit, modifier: Modifier = Modif
     Spacer(Modifier.height(8.dp))
     Text(
       // TODO localize
-      "Build this day as you train. There are no set limits the first time — targets fill in from what you complete.",
+      if (onAddExercise != null)
+        "Build this day as you train. There are no set limits the first time — targets fill in from what you complete."
+      else
+        "Open this day from edit mode on the calendar to add exercises.",
       style = MaterialTheme.typography.body2,
       textAlign = TextAlign.Center
     )
-    Spacer(Modifier.height(16.dp))
-    Button(onClick = onAddExercise) {
-      Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp))
-      Spacer(Modifier.width(8.dp))
-      // TODO localize
-      Text("Add exercise")
+    if (onAddExercise != null) {
+      Spacer(Modifier.height(16.dp))
+      Button(onClick = onAddExercise) {
+        Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+        Spacer(Modifier.width(8.dp))
+        // TODO localize
+        Text("Add exercise")
+      }
     }
   }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerInstruction.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerInstruction.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.EnterExitState
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.togetherWith
@@ -45,6 +44,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -64,6 +64,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.zIndex
@@ -149,11 +150,23 @@ fun PagerExerciseInstructions(
         val currentPage = pagerState.currentPage
         instructions.forEachIndexed { idx, instruction ->
           key(idx) {
+            // Same continuous focus the pager layer computes, keyed the same way (distance
+            // from the settled scroll position) — the pager hands a card off to the deck
+            // mid-focus (at distance -0.5, pageFocus 0.5) as it slides out to the left, so
+            // without this the card's elevation snapped from 3.5dp to a hardcoded 1dp right
+            // at the handoff.
+            val pageFocus by remember(idx) {
+              derivedStateOf {
+                val scroll = pagerState.currentPage + pagerState.currentPageOffsetFraction
+                (1f - (idx - scroll).absoluteValue).coerceIn(0f, 1f)
+              }
+            }
             CardContent(
               instruction, alternateIndex, setRecords,
               // The deck's own copy of a card is never the authoritative, focused render (the
               // pager owns that for the settled page) — never worth animating a swap here.
               isActivePage = false,
+              pageFocus = pageFocus,
               editing = editing,
               onDeleteExercise = onDeleteExercise,
               onEditNote = onEditNote,
@@ -203,12 +216,23 @@ fun PagerExerciseInstructions(
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
       ) { page ->
         val pagesFromCurrent = page - pagerState.currentPage
+        // Continuous distance of this page from front-and-center, in pages — the same
+        // measure the graphicsLayer block below uses for position. Driving elevation from
+        // this instead of the isActivePage boolean means it tracks the drag itself rather
+        // than jumping into a tween at the halfway point where currentPage flips.
+        val pageFocus by remember(page) {
+          derivedStateOf {
+            val distance = (page - pagerState.currentPage) - pagerState.currentPageOffsetFraction
+            (1f - distance.absoluteValue).coerceIn(0f, 1f)
+          }
+        }
         CardContent(
           instructions.getOrNull(page), alternateIndex, setRecords,
           // Only the settled, front-and-center page should ever escape into the unclipped
           // popup — anything mid-swipe or off to the side would just be a phantom animation
           // bleeding through on top of whatever the user is actually looking at.
           isActivePage = pagesFromCurrent == 0,
+          pageFocus = pageFocus,
           editing = editing,
           onDeleteExercise = onDeleteExercise,
           onEditNote = onEditNote,
@@ -318,6 +342,8 @@ private fun CardContent(
   alternateIndex: Int?,
   setRecords: Map<String, ExerciseSetWithRecord>,
   isActivePage: Boolean,
+  /** Continuous 0..1 distance-from-center, in pages — 0 for deck cards, which never focus. */
+  pageFocus: Float = 0f,
   modifier: Modifier = Modifier,
   editing: Boolean = false,
   onDeleteExercise: (ExerciseSet) -> Unit = {},
@@ -390,12 +416,16 @@ private fun CardContent(
 
     @Composable
     fun SwapCard(cardModifier: Modifier) {
-      // Animated rather than a hard cut - isActivePage flips as the pager settles on a new
-      // page mid-swipe, and jumping straight from 1.dp to 6.dp popped visibly at that instant.
-      val elevation = animateDpAsState(
-        targetValue = if (isActivePage) 6.dp else 1.dp,
-        label = "cardElevation"
-      )
+      // Driven straight off pageFocus (the page's continuous distance from center) rather
+      // than a boolean + tween — tracks the drag itself instead of jumping into an animation
+      // at the halfway point where isActivePage flips. Passed to Card's own elevation param,
+      // not just a graphicsLayer shadow, so the tonal surface color moves with it too.
+      //
+      // Known issue: this card's rounded corners render square for the duration of the
+      // NavHost fade transition when first navigating in from the calendar, self-correcting
+      // once the fade settles — a Compose framework bug, not caused by the elevation logic
+      // here. See https://issuetracker.google.com/issues/375496210.
+      val elevation = lerp(1.dp, 6.dp, pageFocus)
       Card(
         cardModifier.graphicsLayer {
           // Clear the card's own full bounds plus a margin, so it's completely offscreen at
@@ -403,8 +433,8 @@ private fun CardContent(
           translationX = swapProgress * (size.width + 32.dp.toPx())
           translationY = -swapProgress * (size.height + 32.dp.toPx())
           rotationZ = swapProgress * 18f
-          shadowElevation = elevation.value.toPx()
         },
+        elevation = elevation,
       ) {
         CompositionLocalProvider(
           LocalOverscrollFactory provides null

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerInstruction.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerInstruction.kt
@@ -26,6 +26,8 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Button
 import androidx.compose.material.Card
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -37,6 +39,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -94,6 +97,8 @@ fun PagerExerciseInstructions(
    * pre-composed pages have correct data without waiting for the parent to re-pass it.
    */
   setRecords: Map<String, ExerciseSetWithRecord> = emptyMap(),
+  editing: Boolean = false,
+  onDeleteExercise: (ExerciseSet) -> Unit = {},
 ) {
   val pageRotations = remember(instructions.size) {
     val rotation = maxRotation - minRotation
@@ -145,6 +150,8 @@ fun PagerExerciseInstructions(
               // The deck's own copy of a card is never the authoritative, focused render (the
               // pager owns that for the settled page) — never worth animating a swap here.
               isActivePage = false,
+              editing = editing,
+              onDeleteExercise = onDeleteExercise,
               modifier = Modifier
                 .fillMaxSize()
                 // Upcoming cards stack above previously completed ones
@@ -197,6 +204,8 @@ fun PagerExerciseInstructions(
           // popup — anything mid-swipe or off to the side would just be a phantom animation
           // bleeding through on top of whatever the user is actually looking at.
           isActivePage = pagesFromCurrent == 0,
+          editing = editing,
+          onDeleteExercise = onDeleteExercise,
           modifier = Modifier
             .fillMaxSize()
             // The card leaving the top of the deck stays above the one being revealed or
@@ -297,6 +306,8 @@ private fun CardContent(
   setRecords: Map<String, ExerciseSetWithRecord>,
   isActivePage: Boolean,
   modifier: Modifier = Modifier,
+  editing: Boolean = false,
+  onDeleteExercise: (ExerciseSet) -> Unit = {},
 ) {
   val exerciseSetFlow = remember(instruction, alternateIndex) { instruction?.set(alternateIndex) }
   val exerciseSet by exerciseSetFlow
@@ -375,7 +386,12 @@ private fun CardContent(
           LocalOverscrollFactory provides null
         ) {
           // Each card self-serves its own progress from the records map — no reflow on swipe
-          ExerciseInstructions(targetSet, setRecords[targetSet?.id]?.numCompleted ?: 0)
+          ExerciseInstructions(
+            targetSet,
+            setRecords[targetSet?.id]?.numCompleted ?: 0,
+            editing = editing,
+            onDeleteExercise = onDeleteExercise
+          )
         }
       }
     }
@@ -431,6 +447,8 @@ private fun ExerciseInstructions(
   exerciseSet: ExerciseSet?,
   /** Defaults to 0 so the progress line always occupies space from first paint — no layout jump. */
   numCompleted: Int = 0,
+  editing: Boolean = false,
+  onDeleteExercise: (ExerciseSet) -> Unit = {},
 ) {
   val cardColor = LocalElevationOverlay.current?.apply(MaterialTheme.colors.surface, LocalAbsoluteElevation.current)
     ?: MaterialTheme.colors.surface
@@ -512,6 +530,35 @@ private fun ExerciseInstructions(
           .align(Alignment.BottomCenter)
           .padding(bottom = 12.dp)
       )
+    }
+
+    // Anchored to the Box, not inside the LazyColumn, so it stays put regardless of scroll.
+    if (editing && exerciseSet != null) {
+      var confirmingDelete by remember(exerciseSet.id) { mutableStateOf(false) }
+      IconButton(
+        onClick = { confirmingDelete = true },
+        modifier = Modifier.align(Alignment.TopEnd)
+      ) {
+        // TODO localize
+        Icon(Icons.Default.Close, contentDescription = "remove ${exerciseSet.exerciseName}")
+      }
+      if (confirmingDelete) {
+        AlertDialog(
+          onDismissRequest = { confirmingDelete = false },
+          // TODO localize
+          title = { Text("Remove ${exerciseSet.exerciseName}?") },
+          text = { Text("This removes it from today's plan. Your past completed sets are kept.") },
+          confirmButton = {
+            Button(onClick = {
+              confirmingDelete = false
+              onDeleteExercise(exerciseSet)
+            }) { Text("Remove") }
+          },
+          dismissButton = {
+            Button(onClick = { confirmingDelete = false }) { Text("Cancel") }
+          }
+        )
+      }
     }
   }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerInstruction.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerInstruction.kt
@@ -518,6 +518,14 @@ private fun ExerciseInstructions(
 
 /** Formats a human-readable prescription string from an [ExerciseSet]. */
 private fun buildPrescriptionText(exerciseSet: ExerciseSet): String {
+  // A freshly-added custom exercise starts fully open (sets and reps both -1) rather than
+  // "AMRAP x AMRAP reps" - that's not a real prescription, just "nothing set yet".
+  if (exerciseSet.sets < 0 && exerciseSet.reps < 0 &&
+    !exerciseSet.isToFailure && !exerciseSet.repsAreSequenced
+  ) {
+    // TODO localize
+    return "Target not set yet"
+  }
   val setsStr = when {
     exerciseSet.sets < 0 -> "AMRAP"
     else -> "${exerciseSet.sets} sets"

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerInstruction.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerInstruction.kt
@@ -607,6 +607,7 @@ private fun buildPrescriptionText(exerciseSet: ExerciseSet): String {
     exerciseSet.isToFailure -> "to failure"
     exerciseSet.repsAreSequenced -> exerciseSet.repsSequence.joinToString("/")
     exerciseSet.reps < 0 -> "AMRAP reps"
+    exerciseSet.repsRange > 0 -> "${exerciseSet.reps}-${exerciseSet.reps + exerciseSet.repsRange} reps"
     else -> "${exerciseSet.reps} reps"
   }
   val restStr = if (exerciseSet.rest > 0) " · ${exerciseSet.rest}s rest" else ""

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerInstruction.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerInstruction.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -73,6 +74,7 @@ import com.litus_animae.refitted.data.models.ExerciseSet
 import com.litus_animae.refitted.ui.models.ExerciseViewModel
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 import kotlin.math.absoluteValue
 import kotlin.math.ceil
@@ -99,6 +101,7 @@ fun PagerExerciseInstructions(
   setRecords: Map<String, ExerciseSetWithRecord> = emptyMap(),
   editing: Boolean = false,
   onDeleteExercise: (ExerciseSet) -> Unit = {},
+  onEditNote: (exerciseSet: ExerciseSet, note: String) -> Unit = { _, _ -> },
 ) {
   val pageRotations = remember(instructions.size) {
     val rotation = maxRotation - minRotation
@@ -152,6 +155,7 @@ fun PagerExerciseInstructions(
               isActivePage = false,
               editing = editing,
               onDeleteExercise = onDeleteExercise,
+              onEditNote = onEditNote,
               modifier = Modifier
                 .fillMaxSize()
                 // Upcoming cards stack above previously completed ones
@@ -206,6 +210,7 @@ fun PagerExerciseInstructions(
           isActivePage = pagesFromCurrent == 0,
           editing = editing,
           onDeleteExercise = onDeleteExercise,
+          onEditNote = onEditNote,
           modifier = Modifier
             .fillMaxSize()
             // The card leaving the top of the deck stays above the one being revealed or
@@ -308,6 +313,7 @@ private fun CardContent(
   modifier: Modifier = Modifier,
   editing: Boolean = false,
   onDeleteExercise: (ExerciseSet) -> Unit = {},
+  onEditNote: (exerciseSet: ExerciseSet, note: String) -> Unit = { _, _ -> },
 ) {
   val exerciseSetFlow = remember(instruction, alternateIndex) { instruction?.set(alternateIndex) }
   val exerciseSet by exerciseSetFlow
@@ -390,7 +396,8 @@ private fun CardContent(
             targetSet,
             setRecords[targetSet?.id]?.numCompleted ?: 0,
             editing = editing,
-            onDeleteExercise = onDeleteExercise
+            onDeleteExercise = onDeleteExercise,
+            onEditNote = onEditNote
           )
         }
       }
@@ -449,9 +456,13 @@ private fun ExerciseInstructions(
   numCompleted: Int = 0,
   editing: Boolean = false,
   onDeleteExercise: (ExerciseSet) -> Unit = {},
+  onEditNote: (exerciseSet: ExerciseSet, note: String) -> Unit = { _, _ -> },
 ) {
   val cardColor = LocalElevationOverlay.current?.apply(MaterialTheme.colors.surface, LocalAbsoluteElevation.current)
     ?: MaterialTheme.colors.surface
+  // Hoisted (rather than collected only inside the LazyColumn item below) so the edit dialog can
+  // show the same description without a second subscription.
+  val exercise by (exerciseSet?.exercise ?: emptyFlow()).collectAsStateWithLifecycle(null)
   // The band anchored above the pinned counter, bottom to top: solidHeight is fully
   // opaque card background (guarantees the counter never sits on visible text, since a
   // linear fade alone only reaches full opacity at its very last pixel), then fadeHeight
@@ -492,7 +503,6 @@ private fun ExerciseInstructions(
       }
       item {
         if (exerciseSet != null) {
-          val exercise by exerciseSet.exercise.collectAsStateWithLifecycle(null)
           Text(exercise?.description ?: "", Modifier.padding(bottom = 5.dp))
         }
       }
@@ -535,12 +545,16 @@ private fun ExerciseInstructions(
     // Anchored to the Box, not inside the LazyColumn, so it stays put regardless of scroll.
     if (editing && exerciseSet != null) {
       var confirmingDelete by remember(exerciseSet.id) { mutableStateOf(false) }
-      IconButton(
-        onClick = { confirmingDelete = true },
-        modifier = Modifier.align(Alignment.TopEnd)
-      ) {
-        // TODO localize
-        Icon(Icons.Default.Close, contentDescription = "remove ${exerciseSet.exerciseName}")
+      var editingNote by remember(exerciseSet.id) { mutableStateOf(false) }
+      Row(modifier = Modifier.align(Alignment.TopEnd)) {
+        IconButton(onClick = { editingNote = true }) {
+          // TODO localize
+          Icon(Icons.Default.Edit, contentDescription = "edit ${exerciseSet.exerciseName} instructions")
+        }
+        IconButton(onClick = { confirmingDelete = true }) {
+          // TODO localize
+          Icon(Icons.Default.Close, contentDescription = "remove ${exerciseSet.exerciseName}")
+        }
       }
       if (confirmingDelete) {
         AlertDialog(
@@ -556,6 +570,18 @@ private fun ExerciseInstructions(
           },
           dismissButton = {
             Button(onClick = { confirmingDelete = false }) { Text("Cancel") }
+          }
+        )
+      }
+      if (editingNote) {
+        EditInstructionDialog(
+          exerciseName = exerciseSet.exerciseName,
+          description = exercise?.description,
+          initialNote = exerciseSet.note,
+          onDismissRequest = { editingNote = false },
+          onSave = { note ->
+            editingNote = false
+            onEditNote(exerciseSet, note)
           }
         )
       }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerInstruction.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerInstruction.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.EnterExitState
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.togetherWith
@@ -294,7 +295,14 @@ fun PagerExerciseInstructions(
     }
 
     val instruction = instructions.getOrNull(pagerState.currentPage)
-    val exerciseSetFlow = remember(instruction, alternateIndex) { instruction?.set(alternateIndex) }
+    // Keyed on the instruction's stable identity, not the instruction object itself - every edit
+    // anywhere rebuilds the whole instructions list into fresh ExerciseInstruction/ExerciseSet
+    // objects (each carrying a newly-queried `exercise: Flow<Exercise?>` field that's never equal
+    // across reloads), so keying on `instruction` would recreate this flow - and reset the
+    // collected state to null for a frame - on every unrelated edit, not just this card's own.
+    val exerciseSetFlow = remember(instruction?.sets?.head?.id, alternateIndex) {
+      instruction?.set(alternateIndex)
+    }
     val exerciseSet by exerciseSetFlow
       ?.collectAsStateWithLifecycle(initialValue = null)
       ?: remember { mutableStateOf(null) }
@@ -315,7 +323,14 @@ private fun CardContent(
   onDeleteExercise: (ExerciseSet) -> Unit = {},
   onEditNote: (exerciseSet: ExerciseSet, note: String) -> Unit = { _, _ -> },
 ) {
-  val exerciseSetFlow = remember(instruction, alternateIndex) { instruction?.set(alternateIndex) }
+  // Keyed on the instruction's stable identity, not the instruction object itself - every edit
+  // anywhere rebuilds the whole instructions list into fresh ExerciseInstruction/ExerciseSet
+  // objects (each carrying a newly-queried `exercise: Flow<Exercise?>` field that's never equal
+  // across reloads), so keying on `instruction` would recreate this flow - and reset the
+  // collected state to null for a frame - on every unrelated edit, not just this card's own.
+  val exerciseSetFlow = remember(instruction?.sets?.head?.id, alternateIndex) {
+    instruction?.set(alternateIndex)
+  }
   val exerciseSet by exerciseSetFlow
     ?.collectAsStateWithLifecycle(initialValue = null)
     ?: remember { mutableStateOf(null) }
@@ -375,6 +390,12 @@ private fun CardContent(
 
     @Composable
     fun SwapCard(cardModifier: Modifier) {
+      // Animated rather than a hard cut - isActivePage flips as the pager settles on a new
+      // page mid-swipe, and jumping straight from 1.dp to 6.dp popped visibly at that instant.
+      val elevation = animateDpAsState(
+        targetValue = if (isActivePage) 6.dp else 1.dp,
+        label = "cardElevation"
+      )
       Card(
         cardModifier.graphicsLayer {
           // Clear the card's own full bounds plus a margin, so it's completely offscreen at
@@ -382,11 +403,8 @@ private fun CardContent(
           translationX = swapProgress * (size.width + 32.dp.toPx())
           translationY = -swapProgress * (size.height + 32.dp.toPx())
           rotationZ = swapProgress * 18f
+          shadowElevation = elevation.value.toPx()
         },
-        // The front-and-center card gets a pronounced shadow so it visibly lifts off the
-        // deck; cards still sitting in the deck stay near-flat so the depth reads from
-        // the active card alone rather than every jittered card casting its own shadow.
-        elevation = if (isActivePage) 6.dp else 1.dp
       ) {
         CompositionLocalProvider(
           LocalOverscrollFactory provides null

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RepsDisplay.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RepsDisplay.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.litus_animae.refitted.ui.R
 import com.litus_animae.refitted.ui.compose.state.ExerciseSetWithRecord
@@ -57,6 +56,9 @@ import java.time.Instant
 /** Minimum height [RepsDisplay] needs; layouts sizing its container must not go below this */
 val RepsDisplayMinHeight = 170.dp
 
+/** Minimum height needed in edit mode, where [RepsRangeStepper] adds a value line and a +/- row */
+val RepsDisplayEditingMinHeight = 200.dp
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun RepsDisplay(
@@ -66,10 +68,11 @@ fun RepsDisplay(
   onUpdateTargetReps: ((reps: Int, repsRange: Int) -> Unit)? = null
 ) {
   val exerciseSet = setWithRecord.exerciseSet
+  val targetUpdater = onUpdateTargetReps.takeIf { editing }
   Column(
     Modifier
       .padding(bottom = 5.dp)
-      .heightIn(min = RepsDisplayMinHeight),
+      .heightIn(min = if (targetUpdater != null) RepsDisplayEditingMinHeight else RepsDisplayMinHeight),
     verticalArrangement = Arrangement.Center,
     horizontalAlignment = Alignment.CenterHorizontally
   ) {
@@ -113,21 +116,20 @@ fun RepsDisplay(
       color = lineColor,
       thickness = 3.dp
     )
-    Row {
+    Row(Modifier.fillMaxWidth()) {
       // Edit mode: adjustable target reps in place of the static prescription text.
       // isToFailure/repsUnit/sequenced reps are admin-only and never occur on a custom set, but
       // a rep range is - hence RepsRangeStepper rather than the plain TargetStepper the sets
       // count next to it uses.
-      if (editing && onUpdateTargetReps != null) {
-        // Matches the NumberPicker's own digit size/width above - the "Reps" header below
-        // already labels this, so the stepper's own caption would just repeat it.
+      if (targetUpdater != null) {
+        // Matches the NumberPicker's own text style above - the "Reps" header below already
+        // labels this, so the stepper's own caption would just repeat it.
         RepsRangeStepper(
           setId = exerciseSet.id,
           reps = exerciseSet.reps,
           repsRange = exerciseSet.repsRange,
-          onChange = onUpdateTargetReps,
-          valueStyle = typography,
-          valueWidth = 64.dp
+          onChange = targetUpdater,
+          valueStyle = typography
         )
       } else {
         Column(
@@ -177,8 +179,7 @@ private fun RepsRangeStepper(
   reps: Int,
   repsRange: Int,
   onChange: (reps: Int, repsRange: Int) -> Unit,
-  valueStyle: TextStyle,
-  valueWidth: Dp
+  valueStyle: TextStyle
 ) {
   val isSet = reps >= 0
   // Defaults to the low-end lock when restoring a persisted range with no remembered choice yet
@@ -197,55 +198,64 @@ private fun RepsRangeStepper(
     onChange(reps, 0)
   }
 
-  Column(horizontalAlignment = Alignment.CenterHorizontally) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-      IconButton(
-        onClick = {
-          when (lock) {
-            RepsRangeLock.NONE -> onChange((reps - 1).coerceAtLeast(1), 0)
-            RepsRangeLock.HIGH -> onChange(reps - 1, repsRange + 1)
-            RepsRangeLock.LOW -> Unit
-          }
-        },
-        enabled = isSet && lock != RepsRangeLock.LOW && reps > 1
-      ) {
-        Icon(Icons.Default.Remove, contentDescription = "decrease reps")
+  Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+    Text(
+      displayValue,
+      style = valueStyle,
+      textAlign = TextAlign.Center,
+      maxLines = 1,
+      softWrap = false,
+      modifier = Modifier.fillMaxWidth()
+    )
+    // Each button is paired with the lock that governs it and the two pairs pushed to the
+    // card's edges, rather than stacking +/- above the locks - that split the row width
+    // between two differently-sized rows the parent Column centered independently, so the
+    // locks never actually lined up under the button each one pins.
+    Row(
+      Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        IconButton(
+          onClick = {
+            when (lock) {
+              RepsRangeLock.NONE -> onChange((reps - 1).coerceAtLeast(1), 0)
+              RepsRangeLock.HIGH -> onChange(reps - 1, repsRange + 1)
+              RepsRangeLock.LOW -> Unit
+            }
+          },
+          enabled = isSet && lock != RepsRangeLock.LOW && reps > 1
+        ) {
+          Icon(Icons.Default.Remove, contentDescription = "decrease reps")
+        }
+        LockToggle(
+          locked = lock == RepsRangeLock.LOW,
+          enabled = isSet,
+          contentDescription = "lock the low end of the reps range",
+          onClick = { toggleLock(RepsRangeLock.LOW) }
+        )
       }
-      // Fixed width so a range's extra digits don't shift the text off-centre between the
-      // two fixed-size IconButtons.
-      Text(
-        displayValue,
-        style = valueStyle,
-        textAlign = TextAlign.Center,
-        modifier = Modifier.width(valueWidth)
-      )
-      IconButton(
-        onClick = {
-          when (lock) {
-            RepsRangeLock.NONE -> onChange((reps.takeIf { isSet } ?: 0) + 1, 0)
-            RepsRangeLock.LOW -> onChange(reps, repsRange + 1)
-            RepsRangeLock.HIGH -> Unit
-          }
-        },
-        enabled = lock != RepsRangeLock.HIGH
-      ) {
-        Icon(Icons.Default.Add, contentDescription = "increase reps")
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        LockToggle(
+          locked = lock == RepsRangeLock.HIGH,
+          enabled = isSet,
+          contentDescription = "lock the high end of the reps range",
+          onClick = { toggleLock(RepsRangeLock.HIGH) }
+        )
+        IconButton(
+          onClick = {
+            when (lock) {
+              RepsRangeLock.NONE -> onChange((reps.takeIf { isSet } ?: 0) + 1, 0)
+              RepsRangeLock.LOW -> onChange(reps, repsRange + 1)
+              RepsRangeLock.HIGH -> Unit
+            }
+          },
+          enabled = lock != RepsRangeLock.HIGH
+        ) {
+          Icon(Icons.Default.Add, contentDescription = "increase reps")
+        }
       }
-    }
-    Row(verticalAlignment = Alignment.CenterVertically) {
-      LockToggle(
-        locked = lock == RepsRangeLock.LOW,
-        enabled = isSet,
-        contentDescription = "lock the low end of the reps range",
-        onClick = { toggleLock(RepsRangeLock.LOW) }
-      )
-      Spacer(Modifier.width(valueWidth))
-      LockToggle(
-        locked = lock == RepsRangeLock.HIGH,
-        enabled = isSet,
-        contentDescription = "lock the high end of the reps range",
-        onClick = { toggleLock(RepsRangeLock.HIGH) }
-      )
     }
   }
 }
@@ -296,7 +306,36 @@ fun RepsDisplayEditingPreview(@PreviewParameter(ExampleExerciseProvider::class) 
   val records = remember { mutableStateListOf<Record>() }
   val currentRecord =
     remember { mutableStateOf(Record(25.0, exerciseSet.reps(0), exerciseSet, Instant.now())) }
-  Card(Modifier.size(170.dp)) {
+  // Sized to match the real portrait card rather than a 170dp square, which under-reports the
+  // width available and hides overcrowding.
+  Card(Modifier.size(width = 181.dp, height = RepsDisplayEditingMinHeight)) {
+    RepsDisplay(
+      setWithRecord = ExerciseSetWithRecord(
+        exerciseSet.copy(reps = reps, repsRange = repsRange),
+        currentRecord,
+        numCompleted = 1,
+        setRecords = records,
+        allSets = emptyFlow()
+      ),
+      Repetitions(95),
+      editing = true,
+      onUpdateTargetReps = { newReps, newRepsRange ->
+        reps = newReps
+        repsRange = newRepsRange
+      }
+    )
+  }
+}
+
+@Composable
+@Preview(apiLevel = 36)
+fun RepsDisplayEditingRangePreview(@PreviewParameter(ExampleExerciseProvider::class) exerciseSet: ExerciseSet) {
+  var reps by remember { mutableStateOf(10) }
+  var repsRange by remember { mutableStateOf(2) }
+  val records = remember { mutableStateListOf<Record>() }
+  val currentRecord =
+    remember { mutableStateOf(Record(25.0, exerciseSet.reps(0), exerciseSet, Instant.now())) }
+  Card(Modifier.size(width = 181.dp, height = RepsDisplayEditingMinHeight)) {
     RepsDisplay(
       setWithRecord = ExerciseSetWithRecord(
         exerciseSet.copy(reps = reps, repsRange = repsRange),

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RepsDisplay.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RepsDisplay.kt
@@ -17,21 +17,33 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Card
 import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.contentColorFor
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.LockOpen
+import androidx.compose.material.icons.filled.Remove
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.capitalize
 import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.litus_animae.refitted.ui.R
 import com.litus_animae.refitted.ui.compose.state.ExerciseSetWithRecord
@@ -49,7 +61,9 @@ val RepsDisplayMinHeight = 170.dp
 @Composable
 fun RepsDisplay(
   setWithRecord: ExerciseSetWithRecord,
-  reps: Repetitions
+  reps: Repetitions,
+  editing: Boolean = false,
+  onUpdateTargetReps: ((reps: Int, repsRange: Int) -> Unit)? = null
 ) {
   val exerciseSet = setWithRecord.exerciseSet
   Column(
@@ -100,18 +114,35 @@ fun RepsDisplay(
       thickness = 3.dp
     )
     Row {
-      Column(
-        Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.Top,
-        horizontalAlignment = Alignment.CenterHorizontally
-      ) {
-        Text(targetRepsTextContent, style = typography)
-        AnimatedVisibility(
-          visible = subtext.isNotBlank(),
-          enter = fadeIn() + expandVertically(),
-          exit = fadeOut() + shrinkVertically()
+      // Edit mode: adjustable target reps in place of the static prescription text.
+      // isToFailure/repsUnit/sequenced reps are admin-only and never occur on a custom set, but
+      // a rep range is - hence RepsRangeStepper rather than the plain TargetStepper the sets
+      // count next to it uses.
+      if (editing && onUpdateTargetReps != null) {
+        // Matches the NumberPicker's own digit size/width above - the "Reps" header below
+        // already labels this, so the stepper's own caption would just repeat it.
+        RepsRangeStepper(
+          setId = exerciseSet.id,
+          reps = exerciseSet.reps,
+          repsRange = exerciseSet.repsRange,
+          onChange = onUpdateTargetReps,
+          valueStyle = typography,
+          valueWidth = 64.dp
+        )
+      } else {
+        Column(
+          Modifier.fillMaxWidth(),
+          verticalArrangement = Arrangement.Top,
+          horizontalAlignment = Alignment.CenterHorizontally
         ) {
-          Text(subtext, style = MaterialTheme.typography.h6)
+          Text(targetRepsTextContent, style = typography)
+          AnimatedVisibility(
+            visible = subtext.isNotBlank(),
+            enter = fadeIn() + expandVertically(),
+            exit = fadeOut() + shrinkVertically()
+          ) {
+            Text(subtext, style = MaterialTheme.typography.h6)
+          }
         }
       }
     }
@@ -127,6 +158,112 @@ fun RepsDisplay(
         .align(Alignment.CenterHorizontally)
     )
     Spacer(Modifier.weight(1f))
+  }
+}
+
+private enum class RepsRangeLock { NONE, LOW, HIGH }
+
+/**
+ * Reps target stepper for edit mode, extending [TargetStepper]'s open/AMRAP handling with an
+ * optional rep range ("10-12"). A lock pins one end of the range - the opposite button then
+ * grows or shrinks the gap to it instead of moving [reps] itself. At most one side locks at a
+ * time; toggling a lock on, off, or to the other side always collapses back to an exact target
+ * (repsRange reset to 0) rather than trying to walk the other end back in - shrinking a range
+ * means unlocking and rebuilding it.
+ */
+@Composable
+private fun RepsRangeStepper(
+  setId: String,
+  reps: Int,
+  repsRange: Int,
+  onChange: (reps: Int, repsRange: Int) -> Unit,
+  valueStyle: TextStyle,
+  valueWidth: Dp
+) {
+  val isSet = reps >= 0
+  // Defaults to the low-end lock when restoring a persisted range with no remembered choice yet
+  // - the natural reading of a stored "10-12" is "10, locked, growing up toward 12".
+  var lock by rememberSaveable(setId) {
+    mutableStateOf(if (repsRange > 0) RepsRangeLock.LOW else RepsRangeLock.NONE)
+  }
+  val displayValue = when {
+    !isSet -> "—"
+    repsRange > 0 -> "$reps-${reps + repsRange}"
+    else -> "$reps"
+  }
+
+  fun toggleLock(side: RepsRangeLock) {
+    lock = if (lock == side) RepsRangeLock.NONE else side
+    onChange(reps, 0)
+  }
+
+  Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      IconButton(
+        onClick = {
+          when (lock) {
+            RepsRangeLock.NONE -> onChange((reps - 1).coerceAtLeast(1), 0)
+            RepsRangeLock.HIGH -> onChange(reps - 1, repsRange + 1)
+            RepsRangeLock.LOW -> Unit
+          }
+        },
+        enabled = isSet && lock != RepsRangeLock.LOW && reps > 1
+      ) {
+        Icon(Icons.Default.Remove, contentDescription = "decrease reps")
+      }
+      // Fixed width so a range's extra digits don't shift the text off-centre between the
+      // two fixed-size IconButtons.
+      Text(
+        displayValue,
+        style = valueStyle,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.width(valueWidth)
+      )
+      IconButton(
+        onClick = {
+          when (lock) {
+            RepsRangeLock.NONE -> onChange((reps.takeIf { isSet } ?: 0) + 1, 0)
+            RepsRangeLock.LOW -> onChange(reps, repsRange + 1)
+            RepsRangeLock.HIGH -> Unit
+          }
+        },
+        enabled = lock != RepsRangeLock.HIGH
+      ) {
+        Icon(Icons.Default.Add, contentDescription = "increase reps")
+      }
+    }
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      LockToggle(
+        locked = lock == RepsRangeLock.LOW,
+        enabled = isSet,
+        contentDescription = "lock the low end of the reps range",
+        onClick = { toggleLock(RepsRangeLock.LOW) }
+      )
+      Spacer(Modifier.width(valueWidth))
+      LockToggle(
+        locked = lock == RepsRangeLock.HIGH,
+        enabled = isSet,
+        contentDescription = "lock the high end of the reps range",
+        onClick = { toggleLock(RepsRangeLock.HIGH) }
+      )
+    }
+  }
+}
+
+@Composable
+private fun LockToggle(
+  locked: Boolean,
+  enabled: Boolean,
+  contentDescription: String,
+  onClick: () -> Unit
+) {
+  IconButton(onClick = onClick, enabled = enabled, modifier = Modifier.size(28.dp)) {
+    Icon(
+      if (locked) Icons.Default.Lock else Icons.Default.LockOpen,
+      contentDescription = contentDescription,
+      modifier = Modifier.size(16.dp),
+      tint = if (locked) MaterialTheme.colors.primary else MaterialTheme.colors.onSurface.copy(alpha = 0.4f)
+    )
   }
 }
 
@@ -147,6 +284,33 @@ fun RepsDisplayPreview(@PreviewParameter(ExampleExerciseProvider::class) exercis
         allSets = emptyFlow()
       ),
       Repetitions(95)
+    )
+  }
+}
+
+@Composable
+@Preview(apiLevel = 36)
+fun RepsDisplayEditingPreview(@PreviewParameter(ExampleExerciseProvider::class) exerciseSet: ExerciseSet) {
+  var reps by remember { mutableStateOf(exerciseSet.reps) }
+  var repsRange by remember { mutableStateOf(exerciseSet.repsRange) }
+  val records = remember { mutableStateListOf<Record>() }
+  val currentRecord =
+    remember { mutableStateOf(Record(25.0, exerciseSet.reps(0), exerciseSet, Instant.now())) }
+  Card(Modifier.size(170.dp)) {
+    RepsDisplay(
+      setWithRecord = ExerciseSetWithRecord(
+        exerciseSet.copy(reps = reps, repsRange = repsRange),
+        currentRecord,
+        numCompleted = 1,
+        setRecords = records,
+        allSets = emptyFlow()
+      ),
+      Repetitions(95),
+      editing = true,
+      onUpdateTargetReps = { newReps, newRepsRange ->
+        reps = newReps
+        repsRange = newRepsRange
+      }
     )
   }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/TargetStepper.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/TargetStepper.kt
@@ -1,0 +1,64 @@
+package com.litus_animae.refitted.ui.compose.exercise
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Compact +/- stepper for editing a custom exercise's target (sets, reps, ...). A negative
+ * [value] is the open/AMRAP state - not yet targeted; the first tap up starts it at 1 rather
+ * than 0, since a 0-target isn't a meaningful prescription.
+ *
+ * [valueStyle]/[valueWidth] let a caller match the stepper's digits to a neighbouring number
+ * (e.g. the reps NumberPicker) instead of always using the compact default; [showLabel] hides
+ * the stepper's own caption when the surrounding layout already labels it.
+ */
+@Composable
+fun TargetStepper(
+  label: String,
+  value: Int,
+  onChange: (Int) -> Unit,
+  valueStyle: TextStyle = MaterialTheme.typography.body2,
+  valueWidth: Dp = 28.dp,
+  showLabel: Boolean = true
+) {
+  val displayValue = value.takeIf { it >= 0 }
+  Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      IconButton(
+        onClick = { onChange(((displayValue ?: 1) - 1).coerceAtLeast(1)) },
+        enabled = displayValue != null && displayValue > 1
+      ) {
+        Icon(Icons.Default.Remove, contentDescription = "decrease $label")
+      }
+      // Fixed width so the digit count (1 vs 2 digits) doesn't shift the text off-centre
+      // between the two fixed-size IconButtons.
+      Text(
+        displayValue?.toString() ?: "—",
+        style = valueStyle,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.width(valueWidth)
+      )
+      IconButton(onClick = { onChange((displayValue ?: 0) + 1) }) {
+        Icon(Icons.Default.Add, contentDescription = "increase $label")
+      }
+    }
+    if (showLabel) {
+      Text(label, style = MaterialTheme.typography.overline)
+    }
+  }
+}

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
@@ -1,0 +1,164 @@
+package com.litus_animae.refitted.ui.compose.exercise.add
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+private val muscleGroups = listOf(
+  "Chest", "Shoulders", "Biceps", "Triceps", "Forearms", "Core",
+  "Traps", "Lats", "Lower back", "Glutes", "Hamstrings", "Quads", "Calves"
+)
+
+// There's no cross-plan exercise catalog yet (exercises today belong to one workout's admin
+// content), so this list is a placeholder shown for any muscle group - selecting an entry still
+// adds a real exercise to the day, it just isn't tailored to what was tapped.
+private val stubExercises = listOf(
+  "Barbell Bench Press", "Incline Dumbbell Press", "Weighted Dip", "Cable Fly",
+  "Machine Chest Press", "Push-Up", "Decline Barbell Press", "Dumbbell Pullover"
+)
+
+/**
+ * Add-exercise flow (design group D): pick a target muscle, then an exercise from the list.
+ * [onExercisePicked] is called with the chosen exercise's display name.
+ */
+@Composable
+fun AddExercisePicker(
+  onExercisePicked: (String) -> Unit,
+  onClose: () -> Unit,
+  modifier: Modifier = Modifier
+) {
+  var selectedMuscle by rememberSaveable { mutableStateOf<String?>(null) }
+  Scaffold(
+    modifier = modifier,
+    topBar = {
+      TopAppBar(
+        // TODO localize
+        title = { Text(selectedMuscle ?: "Add exercise") },
+        backgroundColor = MaterialTheme.colors.primary,
+        navigationIcon = {
+          IconButton(onClick = { if (selectedMuscle != null) selectedMuscle = null else onClose() }) {
+            if (selectedMuscle != null) Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
+            // TODO localize
+            else Icon(Icons.Default.Close, "close")
+          }
+        }
+      )
+    }
+  ) { contentPadding ->
+    val muscle = selectedMuscle
+    if (muscle == null) {
+      MuscleGroupPicker(Modifier.padding(contentPadding), onContinue = { selectedMuscle = it })
+    } else {
+      StubExerciseList(Modifier.padding(contentPadding), onPick = onExercisePicked)
+    }
+  }
+}
+
+@Composable
+private fun MuscleGroupPicker(modifier: Modifier = Modifier, onContinue: (String) -> Unit) {
+  var selected by rememberSaveable { mutableStateOf(muscleGroups.first()) }
+  Column(
+    modifier
+      .fillMaxSize()
+      .padding(16.dp)
+  ) {
+    CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+      // TODO localize
+      Text("Tap the muscle group to target", style = MaterialTheme.typography.body2)
+    }
+    Spacer(Modifier.height(16.dp))
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+      muscleGroups.forEach { muscle ->
+        MuscleChip(muscle, selected = muscle == selected, onClick = { selected = muscle })
+      }
+    }
+    Spacer(Modifier.weight(1f))
+    Button(
+      onClick = { onContinue(selected) },
+      modifier = Modifier.fillMaxWidth()
+    ) {
+      // TODO localize
+      Text("Continue — $selected")
+    }
+  }
+}
+
+@Composable
+private fun MuscleChip(label: String, selected: Boolean, onClick: () -> Unit) {
+  Surface(
+    shape = RoundedCornerShape(16.dp),
+    color = if (selected) MaterialTheme.colors.primary else MaterialTheme.colors.surface,
+    contentColor = if (selected) MaterialTheme.colors.onPrimary else MaterialTheme.colors.onSurface,
+    border = if (selected) null else BorderStroke(
+      1.dp,
+      MaterialTheme.colors.onSurface.copy(alpha = 0.23f)
+    ),
+    modifier = Modifier.clickable(onClick = onClick)
+  ) {
+    Text(label, Modifier.padding(horizontal = 14.dp, vertical = 6.dp), style = MaterialTheme.typography.body2)
+  }
+}
+
+@Composable
+private fun StubExerciseList(modifier: Modifier = Modifier, onPick: (String) -> Unit) {
+  LazyColumn(modifier.fillMaxSize()) {
+    items(stubExercises) { exercise ->
+      Row(
+        Modifier
+          .fillMaxWidth()
+          .clickable { onPick(exercise) }
+          .padding(start = 10.dp, end = 6.dp, top = 15.dp, bottom = 15.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+      ) {
+        Text(exercise, style = MaterialTheme.typography.button)
+        Icon(Icons.Default.Add, "add $exercise", tint = MaterialTheme.colors.primary)
+      }
+      Divider()
+    }
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewAddExercisePicker() {
+  MaterialTheme {
+    AddExercisePicker(onExercisePicked = {}, onClose = {})
+  }
+}

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
@@ -141,8 +141,9 @@ fun ExercisePickerList(
   muscle: String,
   localExercisesByWorkout: Map<String, List<Exercise>>,
   accessibleWorkoutNames: List<String>,
-  remoteExercisesByWorkout: Map<String, List<Exercise>>,
-  loadingWorkouts: Map<String, Boolean>,
+  /** Keyed by (workout, muscle) - a workout's cached rows are only ever for this screen's own muscle. */
+  remoteExercisesByWorkout: Map<Pair<String, String>, List<Exercise>>,
+  loadingWorkouts: Map<Pair<String, String>, Boolean>,
   onLoadWorkout: (String) -> Unit,
   onPick: (Exercise) -> Unit,
   onBack: () -> Unit,
@@ -178,9 +179,9 @@ fun ExercisePickerList(
             style = MaterialTheme.typography.overline
           )
         }
-        val exercises = localExercisesByWorkout[workout] ?: remoteExercisesByWorkout[workout]
+        val exercises = localExercisesByWorkout[workout] ?: remoteExercisesByWorkout[workout to muscle]
         when {
-          exercises == null && loadingWorkouts[workout] == true -> item(key = "loading:$workout") {
+          exercises == null && loadingWorkouts[workout to muscle] == true -> item(key = "loading:$workout") {
             Row(
               Modifier
                 .fillMaxWidth()

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
@@ -1,19 +1,34 @@
 package com.litus_animae.refitted.ui.compose.exercise.add
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Button
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
@@ -37,6 +52,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
@@ -54,67 +70,112 @@ private val stubExercises = listOf(
 )
 
 /**
- * Add-exercise flow (design group D): pick a target muscle, then an exercise from the list.
- * [onExercisePicked] is called with the chosen exercise's display name.
+ * Target-muscle screen (design 1i): body diagram + chips, both driving the same selection.
+ * A separate nav destination from [ExercisePickerList] so system/gesture back steps one
+ * screen at a time instead of leaving the whole add-exercise flow.
  */
 @Composable
-fun AddExercisePicker(
-  onExercisePicked: (String) -> Unit,
+fun MuscleGroupPickerScreen(
+  onContinue: (String) -> Unit,
   onClose: () -> Unit,
   modifier: Modifier = Modifier
 ) {
-  var selectedMuscle by rememberSaveable { mutableStateOf<String?>(null) }
+  var selected by rememberSaveable { mutableStateOf(muscleGroups.first()) }
   Scaffold(
+    contentWindowInsets = WindowInsets.navigationBars.union(WindowInsets.displayCutout),
     modifier = modifier,
     topBar = {
       TopAppBar(
         // TODO localize
-        title = { Text(selectedMuscle ?: "Add exercise") },
+        title = { Text("Add exercise") },
+        windowInsets = AppBarDefaults.topAppBarWindowInsets.union(
+          WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)
+        ),
         backgroundColor = MaterialTheme.colors.primary,
         navigationIcon = {
-          IconButton(onClick = { if (selectedMuscle != null) selectedMuscle = null else onClose() }) {
-            if (selectedMuscle != null) Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
-            // TODO localize
-            else Icon(Icons.Default.Close, "close")
-          }
+          // TODO localize
+          IconButton(onClick = onClose) { Icon(Icons.Default.Close, "close") }
         }
       )
     }
   ) { contentPadding ->
-    val muscle = selectedMuscle
-    if (muscle == null) {
-      MuscleGroupPicker(Modifier.padding(contentPadding), onContinue = { selectedMuscle = it })
-    } else {
-      StubExerciseList(Modifier.padding(contentPadding), onPick = onExercisePicked)
+    Column(modifier.padding(contentPadding).fillMaxSize()) {
+      Column(
+        Modifier
+          .weight(1f)
+          .verticalScroll(rememberScrollState())
+          .padding(16.dp)
+      ) {
+        CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+          // TODO localize
+          Text("Tap the muscle group to target", style = MaterialTheme.typography.body2)
+        }
+        Spacer(Modifier.height(14.dp))
+        BodyDiagram(selected = selected, onSelect = { selected = it }, modifier = Modifier.fillMaxWidth())
+        Spacer(Modifier.height(14.dp))
+        FlowRow(
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+          verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+          muscleGroups.forEach { muscle ->
+            MuscleChip(muscle, selected = muscle == selected, onClick = { selected = muscle })
+          }
+        }
+      }
+      Button(
+        onClick = { onContinue(selected) },
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(16.dp)
+      ) {
+        // TODO localize
+        Text("Continue — $selected")
+      }
     }
   }
 }
 
+/**
+ * Exercise-list screen (design 1j). [onPick] is called with the chosen exercise's display name.
+ */
 @Composable
-private fun MuscleGroupPicker(modifier: Modifier = Modifier, onContinue: (String) -> Unit) {
-  var selected by rememberSaveable { mutableStateOf(muscleGroups.first()) }
-  Column(
-    modifier
-      .fillMaxSize()
-      .padding(16.dp)
-  ) {
-    CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
-      // TODO localize
-      Text("Tap the muscle group to target", style = MaterialTheme.typography.body2)
+fun ExercisePickerList(
+  muscle: String,
+  onPick: (String) -> Unit,
+  onBack: () -> Unit,
+  modifier: Modifier = Modifier
+) {
+  Scaffold(
+    contentWindowInsets = WindowInsets.navigationBars.union(WindowInsets.displayCutout),
+    modifier = modifier,
+    topBar = {
+      TopAppBar(
+        title = { Text(muscle) },
+        windowInsets = AppBarDefaults.topAppBarWindowInsets.union(
+          WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)
+        ),
+        backgroundColor = MaterialTheme.colors.primary,
+        navigationIcon = {
+          IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, "back") }
+        }
+      )
     }
-    Spacer(Modifier.height(16.dp))
-    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-      muscleGroups.forEach { muscle ->
-        MuscleChip(muscle, selected = muscle == selected, onClick = { selected = muscle })
+  ) { contentPadding ->
+    LazyColumn(Modifier.padding(contentPadding).fillMaxSize()) {
+      items(stubExercises) { exercise ->
+        Row(
+          Modifier
+            .fillMaxWidth()
+            .clickable { onPick(exercise) }
+            .padding(start = 10.dp, end = 6.dp, top = 15.dp, bottom = 15.dp),
+          horizontalArrangement = Arrangement.SpaceBetween,
+          verticalAlignment = Alignment.CenterVertically
+        ) {
+          Text(exercise, style = MaterialTheme.typography.button)
+          Icon(Icons.Default.Add, "add $exercise", tint = MaterialTheme.colors.primary)
+        }
+        Divider()
       }
-    }
-    Spacer(Modifier.weight(1f))
-    Button(
-      onClick = { onContinue(selected) },
-      modifier = Modifier.fillMaxWidth()
-    ) {
-      // TODO localize
-      Text("Continue — $selected")
     }
   }
 }
@@ -135,30 +196,114 @@ private fun MuscleChip(label: String, selected: Boolean, onClick: () -> Unit) {
   }
 }
 
+// Front/back body diagram (design 1i) - a stand-in anatomy figure, not tied to real muscle
+// imagery. Each tappable region shares selection state with the chips below it; positions are
+// lifted straight from the design mockup's 150x330 canvas (px treated as dp).
+private data class BodyPart(
+  val muscle: String?,
+  val x: Int,
+  val y: Int,
+  val w: Int,
+  val h: Int,
+  val shape: Shape
+)
+
+private val roundedPart = RoundedCornerShape(40)
+
+private val frontBodyParts = listOf(
+  BodyPart(null, 57, 0, 36, 36, CircleShape),
+  BodyPart(null, 68, 35, 14, 10, RoundedCornerShape(2.dp)),
+  BodyPart("Shoulders", 29, 45, 26, 16, roundedPart),
+  BodyPart("Shoulders", 95, 45, 26, 16, roundedPart),
+  BodyPart("Chest", 45, 47, 60, 36, RoundedCornerShape(10.dp)),
+  BodyPart("Biceps", 26, 64, 15, 46, roundedPart),
+  BodyPart("Biceps", 109, 64, 15, 46, roundedPart),
+  BodyPart("Core", 49, 87, 52, 54, RoundedCornerShape(10.dp)),
+  BodyPart("Forearms", 24, 114, 12, 44, roundedPart),
+  BodyPart("Forearms", 114, 114, 12, 44, roundedPart),
+  BodyPart(null, 47, 145, 56, 22, roundedPart),
+  BodyPart("Quads", 47, 171, 24, 78, RoundedCornerShape(12.dp)),
+  BodyPart("Quads", 79, 171, 24, 78, RoundedCornerShape(12.dp)),
+  BodyPart("Calves", 50, 255, 18, 62, roundedPart),
+  BodyPart("Calves", 82, 255, 18, 62, roundedPart)
+)
+
+private val backBodyParts = listOf(
+  BodyPart(null, 57, 0, 36, 36, CircleShape),
+  BodyPart(null, 68, 35, 14, 10, RoundedCornerShape(2.dp)),
+  BodyPart("Traps", 51, 42, 48, 18, roundedPart),
+  BodyPart("Shoulders", 29, 48, 20, 14, roundedPart),
+  BodyPart("Shoulders", 101, 48, 20, 14, roundedPart),
+  BodyPart("Lats", 45, 63, 60, 52, RoundedCornerShape(10.dp)),
+  BodyPart("Triceps", 26, 64, 15, 46, roundedPart),
+  BodyPart("Triceps", 109, 64, 15, 46, roundedPart),
+  BodyPart("Lower back", 55, 118, 40, 24, roundedPart),
+  BodyPart("Glutes", 47, 145, 56, 26, RoundedCornerShape(12.dp)),
+  BodyPart("Hamstrings", 47, 175, 24, 72, RoundedCornerShape(12.dp)),
+  BodyPart("Hamstrings", 79, 175, 24, 72, RoundedCornerShape(12.dp)),
+  BodyPart("Calves", 50, 252, 18, 62, roundedPart),
+  BodyPart("Calves", 82, 252, 18, 62, roundedPart)
+)
+
 @Composable
-private fun StubExerciseList(modifier: Modifier = Modifier, onPick: (String) -> Unit) {
-  LazyColumn(modifier.fillMaxSize()) {
-    items(stubExercises) { exercise ->
-      Row(
+private fun BodyDiagram(selected: String, onSelect: (String) -> Unit, modifier: Modifier = Modifier) {
+  Row(modifier, horizontalArrangement = Arrangement.SpaceEvenly) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+      BodyFigure(frontBodyParts, selected, onSelect)
+      Spacer(Modifier.height(8.dp))
+      // TODO localize
+      Text("FRONT", style = MaterialTheme.typography.overline)
+    }
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+      BodyFigure(backBodyParts, selected, onSelect)
+      Spacer(Modifier.height(8.dp))
+      // TODO localize
+      Text("BACK", style = MaterialTheme.typography.overline)
+    }
+  }
+}
+
+@Composable
+private fun BodyFigure(parts: List<BodyPart>, selected: String, onSelect: (String) -> Unit) {
+  Box(Modifier.size(150.dp, 330.dp)) {
+    parts.forEach { part ->
+      val isSelected = part.muscle == selected
+      Box(
         Modifier
-          .fillMaxWidth()
-          .clickable { onPick(exercise) }
-          .padding(start = 10.dp, end = 6.dp, top = 15.dp, bottom = 15.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-      ) {
-        Text(exercise, style = MaterialTheme.typography.button)
-        Icon(Icons.Default.Add, "add $exercise", tint = MaterialTheme.colors.primary)
-      }
-      Divider()
+          .offset(x = part.x.dp, y = part.y.dp)
+          .size(part.w.dp, part.h.dp)
+          .let { base ->
+            if (part.muscle != null) {
+              base.clickable(onClickLabel = part.muscle, onClick = { onSelect(part.muscle) })
+            } else base
+          }
+          .background(
+            if (isSelected) MaterialTheme.colors.primary
+            else MaterialTheme.colors.onSurface.copy(alpha = 0.14f),
+            part.shape
+          )
+          .let { base ->
+            if (isSelected) {
+              base.border(2.dp, MaterialTheme.colors.primary.copy(alpha = 0.4f), part.shape)
+            } else base
+          }
+      )
     }
   }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun PreviewAddExercisePicker() {
+private fun PreviewMuscleGroupPicker() {
   MaterialTheme {
-    AddExercisePicker(onExercisePicked = {}, onClose = {})
+    MuscleGroupPickerScreen(onContinue = {}, onClose = {})
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewExercisePickerList() {
+  MaterialTheme {
+    ExercisePickerList(muscle = "Chest", onPick = {}, onBack = {})
   }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
@@ -45,6 +45,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -170,18 +171,47 @@ fun ExercisePickerList(
   ) { contentPadding ->
     LazyColumn(Modifier.padding(contentPadding).fillMaxSize()) {
       workouts.forEach { workout ->
+        // Custom plans have no remote catalog of their own (see the KDoc above) - only ever
+        // appear here from localExercisesByWorkout, so they get no refresh affordance.
+        val isRemoteSource = workout in accessibleWorkoutNames
+        val loading = loadingWorkouts[workout to muscle] == true
+        val hasFetched = remoteExercisesByWorkout.containsKey(workout to muscle)
+        // Merge rather than local ?: remote - a workout opened locally for one day is only
+        // ever partially synced, so its cached rows and a fresh remote fetch both contribute.
+        val exercises = (localExercisesByWorkout[workout].orEmpty() + remoteExercisesByWorkout[workout to muscle].orEmpty())
+          .distinctBy { it.id }
+          .sortedBy { it.name ?: it.id }
+
         item(key = "header:$workout") {
-          Text(
-            workout,
+          Row(
             Modifier
               .fillMaxWidth()
-              .padding(start = 10.dp, top = 14.dp, bottom = 4.dp),
-            style = MaterialTheme.typography.overline
-          )
+              .padding(start = 10.dp, end = 6.dp, top = 14.dp, bottom = 4.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+          ) {
+            Text(workout, style = MaterialTheme.typography.overline)
+            if (isRemoteSource) {
+              if (loading) {
+                CircularProgressIndicator(Modifier.size(16.dp), strokeWidth = 2.dp)
+              } else {
+                IconButton(
+                  onClick = { onLoadWorkout(workout) },
+                  modifier = Modifier.size(28.dp)
+                ) {
+                  // TODO localize
+                  Icon(
+                    Icons.Default.Refresh,
+                    contentDescription = "refresh $workout",
+                    modifier = Modifier.size(18.dp)
+                  )
+                }
+              }
+            }
+          }
         }
-        val exercises = localExercisesByWorkout[workout] ?: remoteExercisesByWorkout[workout to muscle]
         when {
-          exercises == null && loadingWorkouts[workout to muscle] == true -> item(key = "loading:$workout") {
+          exercises.isEmpty() && loading -> item(key = "loading:$workout") {
             Row(
               Modifier
                 .fillMaxWidth()
@@ -192,7 +222,7 @@ fun ExercisePickerList(
             }
           }
 
-          exercises == null -> item(key = "load:$workout") {
+          exercises.isEmpty() && !hasFetched -> item(key = "load:$workout") {
             Row(
               Modifier
                 .fillMaxWidth()
@@ -202,7 +232,7 @@ fun ExercisePickerList(
               verticalAlignment = Alignment.CenterVertically
             ) {
               // TODO localize
-              Text("Load exercises", style = MaterialTheme.typography.button)
+              Text("Refresh to load", style = MaterialTheme.typography.button)
             }
           }
 
@@ -374,7 +404,11 @@ private fun PreviewExercisePickerList() {
         )
       ),
       accessibleWorkoutNames = listOf("Push Pull Legs", "Full Body"),
-      remoteExercisesByWorkout = emptyMap(),
+      // "Push Pull Legs" shows the merge of its cached local row plus a remote fetch already in
+      // hand; "Full Body" has never been fetched, so it falls through to "Refresh to load".
+      remoteExercisesByWorkout = mapOf(
+        ("Push Pull Legs" to "Chest") to listOf(Exercise("Push Pull Legs", "Chest_Incline Dumbbell Press"))
+      ),
       loadingWorkouts = emptyMap(),
       onLoadWorkout = {},
       onPick = {},

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
@@ -57,11 +57,9 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.litus_animae.refitted.data.models.Exercise
+import com.litus_animae.refitted.data.models.MuscleGroup
 
-private val muscleGroups = listOf(
-  "Chest", "Shoulders", "Biceps", "Triceps", "Forearms", "Core",
-  "Traps", "Lats", "Lower back", "Glutes", "Hamstrings", "Quads", "Calves"
-)
+private val muscleGroups = MuscleGroup.displayNames()
 
 /**
  * Target-muscle screen (design 1i): body diagram + chips, both driving the same selection.
@@ -279,8 +277,9 @@ private val frontBodyParts = listOf(
   BodyPart("Biceps", 26, 64, 15, 46, roundedPart),
   BodyPart("Biceps", 109, 64, 15, 46, roundedPart),
   BodyPart("Core", 49, 87, 52, 54, RoundedCornerShape(10.dp)),
-  BodyPart("Forearms", 24, 114, 12, 44, roundedPart),
-  BodyPart("Forearms", 114, 114, 12, 44, roundedPart),
+  // Forearms dropped: no admin program has ever stored an exercise under that prefix.
+  BodyPart(null, 24, 114, 12, 44, roundedPart),
+  BodyPart(null, 114, 114, 12, 44, roundedPart),
   BodyPart(null, 47, 145, 56, 22, roundedPart),
   BodyPart("Quads", 47, 171, 24, 78, RoundedCornerShape(12.dp)),
   BodyPart("Quads", 79, 171, 24, 78, RoundedCornerShape(12.dp)),
@@ -297,7 +296,8 @@ private val backBodyParts = listOf(
   BodyPart("Lats", 45, 63, 60, 52, RoundedCornerShape(10.dp)),
   BodyPart("Triceps", 26, 64, 15, 46, roundedPart),
   BodyPart("Triceps", 109, 64, 15, 46, roundedPart),
-  BodyPart("Lower back", 55, 118, 40, 24, roundedPart),
+  // Lower back dropped: no admin program has ever stored an exercise under that prefix.
+  BodyPart(null, 55, 118, 40, 24, roundedPart),
   BodyPart("Glutes", 47, 145, 56, 26, RoundedCornerShape(12.dp)),
   BodyPart("Hamstrings", 47, 175, 24, 72, RoundedCornerShape(12.dp)),
   BodyPart("Hamstrings", 79, 175, 24, 72, RoundedCornerShape(12.dp)),

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Button
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
@@ -55,18 +56,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.litus_animae.refitted.data.models.Exercise
 
 private val muscleGroups = listOf(
   "Chest", "Shoulders", "Biceps", "Triceps", "Forearms", "Core",
   "Traps", "Lats", "Lower back", "Glutes", "Hamstrings", "Quads", "Calves"
-)
-
-// There's no cross-plan exercise catalog yet (exercises today belong to one workout's admin
-// content), so this list is a placeholder shown for any muscle group - selecting an entry still
-// adds a real exercise to the day, it just isn't tailored to what was tapped.
-private val stubExercises = listOf(
-  "Barbell Bench Press", "Incline Dumbbell Press", "Weighted Dip", "Cable Fly",
-  "Machine Chest Press", "Push-Up", "Decline Barbell Press", "Dumbbell Pullover"
 )
 
 /**
@@ -136,15 +130,28 @@ fun MuscleGroupPickerScreen(
 }
 
 /**
- * Exercise-list screen (design 1j). [onPick] is called with the chosen exercise's display name.
+ * Exercise-list screen (design 1j) - workouts the user can pull exercises from, as sections.
+ * Locally-synced matches ([localExercisesByWorkout]) render immediately; other accessible
+ * workouts render a "Load exercises" row that triggers an on-demand remote query
+ * ([onLoadWorkout] - see ExerciseViewModel.loadRemoteExercises). Picking an exercise reuses its
+ * exact id so its record history carries over ([onPick]).
  */
 @Composable
 fun ExercisePickerList(
   muscle: String,
-  onPick: (String) -> Unit,
+  currentWorkoutId: String,
+  localExercisesByWorkout: Map<String, List<Exercise>>,
+  accessibleWorkoutNames: List<String>,
+  remoteExercisesByWorkout: Map<String, List<Exercise>>,
+  loadingWorkouts: Map<String, Boolean>,
+  onLoadWorkout: (String) -> Unit,
+  onPick: (Exercise) -> Unit,
   onBack: () -> Unit,
   modifier: Modifier = Modifier
 ) {
+  val workouts = (accessibleWorkoutNames + currentWorkoutId + localExercisesByWorkout.keys)
+    .distinct()
+    .sorted()
   Scaffold(
     contentWindowInsets = WindowInsets.navigationBars.union(WindowInsets.displayCutout),
     modifier = modifier,
@@ -162,19 +169,71 @@ fun ExercisePickerList(
     }
   ) { contentPadding ->
     LazyColumn(Modifier.padding(contentPadding).fillMaxSize()) {
-      items(stubExercises) { exercise ->
-        Row(
-          Modifier
-            .fillMaxWidth()
-            .clickable { onPick(exercise) }
-            .padding(start = 10.dp, end = 6.dp, top = 15.dp, bottom = 15.dp),
-          horizontalArrangement = Arrangement.SpaceBetween,
-          verticalAlignment = Alignment.CenterVertically
-        ) {
-          Text(exercise, style = MaterialTheme.typography.button)
-          Icon(Icons.Default.Add, "add $exercise", tint = MaterialTheme.colors.primary)
+      workouts.forEach { workout ->
+        item(key = "header:$workout") {
+          Text(
+            workout,
+            Modifier
+              .fillMaxWidth()
+              .padding(start = 10.dp, top = 14.dp, bottom = 4.dp),
+            style = MaterialTheme.typography.overline
+          )
         }
-        Divider()
+        val exercises = localExercisesByWorkout[workout] ?: remoteExercisesByWorkout[workout]
+        when {
+          exercises == null && loadingWorkouts[workout] == true -> item(key = "loading:$workout") {
+            Row(
+              Modifier
+                .fillMaxWidth()
+                .padding(vertical = 12.dp),
+              horizontalArrangement = Arrangement.Center
+            ) {
+              CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+            }
+          }
+
+          exercises == null -> item(key = "load:$workout") {
+            Row(
+              Modifier
+                .fillMaxWidth()
+                .clickable { onLoadWorkout(workout) }
+                .padding(start = 10.dp, end = 6.dp, top = 15.dp, bottom = 15.dp),
+              horizontalArrangement = Arrangement.SpaceBetween,
+              verticalAlignment = Alignment.CenterVertically
+            ) {
+              // TODO localize
+              Text("Load exercises", style = MaterialTheme.typography.button)
+            }
+          }
+
+          exercises.isEmpty() -> item(key = "empty:$workout") {
+            CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.disabled) {
+              // TODO localize
+              Text(
+                "No $muscle exercises",
+                Modifier
+                  .fillMaxWidth()
+                  .padding(start = 10.dp, bottom = 10.dp),
+                style = MaterialTheme.typography.body2
+              )
+            }
+          }
+
+          else -> items(exercises, key = { "exercise:${it.workout}:${it.id}" }) { exercise ->
+            Row(
+              Modifier
+                .fillMaxWidth()
+                .clickable { onPick(exercise) }
+                .padding(start = 10.dp, end = 6.dp, top = 15.dp, bottom = 15.dp),
+              horizontalArrangement = Arrangement.SpaceBetween,
+              verticalAlignment = Alignment.CenterVertically
+            ) {
+              Text(exercise.name ?: exercise.id, style = MaterialTheme.typography.button)
+              Icon(Icons.Default.Add, "add ${exercise.name}", tint = MaterialTheme.colors.primary)
+            }
+            Divider()
+          }
+        }
       }
     }
   }
@@ -304,6 +363,21 @@ private fun PreviewMuscleGroupPicker() {
 @Composable
 private fun PreviewExercisePickerList() {
   MaterialTheme {
-    ExercisePickerList(muscle = "Chest", onPick = {}, onBack = {})
+    ExercisePickerList(
+      muscle = "Chest",
+      currentWorkoutId = "My Plan",
+      localExercisesByWorkout = mapOf(
+        "Push Pull Legs" to listOf(
+          Exercise("Push Pull Legs", "Chest_Barbell Bench Press"),
+          Exercise("Push Pull Legs", "Chest_Push-Up")
+        )
+      ),
+      accessibleWorkoutNames = listOf("Push Pull Legs", "Full Body"),
+      remoteExercisesByWorkout = emptyMap(),
+      loadingWorkouts = emptyMap(),
+      onLoadWorkout = {},
+      onPick = {},
+      onBack = {}
+    )
   }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
@@ -132,14 +132,15 @@ fun MuscleGroupPickerScreen(
 /**
  * Exercise-list screen (design 1j) - workouts the user can pull exercises from, as sections.
  * Locally-synced matches ([localExercisesByWorkout]) render immediately; other accessible
- * workouts render a "Load exercises" row that triggers an on-demand remote query
- * ([onLoadWorkout] - see ExerciseViewModel.loadRemoteExercises). Picking an exercise reuses its
- * exact id so its record history carries over ([onPick]).
+ * (admin-authored) workouts render a "Load exercises" row that triggers an on-demand remote query
+ * ([onLoadWorkout] - see ExerciseViewModel.loadRemoteExercises). Custom plans - including the one
+ * being edited - only ever show local matches: they're built *from* admin content and have
+ * nothing of their own to load remotely. Picking an exercise reuses its exact id so its record
+ * history carries over ([onPick]).
  */
 @Composable
 fun ExercisePickerList(
   muscle: String,
-  currentWorkoutId: String,
   localExercisesByWorkout: Map<String, List<Exercise>>,
   accessibleWorkoutNames: List<String>,
   remoteExercisesByWorkout: Map<String, List<Exercise>>,
@@ -149,7 +150,7 @@ fun ExercisePickerList(
   onBack: () -> Unit,
   modifier: Modifier = Modifier
 ) {
-  val workouts = (accessibleWorkoutNames + currentWorkoutId + localExercisesByWorkout.keys)
+  val workouts = (accessibleWorkoutNames + localExercisesByWorkout.keys)
     .distinct()
     .sorted()
   Scaffold(
@@ -365,7 +366,6 @@ private fun PreviewExercisePickerList() {
   MaterialTheme {
     ExercisePickerList(
       muscle = "Chest",
-      currentWorkoutId = "My Plan",
       localExercisesByWorkout = mapOf(
         "Push Pull Legs" to listOf(
           Exercise("Push Pull Legs", "Chest_Barbell Bench Press"),

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
@@ -1,5 +1,6 @@
 package com.litus_animae.refitted.ui.compose.exercise.add
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -45,6 +46,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Composable
@@ -54,6 +56,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -153,6 +156,7 @@ fun ExercisePickerList(
   val workouts = (accessibleWorkoutNames + localExercisesByWorkout.keys)
     .distinct()
     .sorted()
+  var collapsedWorkouts by rememberSaveable { mutableStateOf(setOf<String>()) }
   Scaffold(
     contentWindowInsets = WindowInsets.navigationBars.union(WindowInsets.displayCutout),
     modifier = modifier,
@@ -182,6 +186,7 @@ fun ExercisePickerList(
           .distinctBy { it.id }
           .sortedBy { it.name ?: it.id }
 
+        val isCollapsed = workout in collapsedWorkouts
         item(key = "header:$workout") {
           Row(
             Modifier
@@ -190,7 +195,28 @@ fun ExercisePickerList(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
           ) {
-            Text(workout, style = MaterialTheme.typography.overline)
+            Row(
+              Modifier
+                .clickable(onClickLabel = if (isCollapsed) "expand $workout" else "collapse $workout") {
+                  collapsedWorkouts = if (isCollapsed) collapsedWorkouts - workout else collapsedWorkouts + workout
+                }
+                .padding(end = 4.dp),
+              verticalAlignment = Alignment.CenterVertically
+            ) {
+              val rotation by animateFloatAsState(
+                if (isCollapsed) -90f else 0f,
+                label = "collapseChevron"
+              )
+              Icon(
+                Icons.Default.ExpandMore,
+                contentDescription = null,
+                modifier = Modifier
+                  .size(28.dp)
+                  .padding(4.dp)
+                  .rotate(rotation)
+              )
+              Text(workout, style = MaterialTheme.typography.overline)
+            }
             if (isRemoteSource) {
               if (loading) {
                 CircularProgressIndicator(Modifier.size(16.dp), strokeWidth = 2.dp)
@@ -210,6 +236,7 @@ fun ExercisePickerList(
             }
           }
         }
+        if (isCollapsed) return@forEach
         when {
           exercises.isEmpty() && loading -> item(key = "loading:$workout") {
             Row(

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
@@ -12,13 +12,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
 import androidx.compose.material.Card
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Remove
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -39,6 +34,7 @@ import com.litus_animae.refitted.ui.R
 import com.litus_animae.refitted.ui.compose.exercise.CircularRestTimer
 import com.litus_animae.refitted.ui.compose.exercise.RepsDisplay
 import com.litus_animae.refitted.ui.compose.exercise.RepsDisplayMinHeight
+import com.litus_animae.refitted.ui.compose.exercise.TargetStepper
 import com.litus_animae.refitted.ui.compose.exercise.WeightDisplay
 import com.litus_animae.refitted.ui.compose.exercise.exampleExerciseSet
 import com.litus_animae.refitted.ui.compose.state.ExerciseSetWithRecord
@@ -72,7 +68,7 @@ fun ExerciseSetView(
   onRestOverrideChange: ((Int) -> Unit)? = null,
   nextRestSeconds: Int? = null,
   editing: Boolean = false,
-  onUpdateCustomTargets: ((sets: Int, reps: Int) -> Unit)? = null,
+  onUpdateCustomTargets: ((sets: Int, reps: Int, repsRange: Int) -> Unit)? = null,
 ) {
   Column(modifier) {
     ExerciseSetView(
@@ -110,16 +106,20 @@ fun ColumnScope.ExerciseSetView(
   onRestOverrideChange: ((Int) -> Unit)? = null,
   nextRestSeconds: Int? = null,
   editing: Boolean = false,
-  onUpdateCustomTargets: ((sets: Int, reps: Int) -> Unit)? = null,
+  onUpdateCustomTargets: ((sets: Int, reps: Int, repsRange: Int) -> Unit)? = null,
 ) {
   val (exerciseSet, currentRecord, numCompleted, _, _) = setWithRecord
   val record by currentRecord
-  val weight = rememberSaveable(saver = Weight.Saver, inputs = arrayOf(exerciseSet, record)) {
+  // Keyed on exerciseSet.id (day.step), not the exerciseSet object itself - editing this set's
+  // own target/rest (see onUpdateCustomTargets/onRestOverrideChange) replaces that object via
+  // .copy(), and keying on the whole value would reset an in-progress weight/reps pick every
+  // time. record is still a key: a genuinely new record (next set, different day) should reset.
+  val weight = rememberSaveable(saver = Weight.Saver, inputs = arrayOf(exerciseSet.id, record)) {
     Weight(record.weight)
   }
   val reps = rememberSaveable(
     saver = Repetitions.Saver,
-    inputs = arrayOf(exerciseSet, record)
+    inputs = arrayOf(exerciseSet.id, record)
   ) { Repetitions(if (exerciseSet.repsAreSequenced) setWithRecord.reps else record.reps) }
 
   // Local timer state used as fallback for the legacy ExerciseView path
@@ -151,7 +151,14 @@ fun ColumnScope.ExerciseSetView(
           WeightDisplay(onStartEditWeight, weight, saveWeight)
         }
         Card(Modifier.fillMaxWidth(), elevation = 2.dp) {
-          RepsDisplay(setWithRecord, reps)
+          RepsDisplay(
+            setWithRecord,
+            reps,
+            editing = editing,
+            onUpdateTargetReps = onUpdateCustomTargets?.let { update ->
+              { newReps: Int, newRepsRange: Int -> update(exerciseSet.sets, newReps, newRepsRange) }
+            }
+          )
         }
       },
       modifier = Modifier
@@ -185,11 +192,14 @@ fun ColumnScope.ExerciseSetView(
       Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
         if (editing && onUpdateCustomTargets != null) {
           Card(Modifier.fillMaxWidth(), elevation = 2.dp) {
-            TargetEditor(
-              sets = exerciseSet.sets,
-              reps = exerciseSet.reps,
-              onUpdate = onUpdateCustomTargets
-            )
+            Box(Modifier.padding(8.dp).fillMaxWidth(), contentAlignment = Alignment.Center) {
+              // TODO localize
+              TargetStepper(
+                label = "sets",
+                value = exerciseSet.sets,
+                onChange = { onUpdateCustomTargets(it, exerciseSet.reps, exerciseSet.repsRange) }
+              )
+            }
           }
         }
         Card(Modifier.fillMaxWidth(), elevation = 2.dp) {
@@ -197,7 +207,11 @@ fun ColumnScope.ExerciseSetView(
             restSeconds = effectiveRestSeconds,
             isRunning = isTimerRunning,
             startedAt = effectiveTimerStart,
-            modifier = Modifier.fillMaxWidth().height(RepsDisplayMinHeight),
+            // Grows the card instead of insetting the ring - CircularRestTimer's own square
+            // fit (ringDp = min(w,h) - 16.dp) already reserves that same 16dp as its
+            // horizontal margin, so matching top/bottom to it means giving the *box* 16dp
+            // more height, not padding down the ring's existing (correct) size.
+            modifier = Modifier.fillMaxWidth().height(RepsDisplayMinHeight + 16.dp),
             nextRestSeconds = nextRestSeconds,
             onAdjust = onRestOverrideChange,
             onFinish = {
@@ -288,52 +302,6 @@ fun ColumnScope.ExerciseSetView(
     numCompleted,
     isTimerRunning
   )
-}
-
-/** Edit-mode target editor for a custom exercise's set-count and reps prescription. */
-@Composable
-private fun TargetEditor(
-  sets: Int,
-  reps: Int,
-  onUpdate: (sets: Int, reps: Int) -> Unit,
-  modifier: Modifier = Modifier
-) {
-  Column(modifier.padding(8.dp), horizontalAlignment = Alignment.CenterHorizontally) {
-    // TODO localize
-    Text("Target", style = MaterialTheme.typography.overline)
-    Row(
-      Modifier.fillMaxWidth(),
-      horizontalArrangement = Arrangement.SpaceEvenly,
-      verticalAlignment = Alignment.CenterVertically
-    ) {
-      // TODO localize
-      TargetStepper(label = "sets", value = sets, onChange = { onUpdate(it, reps) })
-      // TODO localize
-      TargetStepper(label = "reps", value = reps, onChange = { onUpdate(sets, it) })
-    }
-  }
-}
-
-// A negative value is the open/AMRAP state - not yet targeted. The first tap up starts it at 1
-// rather than 0, since a 0-set or 0-rep target isn't a meaningful prescription.
-@Composable
-private fun TargetStepper(label: String, value: Int, onChange: (Int) -> Unit) {
-  val displayValue = value.takeIf { it >= 0 }
-  Column(horizontalAlignment = Alignment.CenterHorizontally) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-      IconButton(
-        onClick = { onChange(((displayValue ?: 1) - 1).coerceAtLeast(1)) },
-        enabled = displayValue != null && displayValue > 1
-      ) {
-        Icon(Icons.Default.Remove, contentDescription = "decrease $label")
-      }
-      Text(displayValue?.toString() ?: "—", style = MaterialTheme.typography.body2)
-      IconButton(onClick = { onChange((displayValue ?: 0) + 1) }) {
-        Icon(Icons.Default.Add, contentDescription = "increase $label")
-      }
-    }
-    Text(label, style = MaterialTheme.typography.overline)
-  }
 }
 
 @OptIn(FlowPreview::class)

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
@@ -12,7 +12,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
 import androidx.compose.material.Card
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -66,6 +72,8 @@ fun ExerciseSetView(
   restOverride: Int? = null,
   onRestOverrideChange: ((Int) -> Unit)? = null,
   nextRestSeconds: Int? = null,
+  editing: Boolean = false,
+  onUpdateCustomTargets: ((sets: Int, reps: Int) -> Unit)? = null,
 ) {
   Column(modifier) {
     ExerciseSetView(
@@ -82,6 +90,8 @@ fun ExerciseSetView(
       restOverride = restOverride,
       onRestOverrideChange = onRestOverrideChange,
       nextRestSeconds = nextRestSeconds,
+      editing = editing,
+      onUpdateCustomTargets = onUpdateCustomTargets,
     )
   }
 }
@@ -102,6 +112,8 @@ fun ColumnScope.ExerciseSetView(
   restOverride: Int? = null,
   onRestOverrideChange: ((Int) -> Unit)? = null,
   nextRestSeconds: Int? = null,
+  editing: Boolean = false,
+  onUpdateCustomTargets: ((sets: Int, reps: Int) -> Unit)? = null,
 ) {
   val (exerciseSet, currentRecord, numCompleted, _, _) = setWithRecord
   val record by currentRecord
@@ -173,24 +185,35 @@ fun ColumnScope.ExerciseSetView(
       // Wraps its content instead of filling the row's height (which the Weight/Reps
       // stack next to it doesn't fully occupy either) so it floats centered rather than
       // stretching to an arbitrary bottom edge that never quite matched theirs.
-      Card(Modifier.fillMaxWidth(), elevation = 2.dp) {
-        CircularRestTimer(
-          restSeconds = effectiveRestSeconds,
-          maxRestSeconds = maxRestSeconds,
-          isRunning = isTimerRunning,
-          startedAt = effectiveTimerStart,
-          modifier = Modifier.fillMaxWidth().height(RepsDisplayMinHeight),
-          nextRestSeconds = nextRestSeconds,
-          onAdjust = onRestOverrideChange,
-          onFinish = {
-            if (onTimerToggle != null) {
-              onTimerToggle()
-            } else {
-              timerRunning.value = false
-              timerDuration.intValue = exerciseSet.rest * 1000
-            }
+      Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (editing && onUpdateCustomTargets != null) {
+          Card(Modifier.fillMaxWidth(), elevation = 2.dp) {
+            TargetEditor(
+              sets = exerciseSet.sets,
+              reps = exerciseSet.reps,
+              onUpdate = onUpdateCustomTargets
+            )
           }
-        )
+        }
+        Card(Modifier.fillMaxWidth(), elevation = 2.dp) {
+          CircularRestTimer(
+            restSeconds = effectiveRestSeconds,
+            maxRestSeconds = maxRestSeconds,
+            isRunning = isTimerRunning,
+            startedAt = effectiveTimerStart,
+            modifier = Modifier.fillMaxWidth().height(RepsDisplayMinHeight),
+            nextRestSeconds = nextRestSeconds,
+            onAdjust = onRestOverrideChange,
+            onFinish = {
+              if (onTimerToggle != null) {
+                onTimerToggle()
+              } else {
+                timerRunning.value = false
+                timerDuration.intValue = exerciseSet.rest * 1000
+              }
+            }
+          )
+        }
       }
     }
   }
@@ -269,6 +292,52 @@ fun ColumnScope.ExerciseSetView(
     numCompleted,
     isTimerRunning
   )
+}
+
+/** Edit-mode target editor for a custom exercise's set-count and reps prescription. */
+@Composable
+private fun TargetEditor(
+  sets: Int,
+  reps: Int,
+  onUpdate: (sets: Int, reps: Int) -> Unit,
+  modifier: Modifier = Modifier
+) {
+  Column(modifier.padding(8.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+    // TODO localize
+    Text("Target", style = MaterialTheme.typography.overline)
+    Row(
+      Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.SpaceEvenly,
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      // TODO localize
+      TargetStepper(label = "sets", value = sets, onChange = { onUpdate(it, reps) })
+      // TODO localize
+      TargetStepper(label = "reps", value = reps, onChange = { onUpdate(sets, it) })
+    }
+  }
+}
+
+// A negative value is the open/AMRAP state - not yet targeted. The first tap up starts it at 1
+// rather than 0, since a 0-set or 0-rep target isn't a meaningful prescription.
+@Composable
+private fun TargetStepper(label: String, value: Int, onChange: (Int) -> Unit) {
+  val displayValue = value.takeIf { it >= 0 }
+  Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      IconButton(
+        onClick = { onChange(((displayValue ?: 1) - 1).coerceAtLeast(1)) },
+        enabled = displayValue != null && displayValue > 1
+      ) {
+        Icon(Icons.Default.Remove, contentDescription = "decrease $label")
+      }
+      Text(displayValue?.toString() ?: "—", style = MaterialTheme.typography.body2)
+      IconButton(onClick = { onChange((displayValue ?: 0) + 1) }) {
+        Icon(Icons.Default.Add, contentDescription = "increase $label")
+      }
+    }
+    Text(label, style = MaterialTheme.typography.overline)
+  }
 }
 
 @OptIn(FlowPreview::class)

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
@@ -68,7 +68,6 @@ fun ExerciseSetView(
   showNavigationButtons: Boolean = true,
   externalTimerState: ExerciseViewModel.TimerState? = null,
   onTimerToggle: (() -> Unit)? = null,
-  maxRestSeconds: Int = setWithRecord.exerciseSet.rest,
   restOverride: Int? = null,
   onRestOverrideChange: ((Int) -> Unit)? = null,
   nextRestSeconds: Int? = null,
@@ -86,7 +85,6 @@ fun ExerciseSetView(
       showNavigationButtons = showNavigationButtons,
       externalTimerState = externalTimerState,
       onTimerToggle = onTimerToggle,
-      maxRestSeconds = maxRestSeconds,
       restOverride = restOverride,
       onRestOverrideChange = onRestOverrideChange,
       nextRestSeconds = nextRestSeconds,
@@ -108,7 +106,6 @@ fun ColumnScope.ExerciseSetView(
   showNavigationButtons: Boolean = true,
   externalTimerState: ExerciseViewModel.TimerState? = null,
   onTimerToggle: (() -> Unit)? = null,
-  maxRestSeconds: Int = setWithRecord.exerciseSet.rest,
   restOverride: Int? = null,
   onRestOverrideChange: ((Int) -> Unit)? = null,
   nextRestSeconds: Int? = null,
@@ -198,7 +195,6 @@ fun ColumnScope.ExerciseSetView(
         Card(Modifier.fillMaxWidth(), elevation = 2.dp) {
           CircularRestTimer(
             restSeconds = effectiveRestSeconds,
-            maxRestSeconds = maxRestSeconds,
             isRunning = isTimerRunning,
             startedAt = effectiveTimerStart,
             modifier = Modifier.fillMaxWidth().height(RepsDisplayMinHeight),

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import com.litus_animae.refitted.ui.R
 import com.litus_animae.refitted.ui.compose.exercise.CircularRestTimer
 import com.litus_animae.refitted.ui.compose.exercise.RepsDisplay
+import com.litus_animae.refitted.ui.compose.exercise.RepsDisplayEditingMinHeight
 import com.litus_animae.refitted.ui.compose.exercise.RepsDisplayMinHeight
 import com.litus_animae.refitted.ui.compose.exercise.TargetStepper
 import com.litus_animae.refitted.ui.compose.exercise.WeightDisplay
@@ -170,7 +171,12 @@ fun ColumnScope.ExerciseSetView(
       val width = constraints.maxWidth
       val available = (constraints.maxHeight - spacing).coerceAtLeast(0)
       val (weightCard, repsCard) = measurables
-      val repsHeight = maxOf(available / 2, RepsDisplayMinHeight.roundToPx())
+      val repsFloor = if (editing && onUpdateCustomTargets != null) {
+        RepsDisplayEditingMinHeight
+      } else {
+        RepsDisplayMinHeight
+      }
+      val repsHeight = maxOf(available / 2, repsFloor.roundToPx())
         .coerceAtMost(available)
       val weightPlaceable = weightCard.measure(Constraints.fixed(width, available - repsHeight))
       val repsPlaceable = repsCard.measure(Constraints.fixed(width, repsHeight))

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -210,6 +210,17 @@ class ExerciseViewModel @Inject constructor(
     exerciseRepo.refreshExercises()
   }
 
+  fun addExercise(workout: String, day: String, exerciseName: String) {
+    try {
+      viewModelScope.launch {
+        exerciseRepo.addCustomExercise(workout, day, exerciseName)
+      }
+    } catch (ex: Throwable) {
+      log.e(TAG, "error adding custom exercise", ex)
+      exercisesError = "There was an error adding the exercise"
+    }
+  }
+
   fun saveExercise(record: SetRecord) {
     try {
       viewModelScope.launch {

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -225,6 +225,17 @@ class ExerciseViewModel @Inject constructor(
     }
   }
 
+  fun deleteExercise(workout: String, day: String, step: String) {
+    try {
+      viewModelScope.launch {
+        exerciseRepo.deleteCustomExerciseSet(workout, day, step)
+      }
+    } catch (ex: Throwable) {
+      log.e(TAG, "error deleting custom exercise set", ex)
+      exercisesError = "There was an error removing the exercise"
+    }
+  }
+
   // Add-exercise picker (muscle group browsing) - local matches are live; remote matches are
   // fetched per-workout on demand since browsing shouldn't pull every accessible plan's catalog.
   val accessibleWorkoutNames = workoutPlanRepo.accessibleWorkoutNames

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -189,13 +189,13 @@ class ExerciseViewModel @Inject constructor(
   val isLoading = exerciseRepo.exercisesAreLoading
 
   fun loadExercises(day: String, workoutId: String) {
-    try {
-      viewModelScope.launch {
+    viewModelScope.launch {
+      try {
         exerciseRepo.loadExercises(day, workoutId)
+      } catch (ex: Throwable) {
+        log.e(TAG, "error loading exercises", ex)
+        exercisesError = "There was an error loading exercises"
       }
-    } catch (ex: Throwable) {
-      log.e(TAG, "error loading exercises", ex)
-      exercisesError = "There was an error loading exercises"
     }
   }
 
@@ -204,13 +204,13 @@ class ExerciseViewModel @Inject constructor(
   }
 
   fun addExercise(workout: String, day: String, exerciseId: String, description: String? = null) {
-    try {
-      viewModelScope.launch {
+    viewModelScope.launch {
+      try {
         exerciseRepo.addCustomExercise(workout, day, exerciseId, description)
+      } catch (ex: Throwable) {
+        log.e(TAG, "error adding custom exercise", ex)
+        exercisesError = "There was an error adding the exercise"
       }
-    } catch (ex: Throwable) {
-      log.e(TAG, "error adding custom exercise", ex)
-      exercisesError = "There was an error adding the exercise"
     }
   }
 
@@ -223,35 +223,35 @@ class ExerciseViewModel @Inject constructor(
     rest: Int,
     repsRange: Int
   ) {
-    try {
-      viewModelScope.launch {
+    viewModelScope.launch {
+      try {
         exerciseRepo.updateCustomExerciseSet(workout, day, step, sets, reps, rest, repsRange)
+      } catch (ex: Throwable) {
+        log.e(TAG, "error updating custom exercise set targets", ex)
+        exercisesError = "There was an error updating the exercise"
       }
-    } catch (ex: Throwable) {
-      log.e(TAG, "error updating custom exercise set targets", ex)
-      exercisesError = "There was an error updating the exercise"
     }
   }
 
   fun deleteExercise(workout: String, day: String, step: String) {
-    try {
-      viewModelScope.launch {
+    viewModelScope.launch {
+      try {
         exerciseRepo.deleteCustomExerciseSet(workout, day, step)
+      } catch (ex: Throwable) {
+        log.e(TAG, "error deleting custom exercise set", ex)
+        exercisesError = "There was an error removing the exercise"
       }
-    } catch (ex: Throwable) {
-      log.e(TAG, "error deleting custom exercise set", ex)
-      exercisesError = "There was an error removing the exercise"
     }
   }
 
   fun updateCustomExerciseSetNote(workout: String, day: String, step: String, note: String) {
-    try {
-      viewModelScope.launch {
+    viewModelScope.launch {
+      try {
         exerciseRepo.updateCustomExerciseSetNote(workout, day, step, note)
+      } catch (ex: Throwable) {
+        log.e(TAG, "error updating custom exercise set note", ex)
+        exercisesError = "There was an error updating the exercise's instructions"
       }
-    } catch (ex: Throwable) {
-      log.e(TAG, "error updating custom exercise set note", ex)
-      exercisesError = "There was an error updating the exercise's instructions"
     }
   }
 
@@ -283,13 +283,13 @@ class ExerciseViewModel @Inject constructor(
   }
 
   fun saveExercise(record: SetRecord) {
-    try {
-      viewModelScope.launch {
+    viewModelScope.launch {
+      try {
         exerciseRepo.storeSetRecord(record)
+      } catch (ex: Throwable) {
+        log.e(TAG, "error storing set record", ex)
+        exercisesError = "There was an error storing the set record"
       }
-    } catch (ex: Throwable) {
-      log.e(TAG, "error storing set record", ex)
-      exercisesError = "There was an error storing the set record"
     }
   }
 

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -203,10 +203,10 @@ class ExerciseViewModel @Inject constructor(
     exerciseRepo.refreshExercises()
   }
 
-  fun addExercise(workout: String, day: String, exerciseId: String) {
+  fun addExercise(workout: String, day: String, exerciseId: String, description: String? = null) {
     try {
       viewModelScope.launch {
-        exerciseRepo.addCustomExercise(workout, day, exerciseId)
+        exerciseRepo.addCustomExercise(workout, day, exerciseId, description)
       }
     } catch (ex: Throwable) {
       log.e(TAG, "error adding custom exercise", ex)

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -214,10 +214,18 @@ class ExerciseViewModel @Inject constructor(
     }
   }
 
-  fun updateCustomExerciseSetTargets(workout: String, day: String, step: String, sets: Int, reps: Int, rest: Int) {
+  fun updateCustomExerciseSetTargets(
+    workout: String,
+    day: String,
+    step: String,
+    sets: Int,
+    reps: Int,
+    rest: Int,
+    repsRange: Int
+  ) {
     try {
       viewModelScope.launch {
-        exerciseRepo.updateCustomExerciseSet(workout, day, step, sets, reps, rest)
+        exerciseRepo.updateCustomExerciseSet(workout, day, step, sets, reps, rest, repsRange)
       }
     } catch (ex: Throwable) {
       log.e(TAG, "error updating custom exercise set targets", ex)

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -119,7 +119,6 @@ class ExerciseViewModel @Inject constructor(
     val restSeconds: Int = 0
   )
   val timerStateByExerciseId: SnapshotStateMap<String, TimerState> = mutableStateMapOf()
-  val restOverrideByExerciseId: SnapshotStateMap<String, Int> = mutableStateMapOf()
 
   fun setTimerRunning(id: String, running: Boolean, restSeconds: Int = 0) {
     if (running) {
@@ -133,10 +132,6 @@ class ExerciseViewModel @Inject constructor(
     } else {
       timerStateByExerciseId[id] = TimerState(isRunning = false)
     }
-  }
-
-  fun setRestOverride(id: String, seconds: Int) {
-    restOverrideByExerciseId[id] = seconds.coerceAtLeast(0)
   }
 
   data class LatestRecord(val targetSet: ExerciseSet, val completed: Instant)

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -236,6 +236,17 @@ class ExerciseViewModel @Inject constructor(
     }
   }
 
+  fun updateCustomExerciseSetNote(workout: String, day: String, step: String, note: String) {
+    try {
+      viewModelScope.launch {
+        exerciseRepo.updateCustomExerciseSetNote(workout, day, step, note)
+      }
+    } catch (ex: Throwable) {
+      log.e(TAG, "error updating custom exercise set note", ex)
+      exercisesError = "There was an error updating the exercise's instructions"
+    }
+  }
+
   // Add-exercise picker (muscle group browsing) - local matches are live; remote matches are
   // fetched per-workout on demand since browsing shouldn't pull every accessible plan's catalog.
   val accessibleWorkoutNames = workoutPlanRepo.accessibleWorkoutNames

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -261,20 +261,23 @@ class ExerciseViewModel @Inject constructor(
 
   fun exercisesByMuscle(muscle: String): Flow<List<Exercise>> = exerciseRepo.exercisesByMuscle(muscle)
 
-  val remoteExercisesByWorkout: SnapshotStateMap<String, List<Exercise>> = mutableStateMapOf()
-  val loadingWorkouts: SnapshotStateMap<String, Boolean> = mutableStateMapOf()
+  // Keyed by (workout, muscle) - not workout alone - so switching muscle within one session
+  // never shows a stale result cached under the same workout for a different muscle.
+  val remoteExercisesByWorkout: SnapshotStateMap<Pair<String, String>, List<Exercise>> = mutableStateMapOf()
+  val loadingWorkouts: SnapshotStateMap<Pair<String, String>, Boolean> = mutableStateMapOf()
 
   fun loadRemoteExercises(workout: String, muscle: String) {
-    if (loadingWorkouts[workout] == true) return
-    loadingWorkouts[workout] = true
+    val key = workout to muscle
+    if (loadingWorkouts[key] == true) return
+    loadingWorkouts[key] = true
     viewModelScope.launch {
       try {
-        remoteExercisesByWorkout[workout] = exerciseRepo.loadRemoteExercisesByMuscle(workout, muscle)
+        remoteExercisesByWorkout[key] = exerciseRepo.loadRemoteExercisesByMuscle(workout, muscle)
       } catch (ex: Throwable) {
         log.e(TAG, "error loading remote exercises for $workout/$muscle", ex)
         exercisesError = "There was an error loading exercises"
       } finally {
-        loadingWorkouts[workout] = false
+        loadingWorkouts[key] = false
       }
     }
   }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -224,6 +224,17 @@ class ExerciseViewModel @Inject constructor(
     }
   }
 
+  fun updateCustomExerciseSetTargets(workout: String, day: String, step: String, sets: Int, reps: Int, rest: Int) {
+    try {
+      viewModelScope.launch {
+        exerciseRepo.updateCustomExerciseSet(workout, day, step, sets, reps, rest)
+      }
+    } catch (ex: Throwable) {
+      log.e(TAG, "error updating custom exercise set targets", ex)
+      exercisesError = "There was an error updating the exercise"
+    }
+  }
+
   // Add-exercise picker (muscle group browsing) - local matches are live; remote matches are
   // fetched per-workout on demand since browsing shouldn't pull every accessible plan's catalog.
   val accessibleWorkoutNames = workoutPlanRepo.accessibleWorkoutNames

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -11,6 +11,8 @@ import androidx.lifecycle.viewModelScope
 import arrow.core.NonEmptyList
 import arrow.core.toNonEmptyListOrNull
 import com.litus_animae.refitted.data.ExerciseRepository
+import com.litus_animae.refitted.data.WorkoutPlanRepository
+import com.litus_animae.refitted.data.models.Exercise
 import com.litus_animae.refitted.data.models.ExerciseSet
 import com.litus_animae.refitted.data.models.SetRecord
 import com.litus_animae.refitted.util.LogUtil
@@ -28,6 +30,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ExerciseViewModel @Inject constructor(
   private val exerciseRepo: ExerciseRepository,
+  private val workoutPlanRepo: WorkoutPlanRepository,
   private val log: LogUtil
 ) : ViewModel() {
   var exercisesError: String? by mutableStateOf(null)
@@ -210,14 +213,38 @@ class ExerciseViewModel @Inject constructor(
     exerciseRepo.refreshExercises()
   }
 
-  fun addExercise(workout: String, day: String, exerciseName: String) {
+  fun addExercise(workout: String, day: String, exerciseId: String) {
     try {
       viewModelScope.launch {
-        exerciseRepo.addCustomExercise(workout, day, exerciseName)
+        exerciseRepo.addCustomExercise(workout, day, exerciseId)
       }
     } catch (ex: Throwable) {
       log.e(TAG, "error adding custom exercise", ex)
       exercisesError = "There was an error adding the exercise"
+    }
+  }
+
+  // Add-exercise picker (muscle group browsing) - local matches are live; remote matches are
+  // fetched per-workout on demand since browsing shouldn't pull every accessible plan's catalog.
+  val accessibleWorkoutNames = workoutPlanRepo.accessibleWorkoutNames
+
+  fun exercisesByMuscle(muscle: String): Flow<List<Exercise>> = exerciseRepo.exercisesByMuscle(muscle)
+
+  val remoteExercisesByWorkout: SnapshotStateMap<String, List<Exercise>> = mutableStateMapOf()
+  val loadingWorkouts: SnapshotStateMap<String, Boolean> = mutableStateMapOf()
+
+  fun loadRemoteExercises(workout: String, muscle: String) {
+    if (loadingWorkouts[workout] == true) return
+    loadingWorkouts[workout] = true
+    viewModelScope.launch {
+      try {
+        remoteExercisesByWorkout[workout] = exerciseRepo.loadRemoteExercisesByMuscle(workout, muscle)
+      } catch (ex: Throwable) {
+        log.e(TAG, "error loading remote exercises for $workout/$muscle", ex)
+        exercisesError = "There was an error loading exercises"
+      } finally {
+        loadingWorkouts[workout] = false
+      }
     }
   }
 

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -139,11 +139,6 @@ class ExerciseViewModel @Inject constructor(
     restOverrideByExerciseId[id] = seconds.coerceAtLeast(0)
   }
 
-  /** Largest rest value across all exercises in the day, used to normalise the ring fill. */
-  val maxRestSeconds: Flow<Int> = exercises.map { list ->
-    list.flatMap { it.sets.toList() }.maxOfOrNull { it.rest } ?: 0
-  }
-
   data class LatestRecord(val targetSet: ExerciseSet, val completed: Instant)
 
   data class ExerciseInstruction(

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/WorkoutViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/WorkoutViewModel.kt
@@ -202,4 +202,29 @@ class WorkoutViewModel @Inject constructor(
         }
     }
   }
+
+  fun createCustomWorkout(name: String) {
+    viewModelScope.launch(Dispatchers.IO) {
+      log.d(TAG, "Creating custom workout $name")
+      val plan = workoutPlanRepo.createCustomPlan(name)
+      loadWorkoutDaysCompleted(plan)
+    }
+  }
+
+  fun addDay(workout: WorkoutPlan) {
+    viewModelScope.launch(Dispatchers.IO) {
+      log.d(TAG, "Adding day to custom plan ${workout.workout}")
+      workoutPlanRepo.addDayToCustomPlan(workout)
+      workoutPlanRepo.workoutByName(workout.workout).first()?.let { loadWorkoutDaysCompleted(it) }
+    }
+  }
+
+  // A null toDay appends a new day; otherwise toDay is overwritten.
+  fun copyDay(workout: WorkoutPlan, fromDay: Int, toDay: Int?) {
+    viewModelScope.launch(Dispatchers.IO) {
+      log.d(TAG, "Copying day $fromDay to ${toDay ?: "new day"} for custom plan ${workout.workout}")
+      workoutPlanRepo.copyCustomDay(workout, fromDay, toDay)
+      workoutPlanRepo.workoutByName(workout.workout).first()?.let { loadWorkoutDaysCompleted(it) }
+    }
+  }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/WorkoutViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/WorkoutViewModel.kt
@@ -219,11 +219,35 @@ class WorkoutViewModel @Inject constructor(
     }
   }
 
-  // A null toDay appends a new day; otherwise toDay is overwritten.
-  fun copyDay(workout: WorkoutPlan, fromDay: Int, toDay: Int?) {
+  fun addRestDay(workout: WorkoutPlan) {
     viewModelScope.launch(Dispatchers.IO) {
-      log.d(TAG, "Copying day $fromDay to ${toDay ?: "new day"} for custom plan ${workout.workout}")
-      workoutPlanRepo.copyCustomDay(workout, fromDay, toDay)
+      log.d(TAG, "Adding rest day to custom plan ${workout.workout}")
+      workoutPlanRepo.addRestDayToCustomPlan(workout)
+      workoutPlanRepo.workoutByName(workout.workout).first()?.let { loadWorkoutDaysCompleted(it) }
+    }
+  }
+
+  // Always appends - copy-day is non-destructive, it never overwrites an existing day.
+  fun copyDay(workout: WorkoutPlan, fromDay: Int) {
+    viewModelScope.launch(Dispatchers.IO) {
+      log.d(TAG, "Copying day $fromDay to a new day for custom plan ${workout.workout}")
+      workoutPlanRepo.copyCustomDay(workout, fromDay)
+      workoutPlanRepo.workoutByName(workout.workout).first()?.let { loadWorkoutDaysCompleted(it) }
+    }
+  }
+
+  fun clearDay(workout: WorkoutPlan, day: Int) {
+    viewModelScope.launch(Dispatchers.IO) {
+      log.d(TAG, "Clearing day $day of custom plan ${workout.workout}")
+      workoutPlanRepo.clearCustomDay(workout, day)
+      workoutPlanRepo.workoutByName(workout.workout).first()?.let { loadWorkoutDaysCompleted(it) }
+    }
+  }
+
+  fun setDayRest(workout: WorkoutPlan, day: Int, isRest: Boolean) {
+    viewModelScope.launch(Dispatchers.IO) {
+      log.d(TAG, "Setting day $day rest=$isRest for custom plan ${workout.workout}")
+      workoutPlanRepo.setCustomDayRest(workout, day, isRest)
       workoutPlanRepo.workoutByName(workout.workout).first()?.let { loadWorkoutDaysCompleted(it) }
     }
   }

--- a/ui/src/main/res/values/changelog.xml
+++ b/ui/src/main/res/values/changelog.xml
@@ -2,7 +2,9 @@
 <resources>
     <string name="changelog_version_header">**</string>
     <string-array name="changelog">
-        <item>**v1.3.1</item>
+        <item>**v1.4.0</item>
+        <item>Build your own workout: create a custom plan, then add your own days and exercises</item>
+        <item>Edit mode lets you adjust sets, reps, rest, and notes on a custom workout</item>
         <item>Calendar now aligns to real dates</item>
         <item>**v1.3.0</item>
         <item>Updated Exercise UI</item>


### PR DESCRIPTION
## Summary
- Adds BYO custom workout plans: create/edit custom days, add exercises from a muscle-group picker (local + remote), reorder/collapse sections, rest days, and per-exercise-set target/rest/note editing.
- New exercise-picker with local + remote muscle-group queries, cached into Room per workout/muscle.
- Exercise instruction pager: deck/card swipe UI with continuous elevation and swap animations, collapsible sections in the picker, edit-mode delete/note affordances.
- Various fixes surfaced along the way: add-exercise flow spinner/insets/back-behavior, partial-day cache re-check, muscle-group category mismatch, rest-ring normalization, target-editor debounce, and a smoothing pass on the exercise pager's elevation/shadow behavior during swipes.

## Test plan
- [ ] `./gradlew testDebugUnitTest`
- [ ] `./gradlew lintDebug`
- [ ] Manual: build a custom day from the edit-mode calendar, add exercises via the muscle-group picker, edit sets/reps/rest targets, delete an exercise, mark a day as rest
- [ ] Manual: swipe through the exercise pager (portrait and landscape/split-pane) and confirm elevation/shadow transitions smoothly