### PR TITLE
Add equipment libraries to the exercise picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@
 groups.json
 PLAN-web-security.md
 
+# Equipment-library content for scripts/seed_libraries.py - synthesized descriptions, but they
+# live only in DynamoDB, same as workout-program content never belonging in this repo
+content/libraries/
+
 # Generated files
 bin/
 gen/

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepository.kt
@@ -44,7 +44,8 @@ class RoomCacheWorkoutPlanRepository @Inject constructor(
         return workoutPlanDao.planByName(name).map { it?.toDomain() }
     }
 
-    override val accessibleWorkoutNames: Flow<List<String>> = workoutPlanDao.getServerWorkoutNames()
+    override val accessibleWorkouts: Flow<List<WorkoutPlan>> =
+        workoutPlanDao.getServerPlans().map { plans -> plans.map { it.toDomain() } }
 
     override suspend fun setWorkoutLastViewedDay(workoutPlan: WorkoutPlan, day: Int) {
         return workoutPlanDao.update(RoomWorkoutPlan.fromDomain(workoutPlan.copy(lastViewedDay = day)))

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/WorkoutPlanRemoteMediator.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/WorkoutPlanRemoteMediator.kt
@@ -63,7 +63,8 @@ class WorkoutPlanRemoteMediator(
           restDays = newPlan.restDays,
           description = newPlan.description,
           globalAlternateLabels = newPlan.globalAlternateLabels,
-          globalAlternate = existingPlan.globalAlternate ?: newPlan.globalAlternate
+          globalAlternate = existingPlan.globalAlternate ?: newPlan.globalAlternate,
+          kind = newPlan.kind
         ))
       }
       workoutPlanDao.insertAll(upsertPlans)

--- a/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepositoryTest.kt
+++ b/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepositoryTest.kt
@@ -46,7 +46,7 @@ class RoomCacheWorkoutPlanRepositoryTest {
     every { roomDatabase.getWorkoutPlanDao() } returns workoutPlanDao
     every { roomDatabase.getExerciseDao() } returns exerciseDao
     every { workoutPlanDao.update(any()) } returns Unit
-    every { workoutPlanDao.getServerWorkoutNames() } returns emptyFlow()
+    every { workoutPlanDao.getServerPlans() } returns emptyFlow()
 
     subject = RoomCacheWorkoutPlanRepository(roomProvider, networkService, log)
   }

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/WorkoutPlanRepository.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/WorkoutPlanRepository.kt
@@ -14,10 +14,11 @@ interface WorkoutPlanRepository {
   fun workoutByName(name: String): Flow<WorkoutPlan?>
 
   /**
-   * Names of admin-authored plans the user has access to - used by the add-exercise picker to
-   * list which workouts' exercises can be browsed by muscle group.
+   * Admin-authored plans the user has access to, programs and equipment libraries alike - used by
+   * the add-exercise picker to list which workouts' exercises can be browsed by muscle group, and
+   * to order/section that list by [WorkoutPlan.kind].
    */
-  val accessibleWorkoutNames: Flow<List<String>>
+  val accessibleWorkouts: Flow<List<WorkoutPlan>>
   suspend fun setWorkoutLastViewedDay(workoutPlan: WorkoutPlan, day: Int)
   suspend fun setWorkoutStartDate(workoutPlan: WorkoutPlan, startDate: Instant)
   suspend fun setWorkoutGlobalAlternate(workoutPlan: WorkoutPlan, index: Int)

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/models/MuscleGroup.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/models/MuscleGroup.kt
@@ -6,8 +6,10 @@ package com.litus_animae.refitted.data.models
  * inconsistent spellings for the same muscle (e.g. "Quads" vs "Quadricep", "Bicep" vs "Biceps"),
  * and "Back"/"External Rotator" turned out to be the same training focus as "Lats"/"Shoulders"
  * under a different label - confirmed by surveying every admin program's stored exercise ids.
- * "Forearms" and "Lower back" were dropped entirely: no admin program has ever stored an exercise
- * under either prefix.
+ * "Forearms" was dropped entirely: no admin program has ever stored an exercise under that prefix.
+ * "Lower back" was dropped for the same reason until app-authored equipment-library content
+ * started using it (back-extension machines) - it's kept distinct from LATS's "Back" prefix so
+ * erector work doesn't file under lats.
  */
 enum class MuscleGroup(val displayName: String, private val prefixes: List<String>) {
   CHEST("Chest", listOf("Chest")),
@@ -17,6 +19,7 @@ enum class MuscleGroup(val displayName: String, private val prefixes: List<Strin
   CORE("Core", listOf("Core")),
   TRAPS("Traps", listOf("Traps")),
   LATS("Lats", listOf("Lats", "Back")),
+  LOWER_BACK("Lower back", listOf("Lower Back")),
   GLUTES("Glutes", listOf("Glutes")),
   HAMSTRINGS("Hamstrings", listOf("Hamstrings", "Hamstring")),
   QUADS("Quads", listOf("Quads", "Quadricep")),

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/models/PlanKind.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/models/PlanKind.kt
@@ -1,0 +1,12 @@
+package com.litus_animae.refitted.data.models
+
+/** Declaration order is picker order: locations, then equipment, then programs. */
+enum class PlanKind {
+  LOCATION, EQUIPMENT, PROGRAM;
+
+  companion object {
+    /** Unknown or absent stored values fall back to PROGRAM - every pre-existing plan is one. */
+    fun fromStored(value: String?): PlanKind =
+      entries.find { it.name.equals(value, ignoreCase = true) } ?: PROGRAM
+  }
+}

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/models/WorkoutPlan.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/models/WorkoutPlan.kt
@@ -15,7 +15,8 @@ data class WorkoutPlan(
   val description: String = "",
   val globalAlternateLabels: List<String> = emptyList(),
   val globalAlternate: Int? = null,
-  val isCustom: Boolean = false
+  val isCustom: Boolean = false,
+  val kind: PlanKind = PlanKind.PROGRAM
 )
 
 /**

--- a/dynamo/src/main/kotlin/com/litus_animae/refitted/dynamo/DynamoWorkoutPlanNetworkService.kt
+++ b/dynamo/src/main/kotlin/com/litus_animae/refitted/dynamo/DynamoWorkoutPlanNetworkService.kt
@@ -3,6 +3,7 @@ package com.litus_animae.refitted.dynamo
 import android.content.Context
 import com.amazonaws.mobileconnectors.dynamodbv2.dynamodbmapper.DynamoDBMapper
 import com.amazonaws.mobileconnectors.dynamodbv2.dynamodbmapper.DynamoDBQueryExpression
+import com.litus_animae.refitted.data.models.PlanKind
 import com.litus_animae.refitted.data.models.WorkoutPlan
 import com.litus_animae.refitted.data.network.WorkoutPlanNetworkService
 import com.litus_animae.refitted.dynamo.DynamoUtil.queryReverseIndex
@@ -53,6 +54,23 @@ class DynamoWorkoutPlanNetworkService @Inject constructor(
       command
         .mapNotNull { plan ->
           plan.workout?.let { workout ->
+            val kind = PlanKind.fromStored(plan.kind)
+            val alternateLabels = plan.globalAlternateLabels.split(';')
+              .filter { it.isNotBlank() }
+
+            // Equipment libraries have no days - only their Exercise rows matter - so skip the
+            // per-plan day query entirely rather than pay for a round trip that can only come back empty.
+            if (kind != PlanKind.PROGRAM) {
+              return@mapNotNull WorkoutPlan(
+                workout,
+                totalDays = 0,
+                kind = kind,
+                description = plan.description,
+                globalAlternateLabels = alternateLabels,
+                globalAlternate = if (alternateLabels.isNotEmpty()) 0 else null
+              )
+            }
+
             val subKeyValues = DynamoWorkoutDay(workout = workout)
             val subQueryExpression = DynamoDBQueryExpression<DynamoWorkoutDay>()
               .withHashKeyValues(subKeyValues)
@@ -68,8 +86,6 @@ class DynamoWorkoutPlanNetworkService @Inject constructor(
             }
               .mapNotNull { it.day?.toIntOrNull() ?: 0 }
             log.d(TAG, "Got rest days for workout $workout: $restDays")
-            val alternateLabels = plan.globalAlternateLabels.split(';')
-              .filter { it.isNotBlank() }
             if (totalDays != null) {
               WorkoutPlan(
                 workout,

--- a/dynamo/src/main/kotlin/com/litus_animae/refitted/dynamo/entities/DynamoWorkoutPlan.kt
+++ b/dynamo/src/main/kotlin/com/litus_animae/refitted/dynamo/entities/DynamoWorkoutPlan.kt
@@ -27,7 +27,11 @@ internal data class DynamoWorkoutPlan @JvmOverloads constructor(
   var description: String = "",
 
   @get:DynamoDBAttribute(attributeName = "GlobalAlternateLabels")
-  var globalAlternateLabels: String = ""
+  var globalAlternateLabels: String = "",
+
+  /** Absent on every plan stored before equipment libraries existed - PlanKind.fromStored treats that as PROGRAM. */
+  @get:DynamoDBAttribute(attributeName = "Kind")
+  var kind: String? = null
 ) {
   constructor() : this(null)
 }

--- a/room/schemas/com.litus_animae.refitted.room.RefittedRoom/14.json
+++ b/room/schemas/com.litus_animae.refitted.room.RefittedRoom/14.json
@@ -1,0 +1,326 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "fbf107864b34295d658e6c8a8dbb172c",
+    "entities": [
+      {
+        "tableName": "Exercise",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`exercise_workout` TEXT NOT NULL, `exercise_name` TEXT NOT NULL, `description` TEXT, PRIMARY KEY(`exercise_name`, `exercise_workout`))",
+        "fields": [
+          {
+            "fieldPath": "workout",
+            "columnName": "exercise_workout",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "exercise_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "exercise_name",
+            "exercise_workout"
+          ]
+        }
+      },
+      {
+        "tableName": "exerciseset",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`workout` TEXT NOT NULL, `day` TEXT NOT NULL, `step` TEXT NOT NULL, `primaryStep` INTEGER NOT NULL, `superSetStep` INTEGER, `alternateStep` TEXT, `name` TEXT NOT NULL, `note` TEXT NOT NULL, `reps` INTEGER NOT NULL, `sets` INTEGER NOT NULL, `toFailure` INTEGER NOT NULL, `rest` INTEGER NOT NULL, `repsUnit` TEXT NOT NULL, `repsRange` INTEGER NOT NULL, `timeLimit` INTEGER, `timeLimitUnit` TEXT, `repsSequence` TEXT NOT NULL, PRIMARY KEY(`day`, `step`, `workout`), FOREIGN KEY(`name`, `workout`) REFERENCES `Exercise`(`exercise_name`, `exercise_workout`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "workout",
+            "columnName": "workout",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "day",
+            "columnName": "day",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "step",
+            "columnName": "step",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryStep",
+            "columnName": "primaryStep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "superSetStep",
+            "columnName": "superSetStep",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alternateStep",
+            "columnName": "alternateStep",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reps",
+            "columnName": "reps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sets",
+            "columnName": "sets",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isToFailure",
+            "columnName": "toFailure",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rest",
+            "columnName": "rest",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repsUnit",
+            "columnName": "repsUnit",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repsRange",
+            "columnName": "repsRange",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeLimit",
+            "columnName": "timeLimit",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeLimitUnit",
+            "columnName": "timeLimitUnit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repsSequence",
+            "columnName": "repsSequence",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day",
+            "step",
+            "workout"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exerciseset_name_workout",
+            "unique": false,
+            "columnNames": [
+              "name",
+              "workout"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exerciseset_name_workout` ON `${TABLE_NAME}` (`name`, `workout`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Exercise",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "name",
+              "workout"
+            ],
+            "referencedColumns": [
+              "exercise_name",
+              "exercise_workout"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "SetRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`weight` REAL NOT NULL, `reps` INTEGER NOT NULL, `workout` TEXT NOT NULL, `target_set` TEXT NOT NULL, `completed` INTEGER NOT NULL, `exercise` TEXT NOT NULL, PRIMARY KEY(`exercise`, `completed`))",
+        "fields": [
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reps",
+            "columnName": "reps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workout",
+            "columnName": "workout",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetSet",
+            "columnName": "target_set",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exercise",
+            "columnName": "exercise",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "exercise",
+            "completed"
+          ]
+        }
+      },
+      {
+        "tableName": "workouts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`workout` TEXT NOT NULL, `totalDays` INTEGER NOT NULL, `lastViewedDay` INTEGER NOT NULL, `workoutStartDate` INTEGER NOT NULL, `restDays` TEXT NOT NULL, `description` TEXT NOT NULL, `globalAlternateLabels` TEXT NOT NULL, `globalAlternate` INTEGER, `isCustom` INTEGER NOT NULL, `kind` TEXT NOT NULL, PRIMARY KEY(`workout`))",
+        "fields": [
+          {
+            "fieldPath": "workout",
+            "columnName": "workout",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalDays",
+            "columnName": "totalDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastViewedDay",
+            "columnName": "lastViewedDay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workoutStartDate",
+            "columnName": "workoutStartDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restDays",
+            "columnName": "restDays",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "globalAlternateLabels",
+            "columnName": "globalAlternateLabels",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "globalAlternate",
+            "columnName": "globalAlternate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isCustom",
+            "columnName": "isCustom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "workout"
+          ]
+        }
+      },
+      {
+        "tableName": "SavedState",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'fbf107864b34295d658e6c8a8dbb172c')"
+    ]
+  }
+}

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/Converters.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/Converters.kt
@@ -1,9 +1,20 @@
 package com.litus_animae.refitted.room
 
 import androidx.room.TypeConverter
+import com.litus_animae.refitted.data.models.PlanKind
 import java.time.Instant
 
 object Converters {
+  // Stored by name rather than ordinal so the migration default ('PROGRAM') stays legible in the
+  // schema and reordering the enum can't silently remap existing rows.
+  @JvmStatic
+  @TypeConverter
+  fun planKindFromString(value: String?): PlanKind = PlanKind.fromStored(value)
+
+  @JvmStatic
+  @TypeConverter
+  fun planKindToString(kind: PlanKind): String = kind.name
+
   @JvmStatic
   @TypeConverter
   fun fromTimestamp(value: Long?): Instant? {

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/RefittedRoom.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/RefittedRoom.kt
@@ -9,7 +9,7 @@ import com.litus_animae.refitted.room.entities.*
 
 @Database(
   entities = [RoomExercise::class, RoomExerciseSet::class, RoomSetRecord::class, RoomWorkoutPlan::class, RoomSavedState::class],
-  version = 13
+  version = 14
 )
 @TypeConverters(Converters::class)
 abstract class RefittedRoom : RoomDatabase() {
@@ -205,6 +205,15 @@ abstract class RefittedRoom : RoomDatabase() {
         db.execSQL(
           "ALTER TABLE `workouts` " +
             "ADD COLUMN `isCustom` INTEGER NOT NULL DEFAULT 0"
+        )
+      }
+    }
+
+    val MIGRATION_13_14: Migration = object : Migration(13, 14) {
+      override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+          "ALTER TABLE `workouts` " +
+            "ADD COLUMN `kind` TEXT NOT NULL DEFAULT 'PROGRAM'"
         )
       }
     }

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/RefittedRoomProviderLive.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/RefittedRoomProviderLive.kt
@@ -32,7 +32,8 @@ class RefittedRoomProviderLive @Inject constructor(
         RefittedRoom.MIGRATION_9_10,
         RefittedRoom.MIGRATION_10_11,
         RefittedRoom.MIGRATION_11_12,
-        RefittedRoom.MIGRATION_12_13
+        RefittedRoom.MIGRATION_12_13,
+        RefittedRoom.MIGRATION_13_14
       )
       .build()
   }

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/WorkoutPlanDao.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/WorkoutPlanDao.kt
@@ -13,7 +13,8 @@ interface WorkoutPlanDao {
     @Update
     fun update(workoutPlan: RoomWorkoutPlan)
 
-    @Query("SELECT * FROM workouts ORDER BY isCustom ASC, workout ASC")
+    /** Selectable programs only - equipment libraries (kind != PROGRAM) never appear in the drawer. */
+    @Query("SELECT * FROM workouts where `kind` = 'PROGRAM' ORDER BY isCustom ASC, workout ASC")
     fun pagingSource(): PagingSource<Int, RoomWorkoutPlan>
 
     @Query("SELECT * FROM workouts")
@@ -26,12 +27,12 @@ interface WorkoutPlanDao {
     suspend fun getByName(name: String): RoomWorkoutPlan?
 
     /**
-     * Names of admin-authored plans the user has synced access to - the plan list itself is
-     * synced in full on refresh (unlike per-day exercise content), so this doesn't require an
-     * extra network round-trip.
+     * Admin-authored plans the user has synced access to, program or equipment library alike -
+     * the plan list itself is synced in full on refresh (unlike per-day exercise content), so this
+     * doesn't require an extra network round-trip.
      */
-    @Query("SELECT workout FROM workouts where `isCustom` = 0 ORDER BY workout ASC")
-    fun getServerWorkoutNames(): Flow<List<String>>
+    @Query("SELECT * FROM workouts where `isCustom` = 0 ORDER BY workout ASC")
+    fun getServerPlans(): Flow<List<RoomWorkoutPlan>>
 
     @Query("DELETE FROM workouts")
     suspend fun clearAll()

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/entities/RoomWorkoutPlan.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/entities/RoomWorkoutPlan.kt
@@ -2,6 +2,7 @@ package com.litus_animae.refitted.room.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.litus_animae.refitted.data.models.PlanKind
 import com.litus_animae.refitted.data.models.WorkoutPlan
 import java.time.Instant
 
@@ -20,7 +21,8 @@ data class RoomWorkoutPlan(
     val description: String = "",
     val globalAlternateLabels: List<String> = emptyList(),
     val globalAlternate: Int? = null,
-    val isCustom: Boolean = false
+    val isCustom: Boolean = false,
+    val kind: PlanKind = PlanKind.PROGRAM
 ) {
     /**
      * Convert Room entity to domain model
@@ -34,7 +36,8 @@ data class RoomWorkoutPlan(
         description = description,
         globalAlternateLabels = globalAlternateLabels,
         globalAlternate = globalAlternate,
-        isCustom = isCustom
+        isCustom = isCustom,
+        kind = kind
     )
 
     companion object {
@@ -50,7 +53,8 @@ data class RoomWorkoutPlan(
             description = workoutPlan.description,
             globalAlternateLabels = workoutPlan.globalAlternateLabels,
             globalAlternate = workoutPlan.globalAlternate,
-            isCustom = workoutPlan.isCustom
+            isCustom = workoutPlan.isCustom,
+            kind = workoutPlan.kind
         )
     }
 }

--- a/scripts/seed_libraries.py
+++ b/scripts/seed_libraries.py
@@ -1,0 +1,205 @@
+# Seeds equipment-library content (PlanKind.LOCATION / PlanKind.EQUIPMENT) into DynamoDB.
+#
+# A library is authored as one JSON file - see content/libraries/*.json (gitignored; these are
+# our own synthesized descriptions, not workout-program content, and don't belong in the repo
+# either way). Each file becomes one "Plan" row plus one row per exercise, written the same way
+# admin program content already is:
+#
+#   { "name": "Planet Fitness", "kind": "LOCATION", "description": "...",
+#     "exercises": [ { "id": "Quads_Leg Press", "note": "..." }, ... ] }
+#
+# Setup: see scripts/insert_items.py's header for AWS credential/boto3 setup - this script shares
+# that configuration.
+#
+# Usage:
+#   python seed_libraries.py content/libraries/*.json      # seed specific files
+#   python seed_libraries.py                                # seed every file in content/libraries
+#   python seed_libraries.py --dry-run [files...]           # print batches, write nothing
+
+import argparse
+import glob
+import json
+import os
+import sys
+
+TABLE_NAME = "refitted.dev01"
+DEFAULT_CONTENT_DIR = os.path.join(os.path.dirname(__file__), "..", "content", "libraries")
+BATCH_SIZE = 25
+
+# Mirrors data/src/main/kotlin/com/litus_animae/refitted/data/models/MuscleGroup.kt - an id whose
+# prefix isn't in this set is silently invisible in the picker forever, so we catch it here
+# instead of finding out on a device. Keep in sync by hand; it changes rarely.
+VALID_MUSCLE_PREFIXES = {
+    "Chest",
+    "Shoulder", "External Rotator",
+    "Bicep", "Biceps",
+    "Tricep",
+    "Core",
+    "Traps",
+    "Lats", "Back",
+    "Lower Back",
+    "Glutes",
+    "Hamstrings", "Hamstring",
+    "Quads", "Quadricep",
+    "Calf",
+    "Leg",
+    "Agility", "Rope",
+    "Compound",
+}
+
+VALID_KINDS = {"LOCATION", "EQUIPMENT"}
+
+ERROR_HELP_STRINGS = {
+    'ConditionalCheckFailedException': 'Condition check specified in the operation failed, review and update the condition check before retrying',
+    'TransactionConflictException': 'Operation was rejected because there is an ongoing transaction for the item, generally safe to retry with exponential back-off',
+    'ItemCollectionSizeLimitExceededException': 'An item collection is too large for a Local Secondary Index; consider a Global Secondary Index instead',
+    'InternalServerError': 'Internal Server Error, generally safe to retry with exponential back-off',
+    'ProvisionedThroughputExceededException': 'Request rate is too high - retry with exponential back-off or raise capacity',
+    'ResourceNotFoundException': 'One of the tables was not found, verify table exists before retrying',
+    'ServiceUnavailable': 'Had trouble reaching DynamoDB, generally safe to retry with exponential back-off',
+    'ThrottlingException': 'Request denied due to throttling, generally safe to retry with exponential back-off',
+    'UnrecognizedClientException': 'The request signature is incorrect, most likely an invalid AWS access key ID or secret key',
+    'ValidationException': 'The input fails to satisfy the constraints specified by DynamoDB, fix input before retrying',
+    'RequestLimitExceeded': 'Throughput exceeds the current throughput limit for your account, increase account level throughput before retrying',
+}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def load_library(path):
+    with open(path, "r", encoding="utf-8") as f:
+        library = json.load(f)
+
+    name = library.get("name")
+    kind = library.get("kind")
+    exercises = library.get("exercises", [])
+
+    if not name:
+        raise ValidationError(f"{path}: missing \"name\"")
+    if kind not in VALID_KINDS:
+        raise ValidationError(f"{path}: \"kind\" must be one of {sorted(VALID_KINDS)}, got {kind!r}")
+    if not exercises:
+        raise ValidationError(f"{path}: \"exercises\" is empty")
+
+    seen_ids = set()
+    for exercise in exercises:
+        exercise_id = exercise.get("id", "")
+        if "_" not in exercise_id:
+            raise ValidationError(f"{path}: exercise id {exercise_id!r} is missing its \"{{Muscle}}_\" prefix")
+        prefix = exercise_id.split("_", 1)[0]
+        if prefix not in VALID_MUSCLE_PREFIXES:
+            raise ValidationError(
+                f"{path}: exercise id {exercise_id!r} has prefix {prefix!r}, "
+                f"which MuscleGroup doesn't query - it would never appear in the picker"
+            )
+        if exercise_id in seen_ids:
+            raise ValidationError(f"{path}: duplicate exercise id {exercise_id!r}")
+        seen_ids.add(exercise_id)
+
+    return library
+
+
+def build_items(library):
+    items = [
+        {
+            "Id": {"S": "Plan"},
+            "Disc": {"S": library["name"]},
+            "Description": {"S": library.get("description", "")},
+            "Kind": {"S": library["kind"]},
+        }
+    ]
+    for exercise in library["exercises"]:
+        item = {
+            "Id": {"S": exercise["id"]},
+            "Disc": {"S": library["name"]},
+        }
+        note = exercise.get("note", "")
+        if note:
+            item["Note"] = {"S": note}
+        items.append(item)
+    return items
+
+
+def chunk_batches(items, table_name=TABLE_NAME, size=BATCH_SIZE):
+    chunks = [items[i:i + size] for i in range(0, len(items), size)]
+    return [
+        {table_name: [{"PutRequest": {"Item": item}} for item in chunk]}
+        for chunk in chunks
+    ]
+
+
+def create_dynamodb_client(region="us-east-2"):
+    # Imported lazily so --dry-run works without boto3 installed - it's exactly the mode someone
+    # reaches for before setting up AWS credentials in the first place.
+    import boto3
+    return boto3.client("dynamodb", region_name=region)
+
+
+def execute_batch_write(dynamodb_client, batches):
+    from botocore.exceptions import ClientError
+    for batch in batches:
+        try:
+            dynamodb_client.batch_write_item(RequestItems=batch)
+            print(f"  wrote batch of {sum(len(v) for v in batch.values())} items")
+        except ClientError as error:
+            handle_error(error)
+
+
+def handle_error(error):
+    error_code = error.response['Error']['Code']
+    error_message = error.response['Error']['Message']
+    help_string = ERROR_HELP_STRINGS.get(error_code, 'Unrecognized error code')
+    print(f'[{error_code}] {help_string}. Error message: {error_message}')
+
+
+def resolve_paths(args):
+    if args.files:
+        return args.files
+    pattern = os.path.join(DEFAULT_CONTENT_DIR, "*.json")
+    return sorted(glob.glob(pattern))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="*", help=f"library JSON files (default: {DEFAULT_CONTENT_DIR}/*.json)")
+    parser.add_argument("--dry-run", action="store_true", help="print batches instead of writing to DynamoDB")
+    parser.add_argument("--region", default="us-east-2")
+    args = parser.parse_args()
+
+    paths = resolve_paths(args)
+    if not paths:
+        print(f"No library files found (looked in {DEFAULT_CONTENT_DIR}).")
+        sys.exit(1)
+
+    libraries = []
+    had_errors = False
+    for path in paths:
+        try:
+            libraries.append((path, load_library(path)))
+        except ValidationError as error:
+            print(f"VALIDATION ERROR: {error}")
+            had_errors = True
+
+    if had_errors:
+        print("\nFix the errors above before seeding - a bad prefix seeds an exercise nobody will ever see.")
+        sys.exit(1)
+
+    dynamodb_client = None if args.dry_run else create_dynamodb_client(region=args.region)
+
+    for path, library in libraries:
+        items = build_items(library)
+        batches = chunk_batches(items)
+        print(f"{library['name']} ({library['kind']}): {len(items) - 1} exercises, {len(batches)} batch(es)")
+        if args.dry_run:
+            for item in items:
+                print(f"  {json.dumps(item)}")
+        else:
+            execute_batch_write(dynamodb_client, batches)
+
+    print("\nDone." if not args.dry_run else "\nDry run complete - nothing was written.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
@@ -11,6 +11,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.paging.LoadState
+import androidx.paging.compose.collectAsLazyPagingItems
 import com.litus_animae.refitted.ui.compose.calendar.Calendar
 import com.litus_animae.refitted.ui.compose.exercise.Exercise
 import com.litus_animae.refitted.ui.compose.exercise.add.ExercisePickerList
@@ -78,6 +80,7 @@ fun Top() {
     }
     composable("add-exercise/{workout}/{day}/{muscle}") {
       val exerciseModel: ExerciseViewModel = hiltViewModel(it)
+      val workoutModel: WorkoutViewModel = hiltViewModel(it)
       val workoutId = it.arguments?.getString("workout")
       val day = it.arguments?.getString("day")
       val muscle = it.arguments?.getString("muscle")?.let(Uri::decode)
@@ -86,6 +89,10 @@ fun Top() {
           .collectAsStateWithLifecycle(initialValue = emptyList())
         val accessibleWorkouts by exerciseModel.accessibleWorkouts
           .collectAsStateWithLifecycle(initialValue = emptyList())
+        // The plan list itself (accessibleWorkouts) only updates when this same paging refresh
+        // runs - reusing it rather than a separate sync path keeps this screen's "refresh the
+        // plan list" in lockstep with the drawer's.
+        val workoutPlansPagingItems = workoutModel.workouts.collectAsLazyPagingItems()
         ExercisePickerList(
           muscle = muscle,
           // Exclude the plan being built itself - a custom plan is assembled from admin
@@ -104,7 +111,9 @@ fun Top() {
             // Pop the whole add-exercise sub-flow at once, back to the day screen.
             controller.popBackStack("exercise/{workout}/{day}/{editing}", inclusive = false)
           },
-          onBack = { controller.popBackStack() }
+          onBack = { controller.popBackStack() },
+          onRefreshWorkouts = { workoutPlansPagingItems.refresh() },
+          isRefreshingWorkouts = workoutPlansPagingItems.loadState.refresh is LoadState.Loading
         )
       } else {
         controller.navigate("calendar")

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
@@ -84,7 +84,7 @@ fun Top() {
       if (workoutId != null && day != null && muscle != null) {
         val localExercises by remember(muscle) { exerciseModel.exercisesByMuscle(muscle) }
           .collectAsStateWithLifecycle(initialValue = emptyList())
-        val accessibleWorkoutNames by exerciseModel.accessibleWorkoutNames
+        val accessibleWorkouts by exerciseModel.accessibleWorkouts
           .collectAsStateWithLifecycle(initialValue = emptyList())
         ExercisePickerList(
           muscle = muscle,
@@ -93,7 +93,7 @@ fun Top() {
           localExercisesByWorkout = localExercises
             .filter { it.workout != workoutId }
             .groupBy { it.workout },
-          accessibleWorkoutNames = accessibleWorkoutNames,
+          accessibleWorkouts = accessibleWorkouts,
           remoteExercisesByWorkout = exerciseModel.remoteExercisesByWorkout,
           loadingWorkouts = exerciseModel.loadingWorkouts,
           onLoadWorkout = { workout -> exerciseModel.loadRemoteExercises(workout, muscle) },

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
@@ -146,7 +146,9 @@ private data class PickerSection(val name: String, val kind: PlanKind, val isRem
  * cost of browsing a library sits with whoever taps into it. Custom plans - including the one
  * being edited - only ever show local matches: they're built *from* admin content and have
  * nothing of their own to load remotely. Picking an exercise reuses its exact id so its record
- * history carries over ([onPick]).
+ * history carries over ([onPick]). Every section starts collapsed - [onRefreshWorkouts] is a
+ * separate top-bar action re-syncing the plan list itself (new/removed plans), not any one
+ * plan's exercises.
  */
 @Composable
 fun ExercisePickerList(
@@ -159,6 +161,9 @@ fun ExercisePickerList(
   onLoadWorkout: (String) -> Unit,
   onPick: (Exercise) -> Unit,
   onBack: () -> Unit,
+  /** Re-syncs [accessibleWorkouts] itself (new/removed plans) - separate from a section's own onLoadWorkout, which only refreshes that plan's exercises. */
+  onRefreshWorkouts: () -> Unit,
+  isRefreshingWorkouts: Boolean,
   modifier: Modifier = Modifier
 ) {
   val accessibleNames = accessibleWorkouts.map { it.workout }.toSet()
@@ -170,7 +175,9 @@ fun ExercisePickerList(
     .distinctBy { it.name }
     .sortedWith(compareBy({ it.kind.ordinal }, { it.name }))
   val firstProgramIndex = sections.indexOfFirst { it.kind == PlanKind.PROGRAM }
-  var collapsedWorkouts by rememberSaveable { mutableStateOf(setOf<String>()) }
+  // Empty by default means every section starts collapsed - with a location/equipment library
+  // run plus every program, a fully expanded list is more than fits on screen at once.
+  var expandedWorkouts by rememberSaveable { mutableStateOf(setOf<String>()) }
   Scaffold(
     contentWindowInsets = WindowInsets.navigationBars.union(WindowInsets.displayCutout),
     modifier = modifier,
@@ -183,6 +190,22 @@ fun ExercisePickerList(
         backgroundColor = MaterialTheme.colors.primary,
         navigationIcon = {
           IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, "back") }
+        },
+        actions = {
+          if (isRefreshingWorkouts) {
+            CircularProgressIndicator(
+              Modifier
+                .padding(12.dp)
+                .size(20.dp),
+              color = MaterialTheme.colors.onPrimary,
+              strokeWidth = 2.dp
+            )
+          } else {
+            IconButton(onClick = onRefreshWorkouts) {
+              // TODO localize
+              Icon(Icons.Default.Refresh, contentDescription = "refresh plan list")
+            }
+          }
         }
       )
     }
@@ -219,7 +242,7 @@ fun ExercisePickerList(
         // rather than "not checked yet".
         val knowsCount = !isRemoteSource || hasFetched || exercises.isNotEmpty()
 
-        val isCollapsed = workout in collapsedWorkouts
+        val isCollapsed = workout !in expandedWorkouts
         item(key = "header:$workout") {
           Row(
             Modifier
@@ -231,7 +254,7 @@ fun ExercisePickerList(
             Row(
               Modifier
                 .clickable(onClickLabel = if (isCollapsed) "expand $workout" else "collapse $workout") {
-                  collapsedWorkouts = if (isCollapsed) collapsedWorkouts - workout else collapsedWorkouts + workout
+                  expandedWorkouts = if (isCollapsed) expandedWorkouts + workout else expandedWorkouts - workout
                 }
                 .padding(end = 4.dp),
               verticalAlignment = Alignment.CenterVertically
@@ -483,7 +506,9 @@ private fun PreviewExercisePickerList() {
       loadingWorkouts = emptyMap(),
       onLoadWorkout = {},
       onPick = {},
-      onBack = {}
+      onBack = {},
+      onRefreshWorkouts = {},
+      isRefreshingWorkouts = false
     )
   }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
@@ -354,8 +354,7 @@ private val backBodyParts = listOf(
   BodyPart("Lats", 45, 63, 60, 52, RoundedCornerShape(10.dp)),
   BodyPart("Triceps", 26, 64, 15, 46, roundedPart),
   BodyPart("Triceps", 109, 64, 15, 46, roundedPart),
-  // Lower back dropped: no admin program has ever stored an exercise under that prefix.
-  BodyPart(null, 55, 118, 40, 24, roundedPart),
+  BodyPart("Lower back", 55, 118, 40, 24, roundedPart),
   BodyPart("Glutes", 47, 145, 56, 26, RoundedCornerShape(12.dp)),
   BodyPart("Hamstrings", 47, 175, 24, 72, RoundedCornerShape(12.dp)),
   BodyPart("Hamstrings", 79, 175, 24, 72, RoundedCornerShape(12.dp)),

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -62,6 +63,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.litus_animae.refitted.data.models.Exercise
 import com.litus_animae.refitted.data.models.MuscleGroup
+import com.litus_animae.refitted.data.models.PlanKind
+import com.litus_animae.refitted.data.models.WorkoutPlan
 
 private val muscleGroups = MuscleGroup.displayNames()
 
@@ -131,11 +134,16 @@ fun MuscleGroupPickerScreen(
   }
 }
 
+/** A section of [ExercisePickerList] - one accessible plan, ordered by [kind] then name. */
+private data class PickerSection(val name: String, val kind: PlanKind, val isRemoteSource: Boolean)
+
 /**
- * Exercise-list screen (design 1j) - workouts the user can pull exercises from, as sections.
+ * Exercise-list screen (design 1j) - plans the user can pull exercises from, as sections, equipment
+ * libraries ([PlanKind.LOCATION]/[PlanKind.EQUIPMENT]) first and admin programs after a divider.
  * Locally-synced matches ([localExercisesByWorkout]) render immediately; other accessible
- * (admin-authored) workouts render a "Load exercises" row that triggers an on-demand remote query
- * ([onLoadWorkout] - see ExerciseViewModel.loadRemoteExercises). Custom plans - including the one
+ * (admin-authored) plans render a "Load exercises" row that triggers an on-demand remote query
+ * ([onLoadWorkout] - see ExerciseViewModel.loadRemoteExercises) - nothing is pre-fetched, so the
+ * cost of browsing a library sits with whoever taps into it. Custom plans - including the one
  * being edited - only ever show local matches: they're built *from* admin content and have
  * nothing of their own to load remotely. Picking an exercise reuses its exact id so its record
  * history carries over ([onPick]).
@@ -144,7 +152,7 @@ fun MuscleGroupPickerScreen(
 fun ExercisePickerList(
   muscle: String,
   localExercisesByWorkout: Map<String, List<Exercise>>,
-  accessibleWorkoutNames: List<String>,
+  accessibleWorkouts: List<WorkoutPlan>,
   /** Keyed by (workout, muscle) - a workout's cached rows are only ever for this screen's own muscle. */
   remoteExercisesByWorkout: Map<Pair<String, String>, List<Exercise>>,
   loadingWorkouts: Map<Pair<String, String>, Boolean>,
@@ -153,9 +161,15 @@ fun ExercisePickerList(
   onBack: () -> Unit,
   modifier: Modifier = Modifier
 ) {
-  val workouts = (accessibleWorkoutNames + localExercisesByWorkout.keys)
-    .distinct()
-    .sorted()
+  val accessibleNames = accessibleWorkouts.map { it.workout }.toSet()
+  val sections = (
+    accessibleWorkouts.map { PickerSection(it.workout, it.kind, isRemoteSource = true) } +
+      localExercisesByWorkout.keys.filter { it !in accessibleNames }
+        .map { PickerSection(it, PlanKind.PROGRAM, isRemoteSource = false) }
+    )
+    .distinctBy { it.name }
+    .sortedWith(compareBy({ it.kind.ordinal }, { it.name }))
+  val firstProgramIndex = sections.indexOfFirst { it.kind == PlanKind.PROGRAM }
   var collapsedWorkouts by rememberSaveable { mutableStateOf(setOf<String>()) }
   Scaffold(
     contentWindowInsets = WindowInsets.navigationBars.union(WindowInsets.displayCutout),
@@ -174,10 +188,25 @@ fun ExercisePickerList(
     }
   ) { contentPadding ->
     LazyColumn(Modifier.padding(contentPadding).fillMaxSize()) {
-      workouts.forEach { workout ->
+      sections.forEachIndexed { index, section ->
+        val workout = section.name
+        if (index == firstProgramIndex && index > 0) {
+          item(key = "kind-divider") {
+            CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.disabled) {
+              // TODO localize
+              Text(
+                "— programs —",
+                Modifier
+                  .fillMaxWidth()
+                  .padding(start = 10.dp, top = 18.dp, bottom = 2.dp),
+                style = MaterialTheme.typography.overline
+              )
+            }
+          }
+        }
         // Custom plans have no remote catalog of their own (see the KDoc above) - only ever
         // appear here from localExercisesByWorkout, so they get no refresh affordance.
-        val isRemoteSource = workout in accessibleWorkoutNames
+        val isRemoteSource = section.isRemoteSource
         val loading = loadingWorkouts[workout to muscle] == true
         val hasFetched = remoteExercisesByWorkout.containsKey(workout to muscle)
         // Merge rather than local ?: remote - a workout opened locally for one day is only
@@ -185,6 +214,10 @@ fun ExercisePickerList(
         val exercises = (localExercisesByWorkout[workout].orEmpty() + remoteExercisesByWorkout[workout to muscle].orEmpty())
           .distinctBy { it.id }
           .sortedBy { it.name ?: it.id }
+        // A remote section's count isn't meaningful until it's been fetched at least once (or a
+        // local cache already answers it) - showing 0 before that would read as "nothing here"
+        // rather than "not checked yet".
+        val knowsCount = !isRemoteSource || hasFetched || exercises.isNotEmpty()
 
         val isCollapsed = workout in collapsedWorkouts
         item(key = "header:$workout") {
@@ -216,6 +249,12 @@ fun ExercisePickerList(
                   .rotate(rotation)
               )
               Text(workout, style = MaterialTheme.typography.overline)
+              if (knowsCount) {
+                Spacer(Modifier.width(6.dp))
+                CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                  Text(exercises.size.toString(), style = MaterialTheme.typography.overline)
+                }
+              }
             }
             if (isRemoteSource) {
               if (loading) {
@@ -236,7 +275,7 @@ fun ExercisePickerList(
             }
           }
         }
-        if (isCollapsed) return@forEach
+        if (isCollapsed) return@forEachIndexed
         when {
           exercises.isEmpty() && loading -> item(key = "loading:$workout") {
             Row(
@@ -429,9 +468,15 @@ private fun PreviewExercisePickerList() {
           Exercise("Push Pull Legs", "Chest_Push-Up")
         )
       ),
-      accessibleWorkoutNames = listOf("Push Pull Legs", "Full Body"),
-      // "Push Pull Legs" shows the merge of its cached local row plus a remote fetch already in
-      // hand; "Full Body" has never been fetched, so it falls through to "Refresh to load".
+      accessibleWorkouts = listOf(
+        WorkoutPlan("Planet Fitness", kind = PlanKind.LOCATION),
+        WorkoutPlan("Push Pull Legs"),
+        WorkoutPlan("Full Body")
+      ),
+      // "Planet Fitness" sorts first as a LOCATION and has never been fetched, so it falls through
+      // to "Refresh to load". "Push Pull Legs" shows the merge of its cached local row plus a
+      // remote fetch already in hand. "Full Body" is a PROGRAM, sorted after the "— programs —"
+      // divider, and also unfetched.
       remoteExercisesByWorkout = mapOf(
         ("Push Pull Legs" to "Chest") to listOf(Exercise("Push Pull Legs", "Chest_Incline Dumbbell Press"))
       ),

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -257,7 +257,7 @@ class ExerciseViewModel @Inject constructor(
 
   // Add-exercise picker (muscle group browsing) - local matches are live; remote matches are
   // fetched per-workout on demand since browsing shouldn't pull every accessible plan's catalog.
-  val accessibleWorkoutNames = workoutPlanRepo.accessibleWorkoutNames
+  val accessibleWorkouts = workoutPlanRepo.accessibleWorkouts
 
   fun exercisesByMuscle(muscle: String): Flow<List<Exercise>> = exerciseRepo.exercisesByMuscle(muscle)
 


### PR DESCRIPTION
## Summary
- Adds `PlanKind` (`LOCATION` / `EQUIPMENT` / `PROGRAM`) so a plan can carry exercises without being a selectable program in the drawer
- The add-exercise picker sorts accessible plans by kind - equipment libraries first, a divider, then programs - with per-section collapse (collapsed by default) and match counts once a section is known
- A picker-page refresh action re-syncs the plan list via the existing `WorkoutViewModel.workouts` paging refresh, same path the drawer's refresh button already uses
- Restores "Lower back" as a queryable muscle group, distinct from `LATS`'s `Back` prefix
- Adds `scripts/seed_libraries.py` to seed library content into DynamoDB from gitignored `content/libraries/*.json`, validating every exercise id's muscle prefix before writing anything

## Test plan
- [x] `python scripts/seed_libraries.py --dry-run` validates all 10 authored libraries (165 exercises) with no errors
- [x] Run `scripts/seed_libraries.py` for real against `refitted.dev01`, grant each group access to the new library plan names via `web/app/admin/workouts`, then verify on device: no Dynamo traffic until a section's refresh is tapped, a fetched-empty section still shows `0` and its refresh icon rather than disappearing, and the Lower back region on the body diagram selects correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)