### PR TITLE
Add an effort-scored chart to exercise and set history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,3 +340,7 @@ All three components share the same AWS DynamoDB backend for data storage.
 - Each commit should build on its own — avoid a commit that only compiles once a later commit lands.
 - Prefer succinct commit messages over long ones — a short message that explains what's not obvious from the diff beats a detailed one.
 - Do not add a `Claude-Session` link or similar session-tracking trailer to commit messages unless explicitly asked. A `Co-Authored-By` trailer is fine.
+
+## Pull Request Conventions
+
+- Do not include a test plan checklist of CI-run commands (`./gradlew test`, `assembleDebug`, `lint`, etc.) in the PR description — CI (`.github/workflows/build.yml`) already runs these on every push, so listing them as manual checkboxes is redundant. If a test plan section is useful, keep it to what CI *doesn't* cover (on-device/manual verification steps, specific scenarios to check by hand).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,7 @@ The Android app is organized into the following Gradle modules:
 | DAOs | :room | `room/.../*Dao.kt` |
 | Network Services | :dynamo | `dynamo/.../Dynamo*NetworkService.kt` |
 | Firebase Providers | :identity | `identity/.../*Provider.kt` |
+| In-app changelog | :ui | `ui/src/main/res/values/changelog.xml`, `ui/.../compose/Changelog.kt` |
 
 Note: Paths abbreviated with `...` represent the full package path `com/litus_animae/refitted/`
 
@@ -330,6 +331,7 @@ All three components share the same AWS DynamoDB backend for data storage.
 - Keep modules focused: domain logic in `:data`, persistence in `:room`, UI in `:ui`, etc.
 - Repository implementations in `:app` bridge multiple data sources (Room + DynamoDB)
 - Do not add comments explaining what code does when the code is self-explanatory. Only comment non-obvious *why* (a hidden constraint, a workaround, a subtle invariant) — never restate the *what*. Prefer putting that *why* in the commit message over a code comment when it's about the change itself rather than a lasting property of the code
+- User-facing changes should get an entry in `ui/src/main/res/values/changelog.xml` (a `string-array` where an item starting with `**` is a version header, e.g. `**v1.4.0`, and following items are bullets shown under it). New entries go under the current in-progress version header at the top rather than bumping the version — the in-app dialog (`Changelog.kt`, gated in `UserViewModel.shouldShowChangelog()`) fires once per change in `versionCode` (`app/build.gradle`), not per changelog edit, so editing this file alone is safe and doesn't trigger anything for existing users until a release bumps the version. Keep entries short and benefit-oriented, not implementation detail. Order bullets within a version by importance/impact to the user, not chronologically by when they landed — reorder existing entries in that version if a new one outranks them.
 
 ## Commit Conventions
 

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -36,8 +36,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
@@ -366,7 +368,16 @@ class RoomCacheExerciseRepository @Inject constructor(
       Pager(config = PagingConfig(pageSize = 20)) {
         refittedRoom.getExerciseDao().getAllSetRecord(e.exerciseName)
       }.flow.map { it.map { roomRecord -> roomRecord.toDomain() } },
-      currentRecords
+      currentRecords,
+      // The DAO call itself is deferred inside this builder - like the Pager above - so
+      // building an ExerciseRecord never queries Room unless recentSets is collected.
+      flow {
+        emitAll(
+          refittedRoom.getExerciseDao()
+            .getRecentSetRecords(e.exerciseName, SET_RECORD_HISTORY_LIMIT)
+            .map { rows -> rows.asReversed().map { it.toDomain() } }
+        )
+      }.flowOn(Dispatchers.IO)
     )
   }
 
@@ -423,5 +434,9 @@ class RoomCacheExerciseRepository @Inject constructor(
   companion object {
     private const val TAG = "RoomCacheExerciseRepository"
     private const val LOADING_INDICATOR_DEBOUNCE_MILLIS = 250L
+
+    // ~100+ sessions of history; the effort model's recency weighting makes anything
+    // beyond that numerically irrelevant, so there's no reason to load more into memory.
+    private const val SET_RECORD_HISTORY_LIMIT = 400
   }
 }

--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -365,7 +365,11 @@ class RoomCacheExerciseRepository @Inject constructor(
       e,
       defaultRecord,
       latestRecord,
-      Pager(config = PagingConfig(pageSize = 20)) {
+      // initialLoadSize defaults to pageSize * 3 - too little history for the effort
+      // chart's fit to be stable on first composition. A large first page means the
+      // trend only ever refines (recency-weighted, so old sessions barely move it) as
+      // later pages load, rather than visibly refitting.
+      Pager(config = PagingConfig(pageSize = 20, initialLoadSize = 400)) {
         refittedRoom.getExerciseDao().getAllSetRecord(e.exerciseName)
       }.flow.map { it.map { roomRecord -> roomRecord.toDomain() } },
       currentRecords,

--- a/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
+++ b/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
@@ -20,6 +20,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.emptyFlow
@@ -313,6 +314,46 @@ class RoomCacheExerciseRepositoryTest {
         cancelAndIgnoreRemainingEvents()
       }
     }
+    @Test
+    fun `recentSets is not queried until collected`() = runTest {
+      // Given
+      val runTime = Instant.now()
+      setupGetSetRecords(runTime, simpleExerciseSet, emptyList())
+      every { exerciseDao.getLatestSetRecord(simpleExerciseSet.exerciseName) } returns flowOf(null)
+
+      // When - building the record alone must not touch Room, same laziness as the allSets Pager
+      subject.buildExerciseRecord(simpleExerciseSet, runTime)
+
+      // Then
+      verify(exactly = 0) { exerciseDao.getRecentSetRecords(any(), any()) }
+    }
+
+    @Test
+    fun `recentSets reverses the DAO's newest-first rows to chronological order`() = runTest {
+      // Given
+      val runTime = Instant.now()
+      setupGetSetRecords(runTime, simpleExerciseSet, emptyList())
+      every { exerciseDao.getLatestSetRecord(simpleExerciseSet.exerciseName) } returns flowOf(null)
+      val older = SetRecord(90.0, 8, simpleExerciseSet)
+        .copy(completed = runTime.minus(2, ChronoUnit.DAYS))
+      val newer = SetRecord(95.0, 8, simpleExerciseSet)
+        .copy(completed = runTime.minus(1, ChronoUnit.DAYS))
+      // DAO returns newest-first (order by completed desc) - 400 is
+      // RoomCacheExerciseRepository's private SET_RECORD_HISTORY_LIMIT.
+      every {
+        exerciseDao.getRecentSetRecords(simpleExerciseSet.exerciseName, 400)
+      } returns flowOf(listOf(newer, older).map { RoomSetRecord.fromDomain(it) })
+
+      // When
+      val result = subject.buildExerciseRecord(simpleExerciseSet, runTime)
+
+      // Then
+      result.recentSets.test {
+        assertThat(awaitItem()).isEqualTo(listOf(older, newer))
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+
     // TODO test buildNewDayUnstoredRecord directly to test different day behavior
   }
 

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortConfig.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortConfig.kt
@@ -1,10 +1,10 @@
 package com.litus_animae.refitted.data.effort
 
 /**
- * Tunables for [EffortModel]. See `docs/exercise-history-chart.md` for the design this
- * implements.
+ * Tunables for [EffortModel]'s adaptive, causally-fit expectation of demonstrated capacity.
  *
- * [residualScaleFloorFraction] intentionally deviates from that doc's 2.5%: at 2.5% the
+ * [residualScaleFloorFraction] intentionally deviates from the original 2.5% design target:
+ * at 2.5% the
  * floor only ever binds on a near-flat history, and there it makes a small, plausible
  * improvement (e.g. +5 lb on a plateau) score as "implausibly far above" and get punished
  * — the opposite of what an adaptive curve should reward. 5% keeps that case in the

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortConfig.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortConfig.kt
@@ -18,7 +18,11 @@ data class EffortConfig(
   val residualScaleFloorFraction: Double = 0.05,
   val maxExtrapolationDays: Long = 14,
   val shrinkToMean: Boolean = true,
-  val maxAbsZ: Double = 6.0
+  val maxAbsZ: Double = 6.0,
+  // Only consulted by EffortModel.scoreWithBootstrap - how many individual sets from
+  // strictly prior sessions are needed before its coarser, strip-only stand-in trend can
+  // render at all. Mirrors minPriorSessions' role for the real fit.
+  val minPriorSetsForBootstrap: Int = 3
 ) {
   companion object {
     val Default = EffortConfig()

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortConfig.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortConfig.kt
@@ -1,0 +1,26 @@
+package com.litus_animae.refitted.data.effort
+
+/**
+ * Tunables for [EffortModel]. See `docs/exercise-history-chart.md` for the design this
+ * implements.
+ *
+ * [residualScaleFloorFraction] intentionally deviates from that doc's 2.5%: at 2.5% the
+ * floor only ever binds on a near-flat history, and there it makes a small, plausible
+ * improvement (e.g. +5 lb on a plateau) score as "implausibly far above" and get punished
+ * — the opposite of what an adaptive curve should reward. 5% keeps that case in the
+ * growth zone; see the worked-examples test for the numbers this changes.
+ */
+data class EffortConfig(
+  val repCap: Int = 15,
+  val epleyDivisor: Double = 30.0,
+  val halfLifeSessions: Double = 9.0,
+  val minPriorSessions: Int = 3,
+  val residualScaleFloorFraction: Double = 0.05,
+  val maxExtrapolationDays: Long = 14,
+  val shrinkToMean: Boolean = true,
+  val maxAbsZ: Double = 6.0
+) {
+  companion object {
+    val Default = EffortConfig()
+  }
+}

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
@@ -9,8 +9,12 @@ import kotlin.math.pow
 import kotlin.math.sqrt
 
 /**
- * Scores sets against an adaptive, causally-fit expectation of demonstrated capacity.
- * See `docs/exercise-history-chart.md` for the design this implements.
+ * Scores each completed set's demonstrated capacity (weight x reps, Epley-style) against an
+ * adaptive, causally-fit expectation of what a session "should" look like given training
+ * history - never a static baseline, and a session's own outcome never judges itself. A set
+ * scores larger (see [bubbleSize]) the closer it lands to or just above that expectation,
+ * and shrinks again once it's implausibly far above - a likely fluke or typo, still worth
+ * showing but not the target to chase.
  */
 object EffortModel {
 

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
@@ -207,4 +207,140 @@ object EffortModel {
 
     return EffortSeries(scoredSets, trendPoints)
   }
+
+  /**
+   * Strip-only augmentation of [score]: for a session still COLD under the real, session-best
+   * fit (fewer than [EffortConfig.minPriorSessions] prior sessions), fits a second, coarser
+   * regression over individual set capacities from strictly prior sessions instead of
+   * session-bests, so a chart with too little history to trust a session-best fit still has
+   * something real to show rather than a screen of neutral grey. [score] itself is untouched
+   * by this - the doc spec's cold-start rule and every session at or past
+   * [EffortConfig.minPriorSessions] behave identically to calling [score] directly, just
+   * tagged [ExpectationSource.SESSION] instead of left `null`.
+   *
+   * Gated on [EffortConfig.minPriorSetsForBootstrap] sets accumulated from sessions strictly
+   * before the one being scored - never the current session's own sets, so logging a set never
+   * moves that same set's own comparison value (the same causal, fold-in-after-scoring
+   * discipline [score] uses for sessions, just at set granularity). Concretely: a first-ever
+   * session is always all-COLD no matter how many sets it has, since no prior session exists
+   * yet to bootstrap from.
+   */
+  fun scoreWithBootstrap(
+    sets: List<EffortSet>,
+    zone: ZoneId = ZoneId.systemDefault(),
+    config: EffortConfig = EffortConfig.Default
+  ): EffortSeries {
+    val real = score(sets, zone, config)
+    if (real.sets.isEmpty()) return real
+
+    val sessions = sets
+      .sortedBy { it.completed }
+      .groupBy { it.completed.atZone(zone).toLocalDate() }
+      .toSortedMap()
+      .values
+      .toList()
+
+    val decay = 0.5.pow(1.0 / config.halfLifeSessions)
+
+    // Recency-weighted causal regression over individual prior-session set capacities - same
+    // shrink-to-mean shape as score()'s session-best regression, just keyed by a running
+    // set-sequence x instead of day-offset, and fit only on sets from sessions strictly
+    // before the one it predicts for.
+    var sumW = 0.0
+    var sumWx = 0.0
+    var sumWy = 0.0
+    var sumWxx = 0.0
+    var sumWxy = 0.0
+    var sumRepsW = 0.0
+    var sumRepsWr = 0.0
+    var priorSetCount = 0
+    var x = 0.0
+
+    var realIndex = 0
+    val scoredSets = mutableListOf<ScoredSet>()
+    val trendPoints = mutableListOf<TrendPoint>()
+
+    sessions.forEach { sessionSets ->
+      val firstReal = real.sets[realIndex]
+      val useBootstrap = firstReal.expectation == null &&
+        priorSetCount >= config.minPriorSetsForBootstrap
+
+      if (useBootstrap) {
+        val meanY = sumWy / sumW
+        val den = sumW * sumWxx - sumWx * sumWx
+        val cHat = if (abs(den) < 1e-9) {
+          meanY
+        } else {
+          val slope = (sumW * sumWxy - sumWx * sumWy) / den
+          val intercept = (sumWy - slope * sumWx) / sumW
+          (intercept + slope * x).coerceIn(0.5 * meanY, 1.5 * meanY)
+        }
+        // No fitted residual pass here - too little data yet to trust one - always the floor.
+        val residualScale = max(config.residualScaleFloorFraction * cHat, 1e-6)
+        val rHat = (sumRepsWr / sumRepsW).coerceIn(1.0, config.repCap.toDouble())
+        val wHat = cHat / (1 + rHat / config.epleyDivisor)
+
+        trendPoints.add(
+          TrendPoint(
+            sessionIndex = firstReal.sessionIndex,
+            dayOffset = firstReal.dayOffset,
+            at = sessionSets.first().completed,
+            expectedCapacity = cHat,
+            typicalReps = rHat,
+            expectedWeight = wHat,
+            expectationSource = ExpectationSource.BOOTSTRAP
+          )
+        )
+
+        sessionSets.forEach { effortSet ->
+          val c = capacity(effortSet.weight, effortSet.reps, config)
+          val z = ((c - cHat) / residualScale).coerceIn(-config.maxAbsZ, config.maxAbsZ)
+          scoredSets.add(
+            real.sets[realIndex].copy(
+              expectation = cHat,
+              z = z,
+              size = bubbleSize(z),
+              zone = zoneOf(z),
+              expectationSource = ExpectationSource.BOOTSTRAP
+            )
+          )
+          realIndex++
+        }
+      } else {
+        sessionSets.forEach { _ ->
+          val scored = real.sets[realIndex]
+          scoredSets.add(
+            if (scored.expectation != null) {
+              scored.copy(expectationSource = ExpectationSource.SESSION)
+            } else {
+              scored
+            }
+          )
+          realIndex++
+        }
+        real.trend.firstOrNull { it.sessionIndex == firstReal.sessionIndex }?.let {
+          trendPoints.add(it.copy(expectationSource = ExpectationSource.SESSION))
+        }
+      }
+
+      // Fold in after scoring, same discipline as score() - a session's own sets never move
+      // its own bootstrap value.
+      sumW *= decay; sumWx *= decay; sumWy *= decay; sumWxx *= decay; sumWxy *= decay
+      sumRepsW *= decay; sumRepsWr *= decay
+      sessionSets.forEach { effortSet ->
+        val c = capacity(effortSet.weight, effortSet.reps, config)
+        sumW += 1.0
+        sumWx += x
+        sumWy += c
+        sumWxx += x * x
+        sumWxy += x * c
+        sumRepsW += 1.0
+        sumRepsWr += effortSet.reps.coerceIn(0, config.repCap).toDouble()
+        priorSetCount += 1
+        x += 1.0
+      }
+    }
+
+    return EffortSeries(scoredSets, trendPoints.sortedBy { it.sessionIndex })
+  }
 }

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
@@ -1,0 +1,210 @@
+package com.litus_animae.refitted.data.effort
+
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+/**
+ * Scores sets against an adaptive, causally-fit expectation of demonstrated capacity.
+ * See `docs/exercise-history-chart.md` for the design this implements.
+ */
+object EffortModel {
+
+  const val NEUTRAL_SIZE = 0.45f
+
+  // z -> bubble size anchors. Piecewise-linear rather than smoothstep so "slightly above
+  // the curve" (z around 0.2-0.5) stays visually distinct from "on the curve" (z = 0).
+  private val HUMP_ANCHORS = listOf(
+    -2.0 to 0.00,
+    -1.0 to 0.30,
+    0.0 to 0.60,
+    0.5 to 0.85,
+    1.0 to 1.00,
+    1.5 to 0.90,
+    2.5 to 0.40
+  )
+
+  /** Epley-style estimated 1RM, the single scale weight×reps sets are compared on. */
+  fun capacity(weight: Double, reps: Int, config: EffortConfig = EffortConfig.Default): Double {
+    val clampedReps = reps.coerceIn(0, config.repCap)
+    return max(weight, 0.0) * (1 + clampedReps.toDouble() / config.epleyDivisor)
+  }
+
+  fun bubbleSize(z: Double?): Float {
+    if (z == null) return NEUTRAL_SIZE
+    if (z <= HUMP_ANCHORS.first().first) return HUMP_ANCHORS.first().second.toFloat()
+    if (z >= HUMP_ANCHORS.last().first) return HUMP_ANCHORS.last().second.toFloat()
+    for (i in 0 until HUMP_ANCHORS.size - 1) {
+      val (x0, y0) = HUMP_ANCHORS[i]
+      val (x1, y1) = HUMP_ANCHORS[i + 1]
+      if (z <= x1) {
+        val t = (z - x0) / (x1 - x0)
+        return (y0 + t * (y1 - y0)).toFloat()
+      }
+    }
+    return HUMP_ANCHORS.last().second.toFloat()
+  }
+
+  fun zoneOf(z: Double?): EffortZone = when {
+    z == null -> EffortZone.COLD
+    z < -1.0 -> EffortZone.BELOW
+    z < 0.5 -> EffortZone.ON_CURVE
+    z < 2.0 -> EffortZone.GROWTH
+    else -> EffortZone.IMPLAUSIBLE
+  }
+
+  /**
+   * Groups [sets] into calendar-day sessions (in [zone]) and scores every set against a
+   * recency-weighted linear regression of session-best capacity, fit only on sessions
+   * strictly before it (causal / one-step-ahead).
+   *
+   * The regression's x-domain is always day-offset-from-first-session, never a caller's
+   * chart x — the drawer, the exercise-page strip, and the day-exploded variant each use a
+   * different x treatment, and a fit that depended on which one was rendering it would be
+   * wrong.
+   */
+  fun score(
+    sets: List<EffortSet>,
+    zone: ZoneId = ZoneId.systemDefault(),
+    config: EffortConfig = EffortConfig.Default
+  ): EffortSeries {
+    if (sets.isEmpty()) return EffortSeries.Empty
+
+    val sessions = sets
+      .sortedBy { it.completed }
+      .groupBy { it.completed.atZone(zone).toLocalDate() }
+      .toSortedMap()
+      .values
+      .toList()
+
+    val firstDay = sessions.first().first().completed.atZone(zone).toLocalDate()
+    val decay = 0.5.pow(1.0 / config.halfLifeSessions)
+
+    // Regression accumulators (recency-weighted sums of x=dayOffset, y=session-best capacity).
+    var sumW = 0.0
+    var sumWx = 0.0
+    var sumWy = 0.0
+    var sumWxx = 0.0
+    var sumWxy = 0.0
+
+    // Residual-scale accumulators, folded only for sessions that themselves had a prediction.
+    var sumResidualW = 0.0
+    var sumResidualWe2 = 0.0
+
+    // Typical-reps accumulators (session-best reps).
+    var sumRepsW = 0.0
+    var sumRepsWr = 0.0
+
+    var priorSessionCount = 0
+    var lastPriorDayOffset = 0L
+
+    val scoredSets = mutableListOf<ScoredSet>()
+    val trendPoints = mutableListOf<TrendPoint>()
+
+    sessions.forEachIndexed { sessionIndex, sessionSets ->
+      val day = sessionSets.first().completed.atZone(zone).toLocalDate()
+      val dayOffset = ChronoUnit.DAYS.between(firstDay, day)
+
+      var bestCapacity = capacity(sessionSets[0].weight, sessionSets[0].reps, config)
+      var bestReps = sessionSets[0].reps.coerceIn(0, config.repCap)
+      for (i in 1 until sessionSets.size) {
+        val c = capacity(sessionSets[i].weight, sessionSets[i].reps, config)
+        val r = sessionSets[i].reps.coerceIn(0, config.repCap)
+        if (c > bestCapacity || (c == bestCapacity && r > bestReps)) {
+          bestCapacity = c
+          bestReps = r
+        }
+      }
+
+      var expectedCapacity: Double? = null
+      var residualScale: Double? = null
+
+      if (priorSessionCount >= config.minPriorSessions) {
+        val xEff = min(dayOffset, lastPriorDayOffset + config.maxExtrapolationDays).toDouble()
+        val den = sumW * sumWxx - sumWx * sumWx
+        val meanY = sumWy / sumW
+        val raw = if (abs(den) < 1e-9) {
+          meanY
+        } else {
+          val slope = (sumW * sumWxy - sumWx * sumWy) / den
+          val intercept = (sumWy - slope * sumWx) / sumW
+          intercept + slope * xEff
+        }
+        // A causal fit on only 3-4 sessions extrapolates wildly; shrink toward the
+        // recency-weighted mean until enough sessions have accumulated to trust the slope.
+        val lambda = ((priorSessionCount - 2) / 4.0).coerceIn(0.0, 1.0)
+        val shrunk = if (config.shrinkToMean) lambda * raw + (1 - lambda) * meanY else raw
+        val cHat = shrunk.coerceIn(0.5 * meanY, 1.5 * meanY)
+        expectedCapacity = cHat
+
+        val fittedResidualScale = if (sumResidualW >= 2.0) sqrt(sumResidualWe2 / sumResidualW) else 0.0
+        residualScale = max(fittedResidualScale, max(config.residualScaleFloorFraction * cHat, 1e-6))
+
+        val rHat = (sumRepsWr / sumRepsW).coerceIn(1.0, config.repCap.toDouble())
+        val wHat = cHat / (1 + rHat / config.epleyDivisor)
+        trendPoints.add(
+          TrendPoint(
+            sessionIndex = sessionIndex,
+            dayOffset = dayOffset,
+            at = sessionSets.first().completed,
+            expectedCapacity = cHat,
+            typicalReps = rHat,
+            expectedWeight = wHat
+          )
+        )
+      }
+
+      sessionSets.forEachIndexed { setIndex, effortSet ->
+        val c = capacity(effortSet.weight, effortSet.reps, config)
+        val z = expectedCapacity?.let {
+          ((c - it) / (residualScale ?: 1.0)).coerceIn(-config.maxAbsZ, config.maxAbsZ)
+        }
+        scoredSets.add(
+          ScoredSet(
+            source = effortSet,
+            sessionIndex = sessionIndex,
+            setIndexInSession = setIndex,
+            setsInSession = sessionSets.size,
+            dayOffset = dayOffset,
+            capacity = c,
+            expectation = expectedCapacity,
+            z = z,
+            size = bubbleSize(z),
+            zone = zoneOf(z)
+          )
+        )
+      }
+
+      // Fold this session in *after* using it for prediction/scoring, so a session's
+      // outcome (a PR or a bad day) never influences its own expectation.
+      sumW *= decay; sumWx *= decay; sumWy *= decay; sumWxx *= decay; sumWxy *= decay
+      sumResidualW *= decay; sumResidualWe2 *= decay
+      sumRepsW *= decay; sumRepsWr *= decay
+
+      val x = dayOffset.toDouble()
+      sumW += 1.0
+      sumWx += x
+      sumWy += bestCapacity
+      sumWxx += x * x
+      sumWxy += x * bestCapacity
+
+      sumRepsW += 1.0
+      sumRepsWr += bestReps.toDouble()
+
+      if (expectedCapacity != null) {
+        val e = bestCapacity - expectedCapacity
+        sumResidualW += 1.0
+        sumResidualWe2 += e * e
+      }
+
+      priorSessionCount += 1
+      lastPriorDayOffset = dayOffset
+    }
+
+    return EffortSeries(scoredSets, trendPoints)
+  }
+}

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
@@ -28,10 +28,19 @@ object EffortModel {
     2.5 to 0.40
   )
 
-  /** Epley-style estimated 1RM, the single scale weight×reps sets are compared on. */
+  /**
+   * Epley-style estimated 1RM, the single scale weight×reps sets are compared on.
+   *
+   * Floored at 1.0, not 0.0 - a bodyweight-only set (no explicit "bodyweight" flag exists,
+   * so weight = 0 is how one is logged) would otherwise multiply out to 0 regardless of
+   * reps, making every bodyweight session score identically instead of tracking rep
+   * progress. z-scoring only cares about relative capacity changes session-to-session, so
+   * this tiny floor doesn't distort anything - it just keeps reps the driver until real
+   * weight gets logged, at which point the floor stops applying.
+   */
   fun capacity(weight: Double, reps: Int, config: EffortConfig = EffortConfig.Default): Double {
     val clampedReps = reps.coerceIn(0, config.repCap)
-    return max(weight, 0.0) * (1 + clampedReps.toDouble() / config.epleyDivisor)
+    return max(weight, 1.0) * (1 + clampedReps.toDouble() / config.epleyDivisor)
   }
 
   fun bubbleSize(z: Double?): Float {

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortSeries.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortSeries.kt
@@ -1,0 +1,44 @@
+package com.litus_animae.refitted.data.effort
+
+import java.time.Instant
+
+enum class EffortZone { COLD, BELOW, ON_CURVE, GROWTH, IMPLAUSIBLE }
+
+/**
+ * One completed set, scored against its session's expectation.
+ *
+ * [dayOffset] and [sessionIndex]/[setIndexInSession]/[setsInSession] are exposed rather than
+ * left implicit so a chart can build whichever x-domain it needs (calendar time, day-exploded,
+ * or plain set index) without re-deriving session structure from raw [EffortSet]s.
+ */
+data class ScoredSet(
+  val source: EffortSet,
+  val sessionIndex: Int,
+  val setIndexInSession: Int,
+  val setsInSession: Int,
+  val dayOffset: Long,
+  val capacity: Double,
+  val expectation: Double?,
+  val z: Double?,
+  val size: Float,
+  val zone: EffortZone
+)
+
+/** The fitted expectation for one session, in both capacity and weight-at-typical-reps form. */
+data class TrendPoint(
+  val sessionIndex: Int,
+  val dayOffset: Long,
+  val at: Instant,
+  val expectedCapacity: Double,
+  val typicalReps: Double,
+  val expectedWeight: Double
+)
+
+data class EffortSeries(
+  val sets: List<ScoredSet>,
+  val trend: List<TrendPoint>
+) {
+  companion object {
+    val Empty = EffortSeries(emptyList(), emptyList())
+  }
+}

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortSeries.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortSeries.kt
@@ -5,6 +5,14 @@ import java.time.Instant
 enum class EffortZone { COLD, BELOW, ON_CURVE, GROWTH, IMPLAUSIBLE }
 
 /**
+ * Which regression produced a non-null expectation: [SESSION] is [EffortModel.score]'s real,
+ * session-best fit; [BOOTSTRAP] is [EffortModel.scoreWithBootstrap]'s strip-only, per-set
+ * stand-in used while there isn't enough session history to trust the real one yet. `null`
+ * on the [ScoredSet]/[TrendPoint] this decorates means no expectation exists at all (COLD).
+ */
+enum class ExpectationSource { SESSION, BOOTSTRAP }
+
+/**
  * One completed set, scored against its session's expectation.
  *
  * [dayOffset] and [sessionIndex]/[setIndexInSession]/[setsInSession] are exposed rather than
@@ -21,7 +29,8 @@ data class ScoredSet(
   val expectation: Double?,
   val z: Double?,
   val size: Float,
-  val zone: EffortZone
+  val zone: EffortZone,
+  val expectationSource: ExpectationSource? = null
 )
 
 /** The fitted expectation for one session, in both capacity and weight-at-typical-reps form. */
@@ -31,7 +40,8 @@ data class TrendPoint(
   val at: Instant,
   val expectedCapacity: Double,
   val typicalReps: Double,
-  val expectedWeight: Double
+  val expectedWeight: Double,
+  val expectationSource: ExpectationSource? = null
 )
 
 data class EffortSeries(

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortSet.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortSet.kt
@@ -1,0 +1,20 @@
+package com.litus_animae.refitted.data.effort
+
+import com.litus_animae.refitted.data.models.Record
+import com.litus_animae.refitted.data.models.SetRecord
+import java.time.Instant
+
+/**
+ * A single completed set, reduced to the fields the effort model needs.
+ * Decouples [com.litus_animae.refitted.data.effort.EffortModel] from the
+ * persistence-facing [SetRecord] and the in-session [Record] shapes.
+ */
+data class EffortSet(
+  val completed: Instant,
+  val weight: Double,
+  val reps: Int
+)
+
+fun SetRecord.toEffortSet(): EffortSet = EffortSet(completed, weight, reps)
+
+fun Record.toEffortSet(): EffortSet = EffortSet(completed, weight, reps)

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/models/ExerciseRecord.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/models/ExerciseRecord.kt
@@ -2,6 +2,7 @@ package com.litus_animae.refitted.data.models
 
 import androidx.paging.PagingData
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.map
 
 /**
@@ -12,7 +13,8 @@ data class ExerciseRecord(
   val defaultRecord: Record,
   val latestRecord: Flow<Record>,
   val allSets: Flow<PagingData<SetRecord>>,
-  val currentRecords: Flow<List<Record>>
+  val currentRecords: Flow<List<Record>>,
+  val recentSets: Flow<List<SetRecord>> = emptyFlow()
 ) {
   val currentRecordsCount = currentRecords.map { sets -> sets.size }
 

--- a/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
+++ b/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
@@ -323,6 +323,79 @@ class EffortModelTest {
   }
 
   @Nested
+  @DisplayName("scoreWithBootstrap")
+  inner class Bootstrap {
+    @Test
+    fun `a first-ever session is all COLD no matter how many sets it has`() {
+      val firstSession = (0 until 6).map { EffortSet(day(0).plusSeconds(it * 60L), 100.0, 8) }
+      val series = EffortModel.scoreWithBootstrap(firstSession)
+
+      assertThat(series.trend).isEmpty()
+      series.sets.forEach {
+        assertThat(it.expectationSource).isNull()
+        assertThat(it.zone).isEqualTo(EffortZone.COLD)
+      }
+    }
+
+    @Test
+    fun `a second session bootstraps once 3 prior sets exist`() {
+      val firstSession = (0 until 3).map { EffortSet(day(0).plusSeconds(it * 60L), 100.0, 8) }
+      val secondSession = listOf(EffortSet(day(7), 105.0, 8))
+      val series = EffortModel.scoreWithBootstrap(firstSession + secondSession)
+
+      val second = series.sets.last()
+      assertThat(second.expectationSource).isEqualTo(ExpectationSource.BOOTSTRAP)
+      assertThat(second.expectation).isNotNull()
+      assertThat(second.zone).isNotEqualTo(EffortZone.COLD)
+      assertThat(series.trend).hasSize(1)
+      assertThat(series.trend.single().expectationSource).isEqualTo(ExpectationSource.BOOTSTRAP)
+    }
+
+    @Test
+    fun `a second session with too few prior sets stays COLD`() {
+      val firstSession = listOf(EffortSet(day(0), 100.0, 8), EffortSet(day(0).plusSeconds(60), 100.0, 8))
+      val secondSession = listOf(EffortSet(day(7), 105.0, 8))
+      val series = EffortModel.scoreWithBootstrap(firstSession + secondSession)
+
+      assertThat(series.sets.last().expectationSource).isNull()
+      assertThat(series.sets.last().zone).isEqualTo(EffortZone.COLD)
+    }
+
+    @Test
+    fun `a session's own sets never move its own bootstrap value`() {
+      val firstSession = (0 until 3).map { EffortSet(day(0).plusSeconds(it * 60L), 100.0, 8) }
+      val fewSets = listOf(EffortSet(day(7), 105.0, 8))
+      val manySets = (0 until 8).map { EffortSet(day(7).plusSeconds(it * 60L), 105.0 + it * 50, 8) }
+
+      val withFew = EffortModel.scoreWithBootstrap(firstSession + fewSets)
+      val withMany = EffortModel.scoreWithBootstrap(firstSession + manySets)
+
+      val firstDotFew = withFew.sets.first { it.sessionIndex == 1 }
+      val firstDotMany = withMany.sets.first { it.sessionIndex == 1 }
+      assertThat(firstDotMany.expectation).isWithin(1e-9).of(firstDotFew.expectation!!)
+    }
+
+    @Test
+    fun `once real session count is reached, output matches score exactly`() {
+      val sets = (0..3).map { EffortSet(day(it * 7L), 100.0 + it * 2, 8) } +
+        EffortSet(day(28), 108.0, 8)
+      val real = EffortModel.score(sets)
+      val bootstrapped = EffortModel.scoreWithBootstrap(sets)
+
+      val realFourth = real.sets.filter { it.sessionIndex == 4 }
+      val bootstrappedFourth = bootstrapped.sets.filter { it.sessionIndex == 4 }
+      assertThat(bootstrappedFourth.map { it.expectation }).isEqualTo(realFourth.map { it.expectation })
+      assertThat(bootstrappedFourth.map { it.z }).isEqualTo(realFourth.map { it.z })
+      bootstrappedFourth.forEach { assertThat(it.expectationSource).isEqualTo(ExpectationSource.SESSION) }
+    }
+
+    @Test
+    fun `empty input returns the shared Empty instance`() {
+      assertThat(EffortModel.scoreWithBootstrap(emptyList())).isSameInstanceAs(EffortSeries.Empty)
+    }
+  }
+
+  @Nested
   @DisplayName("degenerate input")
   inner class Degenerate {
     @Test

--- a/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
+++ b/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
@@ -39,8 +39,23 @@ class EffortModelTest {
     }
 
     @Test
-    fun `negative weight floors at zero`() {
-      assertThat(EffortModel.capacity(-10.0, 8)).isWithin(1e-9).of(0.0)
+    fun `negative weight floors at the same minimum as bodyweight`() {
+      assertThat(EffortModel.capacity(-10.0, 8))
+        .isWithin(1e-9).of(EffortModel.capacity(0.0, 8))
+    }
+
+    @Test
+    fun `bodyweight (zero weight) capacity still tracks reps instead of collapsing to zero`() {
+      val fewerReps = EffortModel.capacity(0.0, 5)
+      val moreReps = EffortModel.capacity(0.0, 12)
+
+      assertThat(fewerReps).isGreaterThan(0.0)
+      assertThat(moreReps).isGreaterThan(fewerReps)
+    }
+
+    @Test
+    fun `the bodyweight floor stops applying once real weight is logged`() {
+      assertThat(EffortModel.capacity(5.0, 8)).isGreaterThan(EffortModel.capacity(0.0, 8))
     }
   }
 

--- a/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
+++ b/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
@@ -1,0 +1,360 @@
+package com.litus_animae.refitted.data.effort
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+
+private val BASE: Instant = Instant.parse("2024-01-01T12:00:00Z")
+private fun day(n: Long): Instant = BASE.plus(Duration.ofDays(n))
+
+class EffortModelTest {
+
+  @Nested
+  @DisplayName("capacity")
+  inner class Capacity {
+    @Test
+    fun `matches the spec's worked examples`() {
+      assertThat(EffortModel.capacity(80.0, 15)).isWithin(1e-9).of(120.0)
+      assertThat(EffortModel.capacity(90.0, 15)).isWithin(1e-9).of(135.0)
+      assertThat(EffortModel.capacity(130.0, 3)).isWithin(1e-9).of(143.0)
+      assertThat(EffortModel.capacity(100.0, 2)).isWithin(1e-6).of(106.666666)
+      assertThat(EffortModel.capacity(100.0, 10)).isWithin(1e-6).of(133.333333)
+      assertThat(EffortModel.capacity(100.0, 12)).isWithin(1e-9).of(140.0)
+      assertThat(EffortModel.capacity(180.0, 5)).isWithin(1e-9).of(210.0)
+    }
+
+    @Test
+    fun `clamps reps at the configured cap`() {
+      assertThat(EffortModel.capacity(100.0, 20)).isWithin(1e-9)
+        .of(EffortModel.capacity(100.0, 15))
+    }
+
+    @Test
+    fun `zero reps demonstrates only the weight`() {
+      assertThat(EffortModel.capacity(100.0, 0)).isWithin(1e-9).of(100.0)
+    }
+
+    @Test
+    fun `negative weight floors at zero`() {
+      assertThat(EffortModel.capacity(-10.0, 8)).isWithin(1e-9).of(0.0)
+    }
+  }
+
+  @Nested
+  @DisplayName("bubbleSize")
+  inner class Hump {
+    @Test
+    fun `hits every anchor exactly`() {
+      assertThat(EffortModel.bubbleSize(-2.0)).isEqualTo(0.00f)
+      assertThat(EffortModel.bubbleSize(-1.0)).isEqualTo(0.30f)
+      assertThat(EffortModel.bubbleSize(0.0)).isEqualTo(0.60f)
+      assertThat(EffortModel.bubbleSize(0.5)).isEqualTo(0.85f)
+      assertThat(EffortModel.bubbleSize(1.0)).isEqualTo(1.00f)
+      assertThat(EffortModel.bubbleSize(1.5)).isEqualTo(0.90f)
+      assertThat(EffortModel.bubbleSize(2.5)).isEqualTo(0.40f)
+    }
+
+    @Test
+    fun `clamps flat below -2 and above 2_5`() {
+      assertThat(EffortModel.bubbleSize(-5.0)).isEqualTo(0.00f)
+      assertThat(EffortModel.bubbleSize(50.0)).isEqualTo(0.40f)
+    }
+
+    @Test
+    fun `rises monotonically from -2 to the peak at +1`() {
+      val samples = generateSequence(-2.0) { it + 0.1 }.takeWhile { it <= 1.0 }.toList()
+      val sizes = samples.map { EffortModel.bubbleSize(it) }
+      assertThat(sizes).isInOrder()
+    }
+
+    @Test
+    fun `falls monotonically from the peak at +1 to +2_5`() {
+      val samples = generateSequence(1.0) { it + 0.1 }.takeWhile { it <= 2.5 }.toList()
+      val sizes = samples.map { EffortModel.bubbleSize(it) }
+      assertThat(sizes).isInOrder(compareByDescending<Float> { it })
+    }
+
+    @Test
+    fun `null z is neutral, not zero`() {
+      assertThat(EffortModel.bubbleSize(null)).isEqualTo(EffortModel.NEUTRAL_SIZE)
+    }
+  }
+
+  @Nested
+  @DisplayName("worked examples (spec table, curve at ĉ=133, s=10)")
+  inner class WorkedExamples {
+    private fun sizeFor(weight: Double, reps: Int): Float {
+      val c = EffortModel.capacity(weight, reps)
+      val z = (c - 133.0) / 10.0
+      return EffortModel.bubbleSize(z)
+    }
+
+    @Test
+    fun `80 lb x 15 - somewhat below - smallish`() {
+      assertThat(sizeFor(80.0, 15).toDouble()).isWithin(1e-3).of(0.21)
+    }
+
+    @Test
+    fun `90 lb x 15 - slightly above - larger than on-curve`() {
+      val size = sizeFor(90.0, 15)
+      assertThat(size.toDouble()).isWithin(1e-3).of(0.70)
+      assertThat(size).isGreaterThan(EffortModel.bubbleSize(0.0))
+    }
+
+    @Test
+    fun `130 lb x 3 - above - peak`() {
+      assertThat(sizeFor(130.0, 3)).isEqualTo(1.00f)
+    }
+
+    @Test
+    fun `100 lb x 2 - well below - minimum`() {
+      assertThat(sizeFor(100.0, 2)).isEqualTo(0.00f)
+    }
+
+    @Test
+    fun `100 lb x 10 - on-just above - large`() {
+      assertThat(sizeFor(100.0, 10).toDouble()).isWithin(1e-3).of(0.617)
+    }
+
+    @Test
+    fun `100 lb x 12 - on-just above - near peak`() {
+      assertThat(sizeFor(100.0, 12).toDouble()).isWithin(1e-3).of(0.91)
+    }
+
+    @Test
+    fun `180 lb x 5 - far above - punished`() {
+      assertThat(sizeFor(180.0, 5)).isEqualTo(0.40f)
+    }
+
+    @Test
+    fun `ordering matches the spec table`() {
+      val below = sizeFor(100.0, 2)
+      val somewhatBelow = sizeFor(80.0, 15)
+      val onCurve = EffortModel.bubbleSize(0.0)
+      val slightlyAbove = sizeFor(90.0, 15)
+      val peakA = sizeFor(130.0, 3)
+      val peakB = sizeFor(100.0, 12)
+      val punished = sizeFor(180.0, 5)
+
+      assertThat(below).isLessThan(somewhatBelow)
+      assertThat(somewhatBelow).isLessThan(onCurve)
+      assertThat(onCurve).isLessThan(slightlyAbove)
+      assertThat(slightlyAbove).isLessThan(peakB)
+      assertThat(peakB).isLessThan(peakA)
+      assertThat(punished).isLessThan(slightlyAbove)
+    }
+  }
+
+  @Nested
+  @DisplayName("session aggregation")
+  inner class SessionAggregation {
+    @Test
+    fun `a warm-up set does not change the fit driven by the session best`() {
+      val topOnly = (0..2).map { EffortSet(day(it * 7L), 100.0 + it * 2, 5) }
+      val withWarmup = topOnly.dropLast(1) +
+        listOf(EffortSet(day(14), 40.0, 15), EffortSet(day(14), 104.0, 5))
+      val probe = EffortSet(day(28), 110.0, 5)
+
+      val trendTop = EffortModel.score(topOnly + probe).trend.last()
+      val trendWarm = EffortModel.score(withWarmup + probe).trend.last()
+
+      assertThat(trendWarm.expectedCapacity).isWithin(1e-9).of(trendTop.expectedCapacity)
+    }
+
+    @Test
+    fun `sets sharing a session share one expectation`() {
+      val priors = (0..2).map { EffortSet(day(it * 7L), 100.0, 8) }
+      val session = listOf(EffortSet(day(21), 40.0, 15), EffortSet(day(21), 105.0, 8))
+      val series = EffortModel.score(priors + session)
+
+      val scored = series.sets.filter { it.sessionIndex == 3 }
+      assertThat(scored).hasSize(2)
+      assertThat(scored.map { it.expectation }.distinct()).hasSize(1)
+      assertThat(scored[0].expectation).isNotNull()
+    }
+
+    @Test
+    fun `the session zone determines which calendar day a set falls on`() {
+      val early = Instant.parse("2024-01-01T02:00:00Z")
+      val late = Instant.parse("2024-01-01T10:00:00Z")
+      val sets = listOf(EffortSet(early, 100.0, 5), EffortSet(late, 100.0, 5))
+
+      val utc = EffortModel.score(sets, zone = ZoneId.of("UTC"))
+      val chicago = EffortModel.score(sets, zone = ZoneId.of("America/Chicago"))
+
+      assertThat(utc.sets.map { it.sessionIndex }.distinct()).hasSize(1)
+      assertThat(chicago.sets.map { it.sessionIndex }.distinct()).hasSize(2)
+    }
+  }
+
+  @Nested
+  @DisplayName("cold start")
+  inner class ColdStart {
+    @Test
+    fun `fewer than 3 prior sessions predicts nothing`() {
+      val sets = (0..2).map { EffortSet(day(it * 7L), 100.0, 8) }
+      val series = EffortModel.score(sets)
+
+      assertThat(series.trend).isEmpty()
+      assertThat(series.sets).hasSize(3)
+      series.sets.forEach {
+        assertThat(it.expectation).isNull()
+        assertThat(it.z).isNull()
+        assertThat(it.size).isEqualTo(EffortModel.NEUTRAL_SIZE)
+        assertThat(it.zone).isEqualTo(EffortZone.COLD)
+      }
+    }
+
+    @Test
+    fun `the 4th session is the first with a prediction`() {
+      val sets = (0..2).map { EffortSet(day(it * 7L), 100.0, 8) } +
+        EffortSet(day(21), 105.0, 8)
+      val series = EffortModel.score(sets)
+
+      assertThat(series.trend).hasSize(1)
+      assertThat(series.trend.single().sessionIndex).isEqualTo(3)
+      val fourth = series.sets.last()
+      assertThat(fourth.expectation).isNotNull()
+      assertThat(fourth.zone).isNotEqualTo(EffortZone.COLD)
+    }
+  }
+
+  @Nested
+  @DisplayName("causality")
+  inner class Causality {
+    @Test
+    fun `a session's own outcome never changes its own or earlier expectations`() {
+      val ramp = (0..4).map { EffortSet(day(it * 7L), 100.0 + it * 2, 8) }
+      val hugePr = EffortSet(day(35), 250.0, 8)
+
+      val without = EffortModel.score(ramp)
+      val with = EffortModel.score(ramp + hugePr)
+
+      val trendWithout = without.trend.associateBy { it.sessionIndex }
+      val trendWithPrior = with.trend.filter { it.sessionIndex < 5 }.associateBy { it.sessionIndex }
+
+      assertThat(trendWithPrior.keys).isEqualTo(trendWithout.keys)
+      trendWithout.forEach { (idx, tp) ->
+        assertThat(trendWithPrior.getValue(idx).expectedCapacity).isWithin(1e-9).of(tp.expectedCapacity)
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("recency")
+  inner class Recency {
+    @Test
+    fun `a long plateau after a ramp pulls the expectation down to the plateau`() {
+      val ramp = (0..4).map { i -> EffortSet(day(i * 7L), 100.0 + i * 5, 0) }
+      val plateau = (0 until 15).map { i -> EffortSet(day(35L + i * 7L), 120.0, 0) }
+      val series = EffortModel.score(ramp + plateau)
+
+      val last = series.trend.last()
+      assertThat(last.expectedCapacity).isWithin(5.0).of(120.0)
+    }
+  }
+
+  @Nested
+  @DisplayName("residual scale")
+  inner class ResidualScale {
+    @Test
+    fun `a flat history floors s at the configured fraction of the expectation`() {
+      val c = 100.0
+      val priors = (0..2).map { EffortSet(day(it * 7L), c, 0) }
+      val onCurve = EffortSet(day(21), c, 0)
+      val probe = EffortSet(day(21), c * 1.05, 0)
+      val series = EffortModel.score(priors + listOf(onCurve, probe))
+
+      val session3 = series.sets.filter { it.sessionIndex == 3 }
+      val onCurveScored = session3.first { it.source.weight == c }
+      val probeScored = session3.first { it.source.weight == c * 1.05 }
+
+      assertThat(onCurveScored.z!!).isWithin(1e-6).of(0.0)
+      assertThat(onCurveScored.size.toDouble()).isWithin(1e-3).of(0.60)
+      assertThat(probeScored.z!!).isWithin(1e-6).of(1.0)
+      assertThat(probeScored.size).isEqualTo(1.00f)
+    }
+  }
+
+  @Nested
+  @DisplayName("trend")
+  inner class Trend {
+    @Test
+    fun `expectedWeight at typicalReps reconstructs expectedCapacity`() {
+      val sets = (0 until 10).map { i -> EffortSet(day(i * 3L), 80.0 + i * 3, 5 + i % 4) }
+      val series = EffortModel.score(sets)
+
+      assertThat(series.trend).isNotEmpty()
+      series.trend.forEach { tp ->
+        val reconstructed = tp.expectedWeight * (1 + tp.typicalReps / EffortConfig.Default.epleyDivisor)
+        assertThat(reconstructed).isWithin(1e-6).of(tp.expectedCapacity)
+      }
+    }
+
+    @Test
+    fun `typical reps tracks the top set, ignoring warm-up reps`() {
+      val sets = (0 until 6).flatMap { i ->
+        listOf(
+          EffortSet(day(i * 7L), 50.0, 15),
+          EffortSet(day(i * 7L), 100.0, 5)
+        )
+      }
+      val series = EffortModel.score(sets)
+
+      assertThat(series.trend).isNotEmpty()
+      series.trend.forEach { tp -> assertThat(tp.typicalReps).isWithin(1e-6).of(5.0) }
+    }
+
+    @Test
+    fun `a long layoff does not blow up the expectation`() {
+      val priors = (0..3).map { EffortSet(day(it * 7L), 100.0 + it * 10, 8) }
+      val afterLayoff = EffortSet(day(221), 100.0, 8)
+      val series = EffortModel.score(priors + afterLayoff)
+
+      val last = series.trend.last()
+      assertThat(last.expectedCapacity).isFinite()
+      assertThat(last.expectedCapacity).isGreaterThan(0.0)
+      assertThat(last.expectedCapacity).isLessThan(500.0)
+    }
+  }
+
+  @Nested
+  @DisplayName("degenerate input")
+  inner class Degenerate {
+    @Test
+    fun `a single set has no prediction`() {
+      val series = EffortModel.score(listOf(EffortSet(day(0), 100.0, 8)))
+      assertThat(series.sets).hasSize(1)
+      assertThat(series.sets.single().expectation).isNull()
+      assertThat(series.trend).isEmpty()
+    }
+
+    @Test
+    fun `all sets on one day form a single cold session`() {
+      val sets = listOf(
+        EffortSet(day(0), 100.0, 8),
+        EffortSet(day(0).plusSeconds(60), 105.0, 6)
+      )
+      val series = EffortModel.score(sets)
+      assertThat(series.sets.map { it.sessionIndex }.distinct()).containsExactly(0)
+      assertThat(series.trend).isEmpty()
+    }
+
+    @Test
+    fun `identical sets across many sessions is a degenerate but valid flat history`() {
+      val sets = (0 until 6).map { EffortSet(day(it * 7L), 100.0, 8) }
+      val series = EffortModel.score(sets)
+      assertThat(series.sets).hasSize(6)
+      assertThat(series.trend.map { it.expectedCapacity }.all { it.isFinite() }).isTrue()
+    }
+
+    @Test
+    fun `empty input returns the shared Empty instance`() {
+      assertThat(EffortModel.score(emptyList())).isSameInstanceAs(EffortSeries.Empty)
+    }
+  }
+}

--- a/identity/src/main/res/xml/remote_config_defaults.xml
+++ b/identity/src/main/res/xml/remote_config_defaults.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <defaults>
+  <!-- record_chart_type: line | bubble | bubble-exploded | effort -->
   <entry>
     <key>record_chart_type</key>
     <value>line</value>

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/ExerciseDao.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/ExerciseDao.kt
@@ -123,6 +123,14 @@ interface ExerciseDao {
   @Query("select * from setrecord where exercise = :targetExercise order by completed desc")
   fun getAllSetRecord(targetExercise: String): PagingSource<Int, RoomSetRecord>
 
+  /**
+   * Newest [limit] records for [targetExercise], descending - callers reverse for chronology.
+   * Unlike [getAllSetRecord], this is a plain list flow so a trend fit can see a stable window
+   * of history without depending on how many Paging pages happen to be loaded.
+   */
+  @Query("select * from setrecord where exercise = :targetExercise order by completed desc limit :limit")
+  fun getRecentSetRecords(targetExercise: String, limit: Int): Flow<List<RoomSetRecord>>
+
   @Insert
   suspend fun storeExerciseRecord(exerciseRecord: RoomSetRecord)
 

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
@@ -1,0 +1,199 @@
+package com.litus_animae.refitted.ui.compose.charts
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PointMode
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
+import com.litus_animae.refitted.data.effort.EffortZone
+import com.litus_animae.refitted.ui.compose.util.Theme
+import kotlin.math.sqrt
+
+/** One bubble to draw: [x] and [weight] in the caller's chosen domain, [size] in `[0, 1]`. */
+data class EffortPoint(val x: Float, val weight: Float, val size: Float, val zone: EffortZone)
+
+/**
+ * Effort-scored sets as bubbles (radius by demonstrated capacity vs. expectation) plus the
+ * adaptive expectation curve. See `docs/exercise-history-chart.md`.
+ *
+ * [trend] is a list of runs rather than one flat polyline - a run breaks wherever the caller's
+ * domain has no prediction (cold start, or a skipped index in a compact window), and each run
+ * is drawn as its own connected segment rather than one line bridging the gap.
+ */
+@Composable
+fun EffortChart(
+  modifier: Modifier = Modifier,
+  points: List<EffortPoint>,
+  trend: List<List<Pair<Float, Float>>> = emptyList(),
+  compact: Boolean = false,
+  baseColor: Color = MaterialTheme.colors.primary,
+  peakColor: Color = Theme.goodAttention,
+  punishedColor: Color = Theme.timerAmber,
+  coldColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.25f),
+  trendColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.35f),
+  minPointSize: Dp = if (compact) 4.dp else 8.dp,
+  maxPointSize: Dp = if (compact) 16.dp else 30.dp,
+  trendWidth: Dp = if (compact) 1.5.dp else 2.dp
+) {
+  // rangeOf (used by the other charts) throws on empty input, and those charts only survive
+  // because their caller happens to gate on itemCount > 0 - guard here instead of relying on it.
+  if (points.isEmpty()) {
+    Spacer(modifier)
+    return
+  }
+
+  val minX = remember(points, trend) { minOf(points.minOf { it.x }, trend.flatten().minOfOrNull { it.first } ?: Float.POSITIVE_INFINITY) }
+  val maxX = remember(points, trend) { maxOf(points.maxOf { it.x }, trend.flatten().maxOfOrNull { it.first } ?: Float.NEGATIVE_INFINITY) }
+  val minY = remember(points, trend) { minOf(points.minOf { it.weight }, trend.flatten().minOfOrNull { it.second } ?: Float.POSITIVE_INFINITY) }
+  val maxY = remember(points, trend) { maxOf(points.maxOf { it.weight }, trend.flatten().maxOfOrNull { it.second } ?: Float.NEGATIVE_INFINITY) }
+
+  val xSpan = maxX - minX
+  val ySpan = maxY - minY
+
+  // A collapsed domain (single point, or every value identical) has no meaningful position -
+  // center it rather than dividing by the max(range, 1f) floor the other charts use, which
+  // would silently pin everything to one edge instead.
+  fun nx(x: Float) = if (xSpan <= 0f) 0.5f else (x - minX) / xSpan
+  fun ny(y: Float) = if (ySpan <= 0f) 0.5f else (y - minY) / ySpan
+
+  val minPx = with(LocalDensity.current) { minPointSize.toPx() }
+  val maxPx = with(LocalDensity.current) { maxPointSize.toPx() }
+  val trendPx = with(LocalDensity.current) { trendWidth.toPx() }
+
+  val canvasModifier = if (compact) {
+    modifier.padding(horizontal = 6.dp, vertical = 4.dp)
+  } else {
+    modifier.padding(20.dp).defaultMinSize(100.dp, 100.dp)
+  }
+
+  Canvas(canvasModifier) {
+    trend.forEach { run ->
+      if (run.size < 2) return@forEach
+      val offsets = run.map { (x, y) -> Offset(lerp(0f, size.width, nx(x)), lerp(size.height, 0f, ny(y))) }
+      drawPoints(
+        offsets.zipWithNext().flatMap { sequenceOf(it.first, it.second) },
+        PointMode.Lines,
+        trendColor,
+        trendPx
+      )
+    }
+
+    // Largest first so a peak bubble never visually swallows a smaller one drawn after it.
+    points.sortedByDescending { it.size }.forEach { point ->
+      // Stroke width is a diameter, so mapping size -> diameter linearly would make the
+      // *area* (what the eye actually reads as "bigger") grow quadratically with size.
+      // Interpolating the squared diameter and taking the root keeps size proportional to area.
+      val clampedSize = point.size.coerceIn(0f, 1f)
+      val diameter = sqrt(lerp(minPx * minPx, maxPx * maxPx, clampedSize))
+      val color = zoneColor(point.zone, baseColor, peakColor, punishedColor, coldColor)
+      drawPoints(
+        listOf(Offset(lerp(0f, size.width, nx(point.x)), lerp(size.height, 0f, ny(point.weight)))),
+        PointMode.Points,
+        color,
+        diameter,
+        StrokeCap.Round
+      )
+    }
+  }
+}
+
+private fun zoneColor(
+  zone: EffortZone,
+  baseColor: Color,
+  peakColor: Color,
+  punishedColor: Color,
+  coldColor: Color
+): Color = when (zone) {
+  EffortZone.COLD -> coldColor
+  EffortZone.BELOW -> baseColor.copy(alpha = 0.55f)
+  EffortZone.ON_CURVE -> baseColor.copy(alpha = 0.85f)
+  EffortZone.GROWTH -> peakColor
+  EffortZone.IMPLAUSIBLE -> punishedColor
+}
+
+@Preview
+@Composable
+private fun PreviewEffortChartEmpty() {
+  EffortChart(
+    Modifier.size(300.dp).background(Color.White),
+    points = emptyList()
+  )
+}
+
+@Preview
+@Composable
+private fun PreviewEffortChartSinglePoint() {
+  EffortChart(
+    Modifier.size(300.dp).background(Color.White),
+    points = listOf(EffortPoint(0f, 100f, 0.45f, EffortZone.COLD))
+  )
+}
+
+@Preview
+@Composable
+private fun PreviewEffortChartTwoSameDay() {
+  EffortChart(
+    Modifier.size(300.dp).background(Color.White),
+    points = listOf(
+      EffortPoint(0f, 95f, 0.45f, EffortZone.COLD),
+      EffortPoint(0f, 100f, 0.45f, EffortZone.COLD)
+    )
+  )
+}
+
+@Preview
+@Composable
+private fun PreviewEffortChartColdStartOnly() {
+  EffortChart(
+    Modifier.size(300.dp).background(Color.White),
+    points = listOf(
+      EffortPoint(0f, 90f, 0.45f, EffortZone.COLD),
+      EffortPoint(1f, 95f, 0.45f, EffortZone.COLD)
+    )
+  )
+}
+
+@Preview
+@Composable
+private fun PreviewEffortChartLongHistoryWithSpike() {
+  EffortChart(
+    Modifier.size(300.dp).background(Color.White),
+    points = listOf(
+      EffortPoint(0f, 90f, 0.45f, EffortZone.COLD),
+      EffortPoint(1f, 92f, 0.45f, EffortZone.COLD),
+      EffortPoint(2f, 95f, 0.45f, EffortZone.COLD),
+      EffortPoint(3f, 98f, 0.70f, EffortZone.ON_CURVE),
+      EffortPoint(4f, 100f, 0.85f, EffortZone.GROWTH),
+      EffortPoint(5f, 130f, 0.40f, EffortZone.IMPLAUSIBLE),
+      EffortPoint(6f, 103f, 0.60f, EffortZone.ON_CURVE),
+      EffortPoint(7f, 105f, 1.00f, EffortZone.GROWTH)
+    ),
+    trend = listOf(
+      listOf(3f to 96f, 4f to 98f, 5f to 100f, 6f to 101f, 7f to 103f)
+    )
+  )
+}
+
+@Preview
+@Composable
+private fun PreviewEffortChartFlatHistory() {
+  EffortChart(
+    Modifier.size(300.dp).background(Color.White),
+    points = (0..6).map { EffortPoint(it.toFloat(), 100f, 0.60f, EffortZone.ON_CURVE) },
+    trend = listOf((3..6).map { it.toFloat() to 100f })
+  )
+}

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
@@ -39,11 +39,23 @@ import com.litus_animae.refitted.ui.R
 import com.litus_animae.refitted.ui.compose.util.Theme
 import kotlin.math.sqrt
 
-/** One bubble to draw: [x] and [weight] in the caller's chosen domain, [size] in `[0, 1]`. */
-data class EffortPoint(val x: Float, val weight: Float, val size: Float, val zone: EffortZone)
+/**
+ * One bubble to draw: [x] and [weight] in the caller's chosen domain, [size] in `[0, 1]`.
+ * [emphasized] draws a ring around this bubble (e.g. "the set you just did") - false costs
+ * nothing extra to draw.
+ */
+data class EffortPoint(
+  val x: Float,
+  val weight: Float,
+  val size: Float,
+  val zone: EffortZone,
+  val emphasized: Boolean = false
+)
 
 private val LabelPadding = 4.dp
 private val GapMarkDash = 4.dp
+private val EmphasisRingGap = 3.dp
+private val EmphasisRingWidth = 1.5.dp
 
 /**
  * Effort-scored sets as bubbles (radius by demonstrated capacity vs. expectation) plus the
@@ -76,6 +88,7 @@ fun EffortChart(
   punishedColor: Color = Theme.timerAmber,
   coldColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.25f),
   trendColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.35f),
+  emphasisColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
   minPointSize: Dp = if (compact) 4.dp else 8.dp,
   maxPointSize: Dp = if (compact) 16.dp else 30.dp,
   trendWidth: Dp = if (compact) 1.5.dp else 2.dp
@@ -119,6 +132,8 @@ fun EffortChart(
   val trendPx = with(density) { trendWidth.toPx() }
   val labelPaddingPx = with(density) { LabelPadding.toPx() }
   val gapDashPx = with(density) { GapMarkDash.toPx() }
+  val emphasisGapPx = with(density) { EmphasisRingGap.toPx() }
+  val emphasisWidthPx = with(density) { EmphasisRingWidth.toPx() }
 
   val textMeasurer = rememberTextMeasurer()
   val labelStyle = TextStyle(fontSize = 9.sp, color = MaterialTheme.colors.onSurface.copy(alpha = 0.5f))
@@ -200,13 +215,16 @@ fun EffortChart(
       val clampedSize = point.size.coerceIn(0f, 1f)
       val diameter = sqrt(lerp(minPx * minPx, maxPx * maxPx, clampedSize))
       val color = zoneColor(point.zone, baseColor, peakColor, punishedColor, coldColor)
-      drawPoints(
-        listOf(Offset(px(point.x), py(point.weight))),
-        PointMode.Points,
-        color,
-        diameter,
-        StrokeCap.Round
-      )
+      val center = Offset(px(point.x), py(point.weight))
+      drawPoints(listOf(center), PointMode.Points, color, diameter, StrokeCap.Round)
+      if (point.emphasized) {
+        drawCircle(
+          emphasisColor,
+          radius = diameter / 2f + emphasisGapPx,
+          center = center,
+          style = Stroke(width = emphasisWidthPx)
+        )
+      }
     }
 
     yLabelLayouts.forEach { (y, layout) ->
@@ -331,6 +349,21 @@ private fun PreviewEffortChartLongHistoryWithSpike() {
     trend = listOf(
       listOf(3f to 96f, 4f to 98f, 5f to 100f, 6f to 101f, 7f to 103f)
     )
+  )
+}
+
+@Preview
+@Composable
+private fun PreviewEffortChartEmphasizedNewest() {
+  EffortChart(
+    Modifier.size(300.dp).background(Color.White),
+    points = listOf(
+      EffortPoint(0f, 90f, 0.45f, EffortZone.COLD),
+      EffortPoint(1f, 95f, 0.60f, EffortZone.ON_CURVE),
+      EffortPoint(2f, 98f, 0.85f, EffortZone.GROWTH, emphasized = true)
+    ),
+    gapMarks = listOf(0.5f, 1.5f),
+    yLabels = listOf(90f to "90", 98f to "98")
   )
 }
 

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
@@ -19,9 +19,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.PointMode
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -61,6 +63,10 @@ fun EffortChart(
   modifier: Modifier = Modifier,
   points: List<EffortPoint>,
   trend: List<List<Pair<Float, Float>>> = emptyList(),
+  // A second trend line, drawn dashed and beneath [trend] - for callers that fit two kinds
+  // of expectation (e.g. a coarser stand-in while there isn't enough history for the real
+  // one) and want the dash itself to carry that distinction rather than a text label.
+  dashedTrend: List<List<Pair<Float, Float>>> = emptyList(),
   compact: Boolean = false,
   xLabels: List<Pair<Float, String>> = emptyList(),
   yLabels: List<Pair<Float, String>> = emptyList(),
@@ -81,10 +87,18 @@ fun EffortChart(
     return
   }
 
-  val minX = remember(points, trend) { minOf(points.minOf { it.x }, trend.flatten().minOfOrNull { it.first } ?: Float.POSITIVE_INFINITY) }
-  val maxX = remember(points, trend) { maxOf(points.maxOf { it.x }, trend.flatten().maxOfOrNull { it.first } ?: Float.NEGATIVE_INFINITY) }
-  val minY = remember(points, trend) { minOf(points.minOf { it.weight }, trend.flatten().minOfOrNull { it.second } ?: Float.POSITIVE_INFINITY) }
-  val maxY = remember(points, trend) { maxOf(points.maxOf { it.weight }, trend.flatten().maxOfOrNull { it.second } ?: Float.NEGATIVE_INFINITY) }
+  val minX = remember(points, trend, dashedTrend) {
+    minOf(points.minOf { it.x }, (trend + dashedTrend).flatten().minOfOrNull { it.first } ?: Float.POSITIVE_INFINITY)
+  }
+  val maxX = remember(points, trend, dashedTrend) {
+    maxOf(points.maxOf { it.x }, (trend + dashedTrend).flatten().maxOfOrNull { it.first } ?: Float.NEGATIVE_INFINITY)
+  }
+  val minY = remember(points, trend, dashedTrend) {
+    minOf(points.minOf { it.weight }, (trend + dashedTrend).flatten().minOfOrNull { it.second } ?: Float.POSITIVE_INFINITY)
+  }
+  val maxY = remember(points, trend, dashedTrend) {
+    maxOf(points.maxOf { it.weight }, (trend + dashedTrend).flatten().maxOfOrNull { it.second } ?: Float.NEGATIVE_INFINITY)
+  }
 
   val xSpan = maxX - minX
   val ySpan = maxY - minY
@@ -148,6 +162,23 @@ fun EffortChart(
         Offset(px(x), plotBottom),
         strokeWidth = trendPx / 2f,
         pathEffect = PathEffect.dashPathEffect(floatArrayOf(gapDashPx, gapDashPx))
+      )
+    }
+
+    // Drawn first, and beneath the solid trend below, so a solid segment starting exactly
+    // where a dashed one ends (the bootstrap-to-real handoff) renders over it cleanly.
+    dashedTrend.forEach { run ->
+      if (run.size < 2) return@forEach
+      val path = Path().apply {
+        run.forEachIndexed { index, (x, y) ->
+          val offset = Offset(px(x), py(y))
+          if (index == 0) moveTo(offset.x, offset.y) else lineTo(offset.x, offset.y)
+        }
+      }
+      drawPath(
+        path,
+        trendColor,
+        style = Stroke(width = trendPx, pathEffect = PathEffect.dashPathEffect(floatArrayOf(gapDashPx, gapDashPx)))
       )
     }
 
@@ -300,6 +331,25 @@ private fun PreviewEffortChartLongHistoryWithSpike() {
     trend = listOf(
       listOf(3f to 96f, 4f to 98f, 5f to 100f, 6f to 101f, 7f to 103f)
     )
+  )
+}
+
+@Preview
+@Composable
+private fun PreviewEffortChartDashedTrendHandoff() {
+  EffortChart(
+    Modifier.size(300.dp).background(Color.White),
+    points = listOf(
+      EffortPoint(0f, 90f, 0.45f, EffortZone.COLD),
+      EffortPoint(1f, 95f, 0.60f, EffortZone.ON_CURVE),
+      EffortPoint(2f, 98f, 0.60f, EffortZone.ON_CURVE),
+      EffortPoint(3f, 100f, 0.70f, EffortZone.ON_CURVE),
+      EffortPoint(4f, 103f, 0.85f, EffortZone.GROWTH)
+    ),
+    // The bootstrap (dashed) run hands off to the real (solid) run at x=2 - the solid
+    // segment should render cleanly over the dash where they overlap.
+    dashedTrend = listOf(listOf(1f to 94f, 2f to 97f)),
+    trend = listOf(listOf(2f to 97f, 3f to 99f, 4f to 101f))
   )
 }
 

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
@@ -59,7 +59,7 @@ private val EmphasisRingWidth = 1.5.dp
 
 /**
  * Effort-scored sets as bubbles (radius by demonstrated capacity vs. expectation) plus the
- * adaptive expectation curve. See `docs/exercise-history-chart.md`.
+ * adaptive expectation curve.
  *
  * [trend] is a list of runs rather than one flat polyline - a run breaks wherever the caller's
  * domain has no prediction (cold start, or a skipped index in a compact window), and each run

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
@@ -2,29 +2,46 @@ package com.litus_animae.refitted.ui.compose.charts
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.PointMode
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.lerp
 import com.litus_animae.refitted.data.effort.EffortZone
+import com.litus_animae.refitted.ui.R
 import com.litus_animae.refitted.ui.compose.util.Theme
 import kotlin.math.sqrt
 
 /** One bubble to draw: [x] and [weight] in the caller's chosen domain, [size] in `[0, 1]`. */
 data class EffortPoint(val x: Float, val weight: Float, val size: Float, val zone: EffortZone)
+
+private val LabelPadding = 4.dp
+private val GapMarkDash = 4.dp
 
 /**
  * Effort-scored sets as bubbles (radius by demonstrated capacity vs. expectation) plus the
@@ -33,6 +50,11 @@ data class EffortPoint(val x: Float, val weight: Float, val size: Float, val zon
  * [trend] is a list of runs rather than one flat polyline - a run breaks wherever the caller's
  * domain has no prediction (cold start, or a skipped index in a compact window), and each run
  * is drawn as its own connected segment rather than one line bridging the gap.
+ *
+ * [xLabels] and [yLabels] are axis ticks in the caller's domain (`domain value to display
+ * text`); [gapMarks] are x-domain positions for a dashed rule (e.g. between sessions with a
+ * long calendar gap between them). All three default empty and cost nothing when unused - the
+ * compact strip never passes them.
  */
 @Composable
 fun EffortChart(
@@ -40,6 +62,9 @@ fun EffortChart(
   points: List<EffortPoint>,
   trend: List<List<Pair<Float, Float>>> = emptyList(),
   compact: Boolean = false,
+  xLabels: List<Pair<Float, String>> = emptyList(),
+  yLabels: List<Pair<Float, String>> = emptyList(),
+  gapMarks: List<Float> = emptyList(),
   baseColor: Color = MaterialTheme.colors.primary,
   peakColor: Color = Theme.goodAttention,
   punishedColor: Color = Theme.timerAmber,
@@ -70,20 +95,65 @@ fun EffortChart(
   fun nx(x: Float) = if (xSpan <= 0f) 0.5f else (x - minX) / xSpan
   fun ny(y: Float) = if (ySpan <= 0f) 0.5f else (y - minY) / ySpan
 
-  val minPx = with(LocalDensity.current) { minPointSize.toPx() }
-  val maxPx = with(LocalDensity.current) { maxPointSize.toPx() }
-  val trendPx = with(LocalDensity.current) { trendWidth.toPx() }
+  // Largest first so a peak bubble never visually swallows a smaller one drawn after it -
+  // hoisted out of the draw scope so it isn't re-sorted every frame.
+  val sortedPoints = remember(points) { points.sortedByDescending { it.size } }
+
+  val density = LocalDensity.current
+  val minPx = with(density) { minPointSize.toPx() }
+  val maxPx = with(density) { maxPointSize.toPx() }
+  val trendPx = with(density) { trendWidth.toPx() }
+  val labelPaddingPx = with(density) { LabelPadding.toPx() }
+  val gapDashPx = with(density) { GapMarkDash.toPx() }
+
+  val textMeasurer = rememberTextMeasurer()
+  val labelStyle = TextStyle(fontSize = 9.sp, color = MaterialTheme.colors.onSurface.copy(alpha = 0.5f))
+  val xLabelLayouts = remember(xLabels, labelStyle) {
+    xLabels.map { (x, text) -> x to textMeasurer.measure(text, labelStyle) }
+  }
+  val yLabelLayouts = remember(yLabels, labelStyle) {
+    yLabels.map { (y, text) -> y to textMeasurer.measure(text, labelStyle) }
+  }
+  val leftGutter = if (yLabelLayouts.isEmpty()) 0f else {
+    yLabelLayouts.maxOf { it.second.size.width } + labelPaddingPx
+  }
+  val bottomGutter = if (xLabelLayouts.isEmpty()) 0f else {
+    xLabelLayouts.maxOf { it.second.size.height } + labelPaddingPx
+  }
 
   val canvasModifier = if (compact) {
     modifier.padding(horizontal = 6.dp, vertical = 4.dp)
   } else {
-    modifier.padding(20.dp).defaultMinSize(100.dp, 100.dp)
+    modifier.padding(8.dp).defaultMinSize(100.dp, 100.dp)
   }
 
   Canvas(canvasModifier) {
+    // Bubble centers are inset by their own radius so the largest bubble's edge lands on the
+    // canvas boundary instead of its center - previously only the composable's outer padding
+    // stood between a max-size edge bubble and clipping by whatever container (e.g. a Card)
+    // sits around this chart.
+    val maxR = maxPx / 2f
+    val plotLeft = (maxR + leftGutter).coerceAtMost(size.width / 2f)
+    val plotRight = (size.width - maxR).coerceAtLeast(plotLeft)
+    val plotTop = maxR.coerceAtMost(size.height / 2f)
+    val plotBottom = (size.height - maxR - bottomGutter).coerceAtLeast(plotTop)
+
+    fun px(x: Float) = lerp(plotLeft, plotRight, nx(x))
+    fun py(y: Float) = lerp(plotBottom, plotTop, ny(y))
+
+    gapMarks.forEach { x ->
+      drawLine(
+        coldColor,
+        Offset(px(x), plotTop),
+        Offset(px(x), plotBottom),
+        strokeWidth = trendPx / 2f,
+        pathEffect = PathEffect.dashPathEffect(floatArrayOf(gapDashPx, gapDashPx))
+      )
+    }
+
     trend.forEach { run ->
       if (run.size < 2) return@forEach
-      val offsets = run.map { (x, y) -> Offset(lerp(0f, size.width, nx(x)), lerp(size.height, 0f, ny(y))) }
+      val offsets = run.map { (x, y) -> Offset(px(x), py(y)) }
       drawPoints(
         offsets.zipWithNext().flatMap { sequenceOf(it.first, it.second) },
         PointMode.Lines,
@@ -92,8 +162,7 @@ fun EffortChart(
       )
     }
 
-    // Largest first so a peak bubble never visually swallows a smaller one drawn after it.
-    points.sortedByDescending { it.size }.forEach { point ->
+    sortedPoints.forEach { point ->
       // Stroke width is a diameter, so mapping size -> diameter linearly would make the
       // *area* (what the eye actually reads as "bigger") grow quadratically with size.
       // Interpolating the squared diameter and taking the root keeps size proportional to area.
@@ -101,17 +170,63 @@ fun EffortChart(
       val diameter = sqrt(lerp(minPx * minPx, maxPx * maxPx, clampedSize))
       val color = zoneColor(point.zone, baseColor, peakColor, punishedColor, coldColor)
       drawPoints(
-        listOf(Offset(lerp(0f, size.width, nx(point.x)), lerp(size.height, 0f, ny(point.weight)))),
+        listOf(Offset(px(point.x), py(point.weight))),
         PointMode.Points,
         color,
         diameter,
         StrokeCap.Round
       )
     }
+
+    yLabelLayouts.forEach { (y, layout) ->
+      drawText(
+        layout,
+        topLeft = Offset(plotLeft - maxR - labelPaddingPx - layout.size.width, py(y) - layout.size.height / 2f)
+      )
+    }
+    xLabelLayouts.forEach { (x, layout) ->
+      val left = (px(x) - layout.size.width / 2f).coerceIn(0f, size.width - layout.size.width)
+      drawText(layout, topLeft = Offset(left, plotBottom + maxR + labelPaddingPx))
+    }
   }
 }
 
-private fun zoneColor(
+/** Dot + label per [EffortZone], decoding the bubble colors drawn by [EffortChart]. */
+@Composable
+fun EffortLegend(
+  modifier: Modifier = Modifier,
+  baseColor: Color = MaterialTheme.colors.primary,
+  peakColor: Color = Theme.goodAttention,
+  punishedColor: Color = Theme.timerAmber,
+  coldColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.25f)
+) {
+  FlowRow(
+    modifier,
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+    verticalArrangement = Arrangement.spacedBy(2.dp)
+  ) {
+    EffortZone.entries.forEach { zone ->
+      Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        Box(
+          Modifier
+            .size(8.dp)
+            .background(zoneColor(zone, baseColor, peakColor, punishedColor, coldColor), CircleShape)
+        )
+        Text(stringResource(zoneLabelRes(zone)), style = MaterialTheme.typography.caption)
+      }
+    }
+  }
+}
+
+internal fun zoneLabelRes(zone: EffortZone): Int = when (zone) {
+  EffortZone.COLD -> R.string.effort_zone_cold
+  EffortZone.BELOW -> R.string.effort_zone_below
+  EffortZone.ON_CURVE -> R.string.effort_zone_on_curve
+  EffortZone.GROWTH -> R.string.effort_zone_growth
+  EffortZone.IMPLAUSIBLE -> R.string.effort_zone_implausible
+}
+
+internal fun zoneColor(
   zone: EffortZone,
   baseColor: Color,
   peakColor: Color,
@@ -196,4 +311,45 @@ private fun PreviewEffortChartFlatHistory() {
     points = (0..6).map { EffortPoint(it.toFloat(), 100f, 0.60f, EffortZone.ON_CURVE) },
     trend = listOf((3..6).map { it.toFloat() to 100f })
   )
+}
+
+/** Regression check for the plot-rect inset: max-size bubbles sit at every domain corner and
+ * must not touch the [Color.White] box edge. */
+@Preview
+@Composable
+private fun PreviewEffortChartCornerPoints() {
+  EffortChart(
+    Modifier.size(300.dp).background(Color.White),
+    points = listOf(
+      EffortPoint(0f, 0f, 1.00f, EffortZone.GROWTH),
+      EffortPoint(0f, 100f, 1.00f, EffortZone.GROWTH),
+      EffortPoint(10f, 0f, 1.00f, EffortZone.GROWTH),
+      EffortPoint(10f, 100f, 1.00f, EffortZone.GROWTH)
+    )
+  )
+}
+
+@Preview
+@Composable
+private fun PreviewEffortChartWithAxesAndGaps() {
+  EffortChart(
+    Modifier.size(340.dp, 220.dp).background(Color.White),
+    points = listOf(
+      EffortPoint(0f, 20f, 0.30f, EffortZone.COLD),
+      EffortPoint(1f, 20f, 0.30f, EffortZone.COLD),
+      EffortPoint(2f, 15f, 0.60f, EffortZone.ON_CURVE),
+      EffortPoint(3f, 35f, 0.85f, EffortZone.GROWTH),
+      EffortPoint(4f, 40f, 1.00f, EffortZone.GROWTH)
+    ),
+    trend = listOf(listOf(3f to 33f, 4f to 38f)),
+    gapMarks = listOf(1.5f, 2.5f),
+    xLabels = listOf(0f to "Nov '21", 2f to "Jan '23", 4f to "Jun '23"),
+    yLabels = listOf(15f to "15", 40f to "40")
+  )
+}
+
+@Preview
+@Composable
+private fun PreviewEffortLegend() {
+  EffortLegend(Modifier.background(Color.White).padding(8.dp))
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortTrendRuns.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortTrendRuns.kt
@@ -1,0 +1,31 @@
+package com.litus_animae.refitted.ui.compose.charts
+
+/**
+ * Breaks a trend line into runs keyed by contiguous session - a session with no predicted
+ * weight (cold start, or filtered out of the caller's window) breaks the polyline rather
+ * than bridging across the gap.
+ *
+ * [xBySessionIndex] is the x-domain position to draw each session at, paired with the
+ * session index used to look it up in [expectedWeightBySession]. Order matters - runs are
+ * built in list order, so callers must already be sorted along x.
+ */
+fun buildTrendRuns(
+  xBySessionIndex: List<Pair<Float, Int>>,
+  expectedWeightBySession: Map<Int, Double>
+): List<List<Pair<Float, Float>>> {
+  val runs = mutableListOf<MutableList<Pair<Float, Float>>>()
+  var current: MutableList<Pair<Float, Float>>? = null
+  xBySessionIndex.forEach { (x, sessionIndex) ->
+    val expectedWeight = expectedWeightBySession[sessionIndex]
+    if (expectedWeight == null) {
+      current = null
+    } else {
+      val run = current ?: mutableListOf<Pair<Float, Float>>().also {
+        current = it
+        runs.add(it)
+      }
+      run.add(x to expectedWeight.toFloat())
+    }
+  }
+  return runs
+}

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Exercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Exercise.kt
@@ -79,7 +79,7 @@ fun ExerciseView(
 
   LaunchedEffect(exerciseSet) {
     setContextMenu { instruction?.let { ExerciseContextMenu(it, workoutPlan, onAlternateChange) } }
-    currentSetRecord?.let { setHistoryList(SetHistory(it.allSets, it.recentSets)) }
+    currentSetRecord?.let { setHistoryList(SetHistory(it.allSets)) }
   }
 
   val showRefreshIndicator = isRefreshing || exerciseSet == null || currentSetRecord == null

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Exercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Exercise.kt
@@ -26,13 +26,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.paging.PagingData
 import androidx.window.layout.DisplayFeature
 import com.google.accompanist.adaptive.HorizontalTwoPaneStrategy
 import com.google.accompanist.adaptive.TwoPane
 import com.google.accompanist.adaptive.VerticalTwoPaneStrategy
 import com.litus_animae.refitted.ui.compose.exercise.set.ExerciseSetView
 import com.litus_animae.refitted.ui.compose.state.ExerciseSetWithRecord
+import com.litus_animae.refitted.ui.compose.state.SetHistory
 import com.litus_animae.refitted.ui.compose.state.Weight
 import com.litus_animae.refitted.ui.compose.state.recordsByExerciseId
 import com.litus_animae.refitted.ui.compose.util.Theme
@@ -44,7 +44,6 @@ import com.litus_animae.refitted.ui.models.ExerciseViewModel
 import com.litus_animae.refitted.ui.models.WorkoutViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import java.time.Instant
 
@@ -55,7 +54,7 @@ fun ExerciseView(
   model: ExerciseViewModel = viewModel(),
   workoutPlan: WorkoutPlan?,
   contentPadding: PaddingValues,
-  setHistoryList: (Flow<PagingData<SetRecord>>) -> Unit,
+  setHistoryList: (SetHistory) -> Unit,
   setContextMenu: (@Composable RowScope.() -> Unit) -> Unit,
   onAlternateChange: (Int) -> Unit,
   onStartEditWeight: (Weight) -> Unit
@@ -80,7 +79,7 @@ fun ExerciseView(
 
   LaunchedEffect(exerciseSet) {
     setContextMenu { instruction?.let { ExerciseContextMenu(it, workoutPlan, onAlternateChange) } }
-    currentSetRecord?.allSets?.let { setHistoryList(it) }
+    currentSetRecord?.let { setHistoryList(SetHistory(it.allSets, it.recentSets)) }
   }
 
   val showRefreshIndicator = isRefreshing || exerciseSet == null || currentSetRecord == null

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
@@ -37,17 +37,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.paging.PagingData
 import com.litus_animae.refitted.ui.R
 import com.litus_animae.refitted.ui.compose.exercise.input.WeightButtons
+import com.litus_animae.refitted.ui.compose.state.SetHistory
 import com.litus_animae.refitted.ui.compose.state.Weight
 import com.litus_animae.refitted.ui.models.ExerciseViewModel
-import com.litus_animae.refitted.data.models.SetRecord
 import com.litus_animae.refitted.ui.models.WorkoutViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalMaterialApi::class)
@@ -77,7 +75,7 @@ fun Exercise(
   }
   var contextMenu by remember { mutableStateOf<@Composable RowScope.() -> Unit>({}) }
   val (historyList, setHistoryList) = remember {
-    mutableStateOf(emptyFlow<PagingData<SetRecord>>())
+    mutableStateOf(SetHistory())
   }
   Scaffold(
     // navigationBars alone leaves a side-mounted camera cutout unhandled once rotated to
@@ -116,7 +114,7 @@ fun Exercise(
       )
     },
     scaffoldState = scaffoldState,
-    drawerContent = { SetRecordList(flow = historyList) }
+    drawerContent = { SetRecordList(history = historyList) }
   ) {
     var sheetWeight by remember { mutableStateOf(Weight(0.0)) }
     ModalBottomSheetLayout(

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
@@ -138,6 +138,7 @@ fun Exercise(
           scaffoldScope.launch { sheetState.show() }
         },
         onSetSaved = { workoutModel.alignToDayIfUnaligned(loadedWorkoutPlan, day.toIntOrNull() ?: 1) },
+        onOpenHistory = { scaffoldScope.launch { scaffoldState.drawerState.open() } },
         editing = editing,
         onAddExercise = onAddExercise,
         scrollToExerciseName = scrollToExerciseName)

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -39,10 +39,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.paging.PagingData
 import arrow.core.nonEmptyListOf
 import com.litus_animae.refitted.ui.compose.exercise.set.ExerciseSetView
 import com.litus_animae.refitted.ui.compose.state.ExerciseSetWithRecord
+import com.litus_animae.refitted.ui.compose.state.SetHistory
 import com.litus_animae.refitted.ui.compose.state.Weight
 import com.litus_animae.refitted.ui.compose.state.recordsByExerciseId
 import com.litus_animae.refitted.ui.compose.util.Theme
@@ -53,7 +53,6 @@ import com.litus_animae.refitted.data.models.WorkoutPlan
 import com.litus_animae.refitted.ui.models.ExerciseViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
@@ -66,7 +65,7 @@ fun PagerExerciseView(
   model: ExerciseViewModel = viewModel(),
   workoutPlan: WorkoutPlan?,
   contentPadding: PaddingValues,
-  setHistoryList: (Flow<PagingData<SetRecord>>) -> Unit,
+  setHistoryList: (SetHistory) -> Unit,
   setContextMenu: (@Composable RowScope.() -> Unit) -> Unit,
   onAlternateChange: (Int) -> Unit,
   onStartEditWeight: (Weight) -> Unit,
@@ -115,7 +114,7 @@ fun PagerExerciseView(
 
   LaunchedEffect(exerciseSet) {
     setContextMenu { instruction?.let { ExerciseContextMenu(it, workoutPlan, onAlternateChange) } }
-    currentSetRecord?.allSets?.let { setHistoryList(it) }
+    currentSetRecord?.let { setHistoryList(SetHistory(it.allSets, it.recentSets)) }
   }
 
   // A genuinely empty day (no instructions, e.g. a fresh custom day) never resolves an

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -70,6 +70,7 @@ fun PagerExerciseView(
   onAlternateChange: (Int) -> Unit,
   onStartEditWeight: (Weight) -> Unit,
   onSetSaved: () -> Unit = {},
+  onOpenHistory: () -> Unit = {},
   editing: Boolean = false,
   onAddExercise: () -> Unit = {},
   scrollToExerciseName: String? = null
@@ -177,7 +178,8 @@ fun PagerExerciseView(
                 pagerState.requestScrollToPage(pagerState.settledPage + offset)
             }
           },
-          onStartEditWeight = onStartEditWeight
+          onStartEditWeight = onStartEditWeight,
+          onOpenHistory = onOpenHistory
         )
       }
     }
@@ -241,6 +243,7 @@ fun PagerDetailView(
   onTimerToggle: (id: String, running: Boolean, restSeconds: Int) -> Unit = { _, _, _ -> },
   onSave: (Record) -> Unit,
   onStartEditWeight: (Weight) -> Unit,
+  onOpenHistory: () -> Unit = {},
   editing: Boolean = false,
   onUpdateCustomTargets: (
     workout: String, day: String, step: String, sets: Int, reps: Int, rest: Int, repsRange: Int
@@ -356,7 +359,8 @@ fun PagerDetailView(
               activeSetWithRecord.exerciseSet.rest,
               repsRange
             )
-          }
+          },
+          onOpenHistory = onOpenHistory
         )
       }
     }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -114,7 +114,7 @@ fun PagerExerciseView(
 
   LaunchedEffect(exerciseSet) {
     setContextMenu { instruction?.let { ExerciseContextMenu(it, workoutPlan, onAlternateChange) } }
-    currentSetRecord?.let { setHistoryList(SetHistory(it.allSets, it.recentSets)) }
+    currentSetRecord?.let { setHistoryList(SetHistory(it.allSets)) }
   }
 
   // A genuinely empty day (no instructions, e.g. a fresh custom day) never resolves an

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
@@ -27,6 +27,8 @@ import androidx.compose.material.contentColorFor
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,10 +46,14 @@ import com.litus_animae.refitted.ui.compose.LocalFeatures
 import com.litus_animae.refitted.ui.compose.charts.BubbleChart
 import com.litus_animae.refitted.ui.compose.charts.BubbleChartExploded
 import com.litus_animae.refitted.ui.compose.charts.BubbleData
+import com.litus_animae.refitted.ui.compose.charts.EffortChart
+import com.litus_animae.refitted.ui.compose.charts.EffortPoint
 import com.litus_animae.refitted.ui.compose.charts.LineChart
 import com.litus_animae.refitted.ui.compose.state.SetHistory
 import com.litus_animae.refitted.ui.compose.util.LoadingView
 import com.litus_animae.refitted.identity.ConfigProvider
+import com.litus_animae.refitted.data.effort.EffortModel
+import com.litus_animae.refitted.data.effort.toEffortSet
 import com.litus_animae.refitted.data.models.SetRecord
 import kotlinx.coroutines.flow.flowOf
 import java.time.Instant
@@ -142,7 +148,37 @@ fun SetRecordList(
       }
     }
 
-    if (records.itemCount > 0) {
+    val recent by history.recent.collectAsState(initial = emptyList())
+    if (LocalFeatures.current.flags[ConfigProvider.Companion.Feature.RECORD_CHART_TYPE] == "effort") {
+      // Fit from the bounded recent-history flow, never the paged snapshot backing the list
+      // above - that would make the trend visibly shift as the user scrolls and more pages
+      // load, since the fit would be over however much of the list happens to be loaded.
+      if (recent.isNotEmpty()) {
+        val series = remember(recent) { EffortModel.score(recent.map { it.toEffortSet() }) }
+        val points = remember(series) {
+          series.sets.map {
+            EffortPoint(
+              // Spreads same-day sets within [dayOffset, dayOffset + 1) instead of stacking
+              // them on one x value.
+              x = it.dayOffset + (it.setIndexInSession + 1f) / (it.setsInSession + 1f),
+              weight = it.source.weight.toFloat(),
+              size = it.size,
+              zone = it.zone
+            )
+          }
+        }
+        val trend = remember(series) {
+          listOf(series.trend.map { it.dayOffset.toFloat() to it.expectedWeight.toFloat() })
+        }
+        EffortChart(
+          Modifier
+            .fillMaxWidth()
+            .weight(1f),
+          points = points,
+          trend = trend
+        )
+      }
+    } else if (records.itemCount > 0) {
       val items = remember(records.itemSnapshotList) {
         records.itemSnapshotList.items.reversed()
       }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -50,6 +51,7 @@ import androidx.paging.LoadState
 import androidx.paging.LoadStates
 import androidx.paging.PagingData
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.litus_animae.refitted.data.effort.EffortConfig
 import com.litus_animae.refitted.data.effort.EffortModel
 import com.litus_animae.refitted.data.effort.ScoredSet
 import com.litus_animae.refitted.data.effort.TrendPoint
@@ -334,6 +336,18 @@ private fun SessionRow(
  * sessions, and a calendar x-axis would leave most of the plot empty. [EffortModel.score]
  * still fits on real day-offset regardless of this display choice.
  */
+/**
+ * The coarsest tick format that keeps thinned labels legible at the loaded span - avoids the
+ * month/year pattern rounding a handful of days apart down to identical text, while still
+ * collapsing a multi-year history to something coarser than a day-of-month number nobody
+ * needs at that scale.
+ */
+private fun axisFormatterFor(spanDays: Long): DateTimeFormatter = when {
+  spanDays < 120 -> DateTimeFormatter.ofPattern("MMM d")
+  spanDays < 730 -> DateTimeFormatter.ofPattern("MMM ''yy")
+  else -> DateTimeFormatter.ofPattern("yyyy")
+}
+
 @Composable
 private fun EffortHistoryCard(
   modifier: Modifier = Modifier,
@@ -341,7 +355,6 @@ private fun EffortHistoryCard(
   trend: List<TrendPoint>,
   zone: ZoneId
 ) {
-  val monthYear = remember { DateTimeFormatter.ofPattern("MMM ''yy") }
   val sortedEntries = remember(bestBySessionIndex) {
     bestBySessionIndex.entries.sortedBy { it.key }
   }
@@ -362,14 +375,21 @@ private fun EffortHistoryCard(
       if (b.value.dayOffset - a.value.dayOffset > GapThresholdDays) a.key + 0.5f else null
     }
   }
-  val xLabels = remember(sortedEntries) {
+  val xLabels = remember(sortedEntries, zone) {
     if (sortedEntries.isEmpty()) {
       emptyList()
     } else {
+      val spanDays = sortedEntries.last().value.dayOffset - sortedEntries.first().value.dayOffset
+      val formatter = axisFormatterFor(spanDays)
       val step = (sortedEntries.size / MaxXLabels).coerceAtLeast(1)
-      sortedEntries.filterIndexed { index, _ -> index % step == 0 }.map { (sessionIndex, scored) ->
-        sessionIndex.toFloat() to monthYear.format(scored.source.completed.atZone(zone))
-      }
+      sortedEntries.filterIndexed { index, _ -> index % step == 0 }
+        .map { (sessionIndex, scored) ->
+          sessionIndex.toFloat() to formatter.format(scored.source.completed.atZone(zone))
+        }
+        // The whole point of picking a granularity is distinct ticks - a residual collision
+        // (e.g. sessions packed tightly at extreme thinning) drops the later duplicate rather
+        // than showing two ticks with the same rounded text.
+        .distinctBy { it.second }
     }
   }
   val yLabels = remember(points) {
@@ -402,11 +422,28 @@ private fun EffortHistoryCard(
         yLabels = yLabels,
         gapMarks = gapMarks
       )
-      EffortLegend(
-        Modifier
-          .fillMaxWidth()
-          .padding(top = 4.dp)
-      )
+      if (trend.isEmpty()) {
+        // No SESSION-sourced trend point exists yet - say so explicitly instead of a legend
+        // decoding colors that haven't appeared. The drawer only ever calls plain
+        // EffortModel.score(), so it never sees the strip's bootstrap trend either; the wait
+        // is real, not just a rendering gap.
+        val remaining = (EffortConfig.Default.minPriorSessions + 1 - bestBySessionIndex.size)
+          .coerceAtLeast(1)
+        Text(
+          pluralStringResource(R.plurals.sessions_until_trend, remaining, remaining),
+          style = MaterialTheme.typography.caption,
+          color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
+          modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp)
+        )
+      } else {
+        EffortLegend(
+          Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp)
+        )
+      }
     }
   }
 }
@@ -457,5 +494,46 @@ private fun PreviewSetRecordListEffortChart() {
     )
   ) {
     PreviewSetRecordList()
+  }
+}
+
+/**
+ * Only 2 sessions, days apart - regression check for both the adaptive axis (previously
+ * always rendered month/year ticks, which round a 2-day gap to identical text) and the
+ * countdown caption that should replace the legend while EffortModel.score() has no
+ * SESSION-sourced trend point yet.
+ */
+@Preview
+@Composable
+private fun PreviewSetRecordListEffortChartFewSessions() {
+  val records = listOf(
+    SetRecord(20.0, 8, "X", "Y", Instant.parse("2026-07-12T06:44:50Z"), "Z"),
+    SetRecord(20.0, 8, "X", "Y", Instant.parse("2026-07-12T06:46:29Z"), "Z"),
+    SetRecord(20.0, 8, "X", "Y", Instant.parse("2026-07-12T06:49:20Z"), "Z"),
+    SetRecord(22.5, 8, "X", "Y", Instant.parse("2026-07-26T06:29:26Z"), "Z"),
+    SetRecord(22.5, 8, "X", "Y", Instant.parse("2026-07-26T06:31:18Z"), "Z"),
+    SetRecord(22.5, 8, "X", "Y", Instant.parse("2026-07-26T06:33:05Z"), "Z")
+  )
+  val data = PagingData.from(
+    records.reversed(),
+    sourceLoadStates = LoadStates(
+      LoadState.NotLoading(true),
+      LoadState.NotLoading(true),
+      LoadState.NotLoading(true)
+    )
+  )
+
+  CompositionLocalProvider(
+    LocalFeatures provides ConfigProvider.Companion.RemoteConfig(
+      mapOf(ConfigProvider.Companion.Feature.RECORD_CHART_TYPE to "effort")
+    )
+  ) {
+    SetRecordList(
+      Modifier
+        .background(Color.White)
+        .height(500.dp)
+        .width(360.dp),
+      SetHistory(flowOf(data))
+    )
   }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
@@ -45,10 +45,10 @@ import com.litus_animae.refitted.ui.compose.charts.BubbleChart
 import com.litus_animae.refitted.ui.compose.charts.BubbleChartExploded
 import com.litus_animae.refitted.ui.compose.charts.BubbleData
 import com.litus_animae.refitted.ui.compose.charts.LineChart
+import com.litus_animae.refitted.ui.compose.state.SetHistory
 import com.litus_animae.refitted.ui.compose.util.LoadingView
 import com.litus_animae.refitted.identity.ConfigProvider
 import com.litus_animae.refitted.data.models.SetRecord
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import java.time.Instant
 import java.time.ZoneId
@@ -58,9 +58,9 @@ import java.time.format.FormatStyle
 @Composable
 fun SetRecordList(
   modifier: Modifier = Modifier,
-  flow: Flow<PagingData<SetRecord>>
+  history: SetHistory
 ) {
-  val records = flow.collectAsLazyPagingItems()
+  val records = history.paged.collectAsLazyPagingItems()
 
   Column(modifier
     .fillMaxSize()) {
@@ -215,14 +215,15 @@ private fun RecordItem(
 @Preview
 @Composable
 private fun PreviewSetRecordList() {
+  val records = listOf(
+    SetRecord(35.0, 6, "X", "Y", Instant.ofEpochMilli(1000), "Z"),
+    SetRecord(37.5, 6, "X", "Y", Instant.ofEpochMilli(2000), "Z"),
+    SetRecord(35.0, 10, "X", "Y", Instant.ofEpochMilli(4000), "Z"),
+    SetRecord(40.0, 6, "X", "Y", Instant.ofEpochMilli(6000), "Z"),
+    SetRecord(45.0, 2, "X", "Y", Instant.ofEpochMilli(7000), "Z"),
+  )
   val data = PagingData.from(
-    listOf(
-      SetRecord(35.0, 6, "X", "Y", Instant.ofEpochMilli(1000), "Z"),
-      SetRecord(37.5, 6, "X", "Y", Instant.ofEpochMilli(2000), "Z"),
-      SetRecord(35.0, 10, "X", "Y", Instant.ofEpochMilli(4000), "Z"),
-      SetRecord(40.0, 6, "X", "Y", Instant.ofEpochMilli(6000), "Z"),
-      SetRecord(45.0, 2, "X", "Y", Instant.ofEpochMilli(7000), "Z"),
-    ),
+    records,
     sourceLoadStates = LoadStates(
       LoadState.NotLoading(true),
       LoadState.NotLoading(true),
@@ -235,6 +236,6 @@ private fun PreviewSetRecordList() {
       .background(Color.White)
       .height(400.dp)
       .width(200.dp),
-    flowOf(data)
+    SetHistory(flowOf(data), flowOf(records))
   )
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
@@ -1,8 +1,10 @@
 package com.litus_animae.refitted.ui.compose.exercise
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
@@ -43,6 +45,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -156,95 +159,111 @@ fun SetRecordList(
       }
     }
 
-    // Charted above the scrolling list, not below it - a card anchored at the very bottom of
-    // the drawer sat under the gesture nav bar / corner bezel on edge-to-edge devices. The
-    // list is the one thing here that's meant to scroll, so it's the one that should own the
-    // bottom edge, with its own inset padding rather than a card fighting the system bars.
-    if (LocalFeatures.current.flags[ConfigProvider.Companion.Feature.RECORD_CHART_TYPE] == "effort") {
-      if (bestBySessionIndex.isNotEmpty()) {
-        EffortHistoryCard(
-          Modifier
-            .fillMaxWidth()
-            .weight(1f),
-          bestBySessionIndex = bestBySessionIndex,
-          trend = series.trend,
-          zone = zone
-        )
-      }
-    } else if (records.itemCount > 0) {
-      val items = remember(records.itemSnapshotList) {
-        records.itemSnapshotList.items.reversed()
-      }
-      if (LocalFeatures.current.flags[ConfigProvider.Companion.Feature.RECORD_CHART_TYPE] == "bubble-exploded") {
-        val data = remember(items) {
-          items.map { BubbleData(it.completed, it.weight.toFloat(), it.reps) }
-        }
-
-        BubbleChartExploded(
-          Modifier
-            .fillMaxWidth()
-            .weight(1f),
-          data = data,
-          inverseRelationship = true
-        )
-      } else if (LocalFeatures.current.flags[ConfigProvider.Companion.Feature.RECORD_CHART_TYPE] == "bubble") {
-        val data = remember(items) {
-          items.map { BubbleData(it.completed, it.weight.toFloat(), it.reps) }
-        }
-
-        BubbleChart(
-          Modifier
-            .fillMaxWidth()
-            .weight(1f),
-          data = data,
-          inverseRelationship = true
-        )
-      } else {
-        val data = remember(items) {
-          items.map { it.completed to it.weight.toFloat() }
-        }
-        LineChart(
-          Modifier
-            .fillMaxWidth()
-            .weight(1f),
-          data = data
-        )
-      }
+    // AdaptiveExercisePanes applies one ratio to both axes, but the list's good portrait
+    // width (2/3 of a narrow screen) and its good landscape width (which only needs to stay
+    // roughly that same absolute width, not 2/3 of a much wider screen) aren't the same
+    // fraction - a landscape screen is wide enough that giving the chart a bigger share still
+    // leaves the list at a comparable width to portrait's, rather than needlessly wide.
+    val chartSplitRatio = if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+      0.6f
+    } else {
+      1f / 3f
     }
 
-    LazyColumn(
-      Modifier.weight(2f),
-      contentPadding = WindowInsets.navigationBars.only(WindowInsetsSides.Bottom).asPaddingValues()
-    ) {
-      // TODO does this cause everything to recompose? Should we just overlay?
-      if (records.loadState.refresh is LoadState.Loading) {
-        item {
-          Row(Modifier.fillMaxWidth()) {
-            LoadingView()
-          }
-        }
-      } else {
-        items(sessions, key = { it.day.toEpochDay() }) { session ->
-          val scored = bestBySessionIndex[sessionIndexByDay[session.day]]
-          SessionRow(
-            session = session,
-            isPR = scored != null && scored.capacity == bestCapacityOverall,
-            expanded = isExpanded(session.day),
-            onToggle = {
-              expandedOverrides = expandedOverrides +
-                (session.day.toEpochDay() to !isExpanded(session.day))
+    // Chart left / list right in landscape, chart top / list bottom in portrait - reuses the
+    // same reflow PagerExercise.kt uses for its instructions/set-detail split. In landscape a
+    // side-mounted camera cutout lands on whichever pane sits at that edge, so this needs the
+    // same horizontal cutout inset the header above already applies to itself - unlike the
+    // header, there's no app bar to carry it, so it's applied directly here. The chart pane
+    // must always emit exactly one composable (AdaptiveExercisePanes measures first() and
+    // second() as one child each), so the flag/empty-state branches below are wrapped in one
+    // outer Box rather than conditionally emitting nothing.
+    AdaptiveExercisePanes(
+      Modifier
+        .fillMaxWidth()
+        .weight(1f)
+        .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
+      splitRatio = chartSplitRatio,
+      first = {
+        // Matches SessionRow's own horizontal inset (10.dp) so the chart pane doesn't sit
+        // flush against the drawer edge or the header the way the list's Card rows don't
+        // either - the elevated Card had no margin of its own in any orientation, most
+        // visible in landscape where it touched both the header and the pane's bottom edge.
+        Box(
+          Modifier
+            .fillMaxSize()
+            .padding(horizontal = 10.dp, vertical = 8.dp)
+        ) {
+          if (LocalFeatures.current.flags[ConfigProvider.Companion.Feature.RECORD_CHART_TYPE] == "effort") {
+            if (bestBySessionIndex.isNotEmpty()) {
+              EffortHistoryCard(
+                Modifier.fillMaxSize(),
+                bestBySessionIndex = bestBySessionIndex,
+                trend = series.trend,
+                zone = zone
+              )
             }
-          )
-        }
-        if (records.loadState.append is LoadState.Loading) {
-          item {
-            Row(Modifier.fillMaxWidth()) {
-              LoadingView()
+          } else if (records.itemCount > 0) {
+            val items = remember(records.itemSnapshotList) {
+              records.itemSnapshotList.items.reversed()
+            }
+            if (LocalFeatures.current.flags[ConfigProvider.Companion.Feature.RECORD_CHART_TYPE] == "bubble-exploded") {
+              val data = remember(items) {
+                items.map { BubbleData(it.completed, it.weight.toFloat(), it.reps) }
+              }
+
+              BubbleChartExploded(Modifier.fillMaxSize(), data = data, inverseRelationship = true)
+            } else if (LocalFeatures.current.flags[ConfigProvider.Companion.Feature.RECORD_CHART_TYPE] == "bubble") {
+              val data = remember(items) {
+                items.map { BubbleData(it.completed, it.weight.toFloat(), it.reps) }
+              }
+
+              BubbleChart(Modifier.fillMaxSize(), data = data, inverseRelationship = true)
+            } else {
+              val data = remember(items) {
+                items.map { it.completed to it.weight.toFloat() }
+              }
+              LineChart(Modifier.fillMaxSize(), data = data)
             }
           }
         }
+      },
+      second = {
+        LazyColumn(
+          Modifier.fillMaxSize(),
+          contentPadding = WindowInsets.navigationBars.only(WindowInsetsSides.Bottom).asPaddingValues()
+        ) {
+          // TODO does this cause everything to recompose? Should we just overlay?
+          if (records.loadState.refresh is LoadState.Loading) {
+            item {
+              Row(Modifier.fillMaxWidth()) {
+                LoadingView()
+              }
+            }
+          } else {
+            items(sessions, key = { it.day.toEpochDay() }) { session ->
+              val scored = bestBySessionIndex[sessionIndexByDay[session.day]]
+              SessionRow(
+                session = session,
+                isPR = scored != null && scored.capacity == bestCapacityOverall,
+                expanded = isExpanded(session.day),
+                onToggle = {
+                  expandedOverrides = expandedOverrides +
+                    (session.day.toEpochDay() to !isExpanded(session.day))
+                }
+              )
+            }
+            if (records.loadState.append is LoadState.Loading) {
+              item {
+                Row(Modifier.fillMaxWidth()) {
+                  LoadingView()
+                }
+              }
+            }
+          }
+        }
       }
-    }
+    )
   }
 }
 

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
@@ -17,7 +17,10 @@ import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.AppBarDefaults
+import androidx.compose.material.Card
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -25,11 +28,16 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.contentColorFor
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -40,26 +48,35 @@ import androidx.paging.LoadState
 import androidx.paging.LoadStates
 import androidx.paging.PagingData
 import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.paging.compose.itemKey
+import com.litus_animae.refitted.data.effort.EffortModel
+import com.litus_animae.refitted.data.effort.ScoredSet
+import com.litus_animae.refitted.data.effort.TrendPoint
+import com.litus_animae.refitted.data.effort.toEffortSet
+import com.litus_animae.refitted.data.models.SetRecord
+import com.litus_animae.refitted.identity.ConfigProvider
 import com.litus_animae.refitted.ui.R
 import com.litus_animae.refitted.ui.compose.LocalFeatures
 import com.litus_animae.refitted.ui.compose.charts.BubbleChart
 import com.litus_animae.refitted.ui.compose.charts.BubbleChartExploded
 import com.litus_animae.refitted.ui.compose.charts.BubbleData
 import com.litus_animae.refitted.ui.compose.charts.EffortChart
+import com.litus_animae.refitted.ui.compose.charts.EffortLegend
 import com.litus_animae.refitted.ui.compose.charts.EffortPoint
 import com.litus_animae.refitted.ui.compose.charts.LineChart
+import com.litus_animae.refitted.ui.compose.charts.buildTrendRuns
 import com.litus_animae.refitted.ui.compose.state.SetHistory
 import com.litus_animae.refitted.ui.compose.util.LoadingView
-import com.litus_animae.refitted.identity.ConfigProvider
-import com.litus_animae.refitted.data.effort.EffortModel
-import com.litus_animae.refitted.data.effort.toEffortSet
-import com.litus_animae.refitted.data.models.SetRecord
+import com.litus_animae.refitted.ui.compose.util.Theme
 import kotlinx.coroutines.flow.flowOf
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
+import kotlin.math.roundToInt
+
+private const val GapThresholdDays = 21L
+private const val MaxXLabels = 4
 
 @Composable
 fun SetRecordList(
@@ -67,9 +84,45 @@ fun SetRecordList(
   history: SetHistory
 ) {
   val records = history.paged.collectAsLazyPagingItems()
+  val zone = remember { ZoneId.systemDefault() }
 
-  Column(modifier
-    .fillMaxSize()) {
+  // The oldest loaded session may be an arbitrary slice of Paging's page boundary rather
+  // than the exercise's actual set count for that day - holding it back until pagination
+  // is exhausted keeps its row summary (set count, top weight) and its bubble/PR status
+  // from flickering, and keeps a truncated session from understating its capacity into the
+  // effort fit.
+  val appendDone = records.loadState.append.endOfPaginationReached
+  val retained = remember(records.itemSnapshotList, appendDone) {
+    val items = records.itemSnapshotList.items
+    if (appendDone || items.isEmpty()) {
+      items
+    } else {
+      val oldestDay = items.minOf { it.completed.atZone(zone).toLocalDate() }
+      items.filterNot { it.completed.atZone(zone).toLocalDate() == oldestDay }
+    }
+  }
+
+  val sessions = remember(retained) {
+    retained.groupBy { it.completed.atZone(zone).toLocalDate() }
+      .map { (day, sets) -> SessionGroup(day, sets.sortedBy { it.completed }) }
+  }
+  val series = remember(retained) { EffortModel.score(retained.map { it.toEffortSet() }) }
+  val sessionIndexByDay = remember(retained) {
+    retained.map { it.completed.atZone(zone).toLocalDate() }.distinct().sorted()
+      .withIndex().associate { (i, day) -> day to i }
+  }
+  val bestBySessionIndex = remember(series) {
+    series.sets.groupBy { it.sessionIndex }.mapValues { (_, scored) -> scored.maxBy { it.capacity } }
+  }
+  val bestCapacityOverall = remember(bestBySessionIndex) {
+    bestBySessionIndex.values.maxOfOrNull { it.capacity }
+  }
+
+  var expandedOverrides by rememberSaveable { mutableStateOf<Map<Long, Boolean>>(emptyMap()) }
+  fun isExpanded(day: LocalDate) =
+    expandedOverrides[day.toEpochDay()] ?: (day == sessions.firstOrNull()?.day)
+
+  Column(modifier.fillMaxSize()) {
     Row(
       Modifier
         .fillMaxWidth()
@@ -100,7 +153,6 @@ fun SetRecordList(
     }
 
     LazyColumn(Modifier.weight(2f)) {
-
       // TODO does this cause everything to recompose? Should we just overlay?
       if (records.loadState.refresh is LoadState.Loading) {
         item {
@@ -109,73 +161,37 @@ fun SetRecordList(
           }
         }
       } else {
-        // TODO if we can pull the loading state out, then make this sticky at the top outside the lazycolumn
-        val dateFormat = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)
-          .withZone(ZoneId.systemDefault())
-        item {
-          Row(
-            Modifier
-              .fillMaxWidth()
-              .padding(horizontal = 10.dp, vertical = 15.dp),
-            horizontalArrangement = Arrangement.SpaceBetween
-          ) {
-            Text(
-              stringResource(id = R.string.date),
-              style = MaterialTheme.typography.button
-            )
-            Text(
-              stringResource(id = R.string.reps_label),
-              style = MaterialTheme.typography.button
-            )
-            val weightLabel = stringResource(id = R.string.weight_label)
-            val weightUnits = stringResource(id = R.string.lbs)
-            Text(
-              "$weightLabel ($weightUnits)",
-              style = MaterialTheme.typography.button
-            )
-          }
+        items(sessions, key = { it.day.toEpochDay() }) { session ->
+          val scored = bestBySessionIndex[sessionIndexByDay[session.day]]
+          SessionRow(
+            session = session,
+            isPR = scored != null && scored.capacity == bestCapacityOverall,
+            expanded = isExpanded(session.day),
+            onToggle = {
+              expandedOverrides = expandedOverrides +
+                (session.day.toEpochDay() to !isExpanded(session.day))
+            }
+          )
         }
-
-        items(
-          count = records.itemCount,
-          key = records.itemKey { it.completed }
-        ) { index ->
-          val record = records[index]
-          if (record != null) {
-            RecordItem(dateFormat, record)
+        if (records.loadState.append is LoadState.Loading) {
+          item {
+            Row(Modifier.fillMaxWidth()) {
+              LoadingView()
+            }
           }
         }
       }
     }
 
-    val recent by history.recent.collectAsState(initial = emptyList())
     if (LocalFeatures.current.flags[ConfigProvider.Companion.Feature.RECORD_CHART_TYPE] == "effort") {
-      // Fit from the bounded recent-history flow, never the paged snapshot backing the list
-      // above - that would make the trend visibly shift as the user scrolls and more pages
-      // load, since the fit would be over however much of the list happens to be loaded.
-      if (recent.isNotEmpty()) {
-        val series = remember(recent) { EffortModel.score(recent.map { it.toEffortSet() }) }
-        val points = remember(series) {
-          series.sets.map {
-            EffortPoint(
-              // Spreads same-day sets within [dayOffset, dayOffset + 1) instead of stacking
-              // them on one x value.
-              x = it.dayOffset + (it.setIndexInSession + 1f) / (it.setsInSession + 1f),
-              weight = it.source.weight.toFloat(),
-              size = it.size,
-              zone = it.zone
-            )
-          }
-        }
-        val trend = remember(series) {
-          listOf(series.trend.map { it.dayOffset.toFloat() to it.expectedWeight.toFloat() })
-        }
-        EffortChart(
+      if (bestBySessionIndex.isNotEmpty()) {
+        EffortHistoryCard(
           Modifier
             .fillMaxWidth()
             .weight(1f),
-          points = points,
-          trend = trend
+          bestBySessionIndex = bestBySessionIndex,
+          trend = series.trend,
+          zone = zone
         )
       }
     } else if (records.itemCount > 0) {
@@ -221,45 +237,192 @@ fun SetRecordList(
   }
 }
 
+private data class SessionGroup(val day: LocalDate, val sets: List<SetRecord>) {
+  val topWeight = sets.maxOf { it.weight }
+  val volume = sets.sumOf { it.reps * it.weight }
+}
+
 @Composable
-private fun RecordItem(
-  dateFormat: DateTimeFormatter,
-  record: SetRecord
+private fun SessionRow(
+  session: SessionGroup,
+  isPR: Boolean,
+  expanded: Boolean,
+  onToggle: () -> Unit
 ) {
-  Row(
+  val dayFormat = remember { DateTimeFormatter.ofPattern("MMM d, yyyy") }
+  val timeFormat = remember {
+    DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withZone(ZoneId.systemDefault())
+  }
+
+  Card(
     Modifier
       .fillMaxWidth()
-      .padding(horizontal = 10.dp, vertical = 15.dp),
-    horizontalArrangement = Arrangement.SpaceBetween
+      .padding(horizontal = 10.dp, vertical = 4.dp),
+    elevation = 1.dp
   ) {
-    Text(
-      dateFormat.format(record.completed),
-      style = MaterialTheme.typography.button
-    )
-    Text(
-      record.reps.toString(),
-      style = MaterialTheme.typography.button
-    )
-    Text(
-      String.format("%.1f", record.weight),
-      style = MaterialTheme.typography.button
-    )
+    Column {
+      Row(
+        Modifier
+          .fillMaxWidth()
+          .clickable(onClick = onToggle)
+          .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+      ) {
+        Column(Modifier.weight(1f)) {
+          Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+          ) {
+            Text(dayFormat.format(session.day), style = MaterialTheme.typography.subtitle2)
+            if (isPR) {
+              Text(
+                // TODO localize
+                "PR",
+                style = MaterialTheme.typography.caption,
+                color = Color.White,
+                modifier = Modifier
+                  .background(Theme.goodAttention, RoundedCornerShape(4.dp))
+                  .padding(horizontal = 4.dp, vertical = 1.dp)
+              )
+            }
+          }
+          Text(
+            // TODO localize
+            "${session.sets.size} sets · ${String.format("%.0f", session.volume)} lbs volume",
+            style = MaterialTheme.typography.caption,
+            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+          )
+        }
+        Text(String.format("%.1f", session.topWeight), style = MaterialTheme.typography.button)
+        Icon(
+          if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+          contentDescription = null
+        )
+      }
+      if (expanded) {
+        session.sets.forEachIndexed { index, set ->
+          Divider()
+          Row(
+            Modifier
+              .fillMaxWidth()
+              .padding(horizontal = 12.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+          ) {
+            Text(timeFormat.format(set.completed), style = MaterialTheme.typography.caption)
+            Text(set.reps.toString(), style = MaterialTheme.typography.body2)
+            Text(String.format("%.1f", set.weight), style = MaterialTheme.typography.body2)
+          }
+        }
+      }
+    }
   }
-  Divider()
+}
+
+/**
+ * The effort chart, titled and cared, plotting one bubble per session (its best set) against
+ * uniform session slots rather than calendar time - real histories jump months between
+ * sessions, and a calendar x-axis would leave most of the plot empty. [EffortModel.score]
+ * still fits on real day-offset regardless of this display choice.
+ */
+@Composable
+private fun EffortHistoryCard(
+  modifier: Modifier = Modifier,
+  bestBySessionIndex: Map<Int, ScoredSet>,
+  trend: List<TrendPoint>,
+  zone: ZoneId
+) {
+  val monthYear = remember { DateTimeFormatter.ofPattern("MMM ''yy") }
+  val sortedEntries = remember(bestBySessionIndex) {
+    bestBySessionIndex.entries.sortedBy { it.key }
+  }
+
+  val points = remember(sortedEntries) {
+    sortedEntries.map { (sessionIndex, scored) ->
+      EffortPoint(sessionIndex.toFloat(), scored.source.weight.toFloat(), scored.size, scored.zone)
+    }
+  }
+  val expectedWeightBySession = remember(trend) {
+    trend.associateBy({ it.sessionIndex }, { it.expectedWeight })
+  }
+  val trendRuns = remember(sortedEntries, expectedWeightBySession) {
+    buildTrendRuns(sortedEntries.map { it.key.toFloat() to it.key }, expectedWeightBySession)
+  }
+  val gapMarks = remember(sortedEntries) {
+    sortedEntries.zipWithNext().mapNotNull { (a, b) ->
+      if (b.value.dayOffset - a.value.dayOffset > GapThresholdDays) a.key + 0.5f else null
+    }
+  }
+  val xLabels = remember(sortedEntries) {
+    if (sortedEntries.isEmpty()) {
+      emptyList()
+    } else {
+      val step = (sortedEntries.size / MaxXLabels).coerceAtLeast(1)
+      sortedEntries.filterIndexed { index, _ -> index % step == 0 }.map { (sessionIndex, scored) ->
+        sessionIndex.toFloat() to monthYear.format(scored.source.completed.atZone(zone))
+      }
+    }
+  }
+  val yLabels = remember(points) {
+    if (points.isEmpty()) {
+      emptyList()
+    } else {
+      val minWeight = points.minOf { it.weight }
+      val maxWeight = points.maxOf { it.weight }
+      listOf(minWeight, (minWeight + maxWeight) / 2f, maxWeight)
+        .distinct()
+        .map { it to it.roundToInt().toString() }
+    }
+  }
+
+  Card(modifier, elevation = 2.dp) {
+    Column(Modifier.padding(12.dp)) {
+      Text(stringResource(R.string.effort_label), style = MaterialTheme.typography.subtitle2)
+      Text(
+        stringResource(R.string.effort_chart_subtitle),
+        style = MaterialTheme.typography.caption,
+        color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+      )
+      EffortChart(
+        Modifier
+          .fillMaxWidth()
+          .weight(1f),
+        points = points,
+        trend = trendRuns,
+        xLabels = xLabels,
+        yLabels = yLabels,
+        gapMarks = gapMarks
+      )
+      EffortLegend(
+        Modifier
+          .fillMaxWidth()
+          .padding(top = 4.dp)
+      )
+    }
+  }
 }
 
 @Preview
 @Composable
 private fun PreviewSetRecordList() {
+  // Spans a multi-year gap so the drawer preview exercises grouping, the PR badge, and the
+  // chart's gap marks together - same fixture shape as the drafted redesign this was based on.
   val records = listOf(
-    SetRecord(35.0, 6, "X", "Y", Instant.ofEpochMilli(1000), "Z"),
-    SetRecord(37.5, 6, "X", "Y", Instant.ofEpochMilli(2000), "Z"),
-    SetRecord(35.0, 10, "X", "Y", Instant.ofEpochMilli(4000), "Z"),
-    SetRecord(40.0, 6, "X", "Y", Instant.ofEpochMilli(6000), "Z"),
-    SetRecord(45.0, 2, "X", "Y", Instant.ofEpochMilli(7000), "Z"),
+    SetRecord(20.0, 8, "X", "Y", Instant.parse("2021-11-16T06:44:50Z"), "Z"),
+    SetRecord(20.0, 8, "X", "Y", Instant.parse("2021-11-16T06:46:29Z"), "Z"),
+    SetRecord(20.0, 8, "X", "Y", Instant.parse("2021-11-16T06:49:20Z"), "Z"),
+    SetRecord(15.0, 11, "X", "Y", Instant.parse("2023-01-17T06:29:26Z"), "Z"),
+    SetRecord(15.0, 10, "X", "Y", Instant.parse("2023-01-17T06:31:18Z"), "Z"),
+    SetRecord(15.0, 10, "X", "Y", Instant.parse("2023-01-17T06:33:05Z"), "Z"),
+    SetRecord(35.0, 10, "X", "Y", Instant.parse("2023-06-05T06:32:29Z"), "Z"),
+    SetRecord(35.0, 11, "X", "Y", Instant.parse("2023-06-05T06:34:27Z"), "Z"),
+    SetRecord(35.0, 11, "X", "Y", Instant.parse("2023-06-05T06:36:36Z"), "Z"),
+    SetRecord(40.0, 11, "X", "Y", Instant.parse("2023-06-13T06:24:07Z"), "Z"),
+    SetRecord(40.0, 10, "X", "Y", Instant.parse("2023-06-13T06:25:59Z"), "Z"),
+    SetRecord(40.0, 10, "X", "Y", Instant.parse("2023-06-13T06:27:55Z"), "Z")
   )
   val data = PagingData.from(
-    records,
+    records.reversed(),
     sourceLoadStates = LoadStates(
       LoadState.NotLoading(true),
       LoadState.NotLoading(true),
@@ -270,8 +433,20 @@ private fun PreviewSetRecordList() {
   SetRecordList(
     Modifier
       .background(Color.White)
-      .height(400.dp)
-      .width(200.dp),
-    SetHistory(flowOf(data), flowOf(records))
+      .height(500.dp)
+      .width(360.dp),
+    SetHistory(flowOf(data))
   )
+}
+
+@Preview
+@Composable
+private fun PreviewSetRecordListEffortChart() {
+  CompositionLocalProvider(
+    LocalFeatures provides ConfigProvider.Companion.RemoteConfig(
+      mapOf(ConfigProvider.Companion.Feature.RECORD_CHART_TYPE to "effort")
+    )
+  ) {
+    PreviewSetRecordList()
+  }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
@@ -7,10 +7,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.union
@@ -152,37 +154,10 @@ fun SetRecordList(
       }
     }
 
-    LazyColumn(Modifier.weight(2f)) {
-      // TODO does this cause everything to recompose? Should we just overlay?
-      if (records.loadState.refresh is LoadState.Loading) {
-        item {
-          Row(Modifier.fillMaxWidth()) {
-            LoadingView()
-          }
-        }
-      } else {
-        items(sessions, key = { it.day.toEpochDay() }) { session ->
-          val scored = bestBySessionIndex[sessionIndexByDay[session.day]]
-          SessionRow(
-            session = session,
-            isPR = scored != null && scored.capacity == bestCapacityOverall,
-            expanded = isExpanded(session.day),
-            onToggle = {
-              expandedOverrides = expandedOverrides +
-                (session.day.toEpochDay() to !isExpanded(session.day))
-            }
-          )
-        }
-        if (records.loadState.append is LoadState.Loading) {
-          item {
-            Row(Modifier.fillMaxWidth()) {
-              LoadingView()
-            }
-          }
-        }
-      }
-    }
-
+    // Charted above the scrolling list, not below it - a card anchored at the very bottom of
+    // the drawer sat under the gesture nav bar / corner bezel on edge-to-edge devices. The
+    // list is the one thing here that's meant to scroll, so it's the one that should own the
+    // bottom edge, with its own inset padding rather than a card fighting the system bars.
     if (LocalFeatures.current.flags[ConfigProvider.Companion.Feature.RECORD_CHART_TYPE] == "effort") {
       if (bestBySessionIndex.isNotEmpty()) {
         EffortHistoryCard(
@@ -232,6 +207,40 @@ fun SetRecordList(
             .weight(1f),
           data = data
         )
+      }
+    }
+
+    LazyColumn(
+      Modifier.weight(2f),
+      contentPadding = WindowInsets.navigationBars.only(WindowInsetsSides.Bottom).asPaddingValues()
+    ) {
+      // TODO does this cause everything to recompose? Should we just overlay?
+      if (records.loadState.refresh is LoadState.Loading) {
+        item {
+          Row(Modifier.fillMaxWidth()) {
+            LoadingView()
+          }
+        }
+      } else {
+        items(sessions, key = { it.day.toEpochDay() }) { session ->
+          val scored = bestBySessionIndex[sessionIndexByDay[session.day]]
+          SessionRow(
+            session = session,
+            isPR = scored != null && scored.capacity == bestCapacityOverall,
+            expanded = isExpanded(session.day),
+            onToggle = {
+              expandedOverrides = expandedOverrides +
+                (session.day.toEpochDay() to !isExpanded(session.day))
+            }
+          )
+        }
+        if (records.loadState.append is LoadState.Loading) {
+          item {
+            Row(Modifier.fillMaxWidth()) {
+              LoadingView()
+            }
+          }
+        }
       }
     }
   }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
@@ -60,8 +60,9 @@ import java.time.Instant
 // label + the surrounding 8.dp padding on each side) - pinned rather than measured so the
 // strip's height budget below can be computed exactly instead of guessed.
 private val EditStepperCardHeight = 80.dp
-private val StripPreferredHeight = 72.dp
-private val StripMinHeight = 48.dp
+// Raised from 72/48.dp to fit the strip's title + zone-label header row on top of the chart.
+private val StripPreferredHeight = 88.dp
+private val StripMinHeight = 64.dp
 
 /**
  * Wrapper overload that puts [ExerciseSetView] in its own [Column].

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
@@ -86,6 +86,7 @@ fun ExerciseSetView(
   nextRestSeconds: Int? = null,
   editing: Boolean = false,
   onUpdateCustomTargets: ((sets: Int, reps: Int, repsRange: Int) -> Unit)? = null,
+  onOpenHistory: () -> Unit = {},
 ) {
   Column(modifier) {
     ExerciseSetView(
@@ -103,6 +104,7 @@ fun ExerciseSetView(
       nextRestSeconds = nextRestSeconds,
       editing = editing,
       onUpdateCustomTargets = onUpdateCustomTargets,
+      onOpenHistory = onOpenHistory,
     )
   }
 }
@@ -124,6 +126,7 @@ fun ColumnScope.ExerciseSetView(
   nextRestSeconds: Int? = null,
   editing: Boolean = false,
   onUpdateCustomTargets: ((sets: Int, reps: Int, repsRange: Int) -> Unit)? = null,
+  onOpenHistory: () -> Unit = {},
 ) {
   val exerciseSet = setWithRecord.exerciseSet
   val currentRecord = setWithRecord.currentRecord
@@ -239,7 +242,8 @@ fun ColumnScope.ExerciseSetView(
               .fillMaxWidth()
               .height(stripHeight),
             history = setWithRecord.recentSets,
-            todaysRecords = setWithRecord.setRecords
+            todaysRecords = setWithRecord.setRecords,
+            onClick = onOpenHistory
           )
         }
         if (stepperShown) {

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
@@ -2,6 +2,7 @@ package com.litus_animae.refitted.ui.compose.exercise.set
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -15,6 +16,7 @@ import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -29,8 +31,11 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.litus_animae.refitted.identity.ConfigProvider
 import com.litus_animae.refitted.ui.R
+import com.litus_animae.refitted.ui.compose.LocalFeatures
 import com.litus_animae.refitted.ui.compose.exercise.CircularRestTimer
 import com.litus_animae.refitted.ui.compose.exercise.RepsDisplay
 import com.litus_animae.refitted.ui.compose.exercise.RepsDisplayEditingMinHeight
@@ -44,9 +49,19 @@ import com.litus_animae.refitted.ui.compose.state.Weight
 import com.litus_animae.refitted.ui.compose.util.Theme
 import com.litus_animae.refitted.ui.models.ExerciseViewModel
 import com.litus_animae.refitted.data.models.Record
+import com.litus_animae.refitted.data.models.SetRecord
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import java.time.Duration
 import java.time.Instant
+
+// Wrapped-content height of the sets TargetStepper card (48.dp IconButton row + overline
+// label + the surrounding 8.dp padding on each side) - pinned rather than measured so the
+// strip's height budget below can be computed exactly instead of guessed.
+private val EditStepperCardHeight = 80.dp
+private val StripPreferredHeight = 72.dp
+private val StripMinHeight = 48.dp
 
 /**
  * Wrapper overload that puts [ExerciseSetView] in its own [Column].
@@ -109,7 +124,9 @@ fun ColumnScope.ExerciseSetView(
   editing: Boolean = false,
   onUpdateCustomTargets: ((sets: Int, reps: Int, repsRange: Int) -> Unit)? = null,
 ) {
-  val (exerciseSet, currentRecord, numCompleted, _, _) = setWithRecord
+  val exerciseSet = setWithRecord.exerciseSet
+  val currentRecord = setWithRecord.currentRecord
+  val numCompleted = setWithRecord.numCompleted
   val record by currentRecord
   // Keyed on exerciseSet.id (day.step), not the exerciseSet object itself - editing this set's
   // own target/rest (see onUpdateCustomTargets/onRestOverrideChange) replaces that object via
@@ -185,19 +202,47 @@ fun ColumnScope.ExerciseSetView(
         repsPlaceable.place(0, weightPlaceable.height + spacing)
       }
     }
-    Box(
+    BoxWithConstraints(
       Modifier
         .weight(1f)
         .fillMaxHeight()
         .padding(start = 8.dp),
       contentAlignment = Alignment.Center
     ) {
+      val stepperShown = editing && onUpdateCustomTargets != null
+      val stepperHeight = if (stepperShown) EditStepperCardHeight + 8.dp else 0.dp
+      val timerHeight = RepsDisplayMinHeight + 16.dp
+      // No scroll exists in this pane, so a strip that doesn't fit is omitted rather than
+      // shrunk below legibility or wrapped - landscape and short screens fall through to
+      // stripHeight == null and the layout is unchanged from before the strip existed.
+      val stripHeight = if (maxHeight == Dp.Infinity) {
+        null
+      } else {
+        val slack = maxHeight - timerHeight - stepperHeight - 8.dp
+        when {
+          slack >= StripPreferredHeight -> StripPreferredHeight
+          slack >= StripMinHeight -> slack
+          else -> null
+        }
+      }
+      val showStrip = stripHeight != null &&
+        LocalFeatures.current.flags[ConfigProvider.Companion.Feature.RECORD_CHART_TYPE] == "effort"
+
       // Wraps its content instead of filling the row's height (which the Weight/Reps
       // stack next to it doesn't fully occupy either) so it floats centered rather than
       // stretching to an arbitrary bottom edge that never quite matched theirs.
       Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        if (editing && onUpdateCustomTargets != null) {
-          Card(Modifier.fillMaxWidth(), elevation = 2.dp) {
+        if (showStrip) {
+          SetTrendStrip(
+            Modifier
+              .fillMaxWidth()
+              .height(stripHeight),
+            history = setWithRecord.recentSets,
+            todaysRecords = setWithRecord.setRecords
+          )
+        }
+        if (stepperShown) {
+          Card(Modifier.fillMaxWidth().height(EditStepperCardHeight), elevation = 2.dp) {
             Box(Modifier.padding(8.dp).fillMaxWidth(), contentAlignment = Alignment.Center) {
               // TODO localize
               TargetStepper(
@@ -310,12 +355,32 @@ fun ColumnScope.ExerciseSetView(
   )
 }
 
+private val previewRecentSets: List<SetRecord> = run {
+  val base = Instant.now().minus(Duration.ofDays(10))
+  (0 until 10).flatMap { day ->
+    (0 until 3).map { setIndex ->
+      SetRecord(
+        weight = 95.0 + day * 1.5,
+        reps = 8,
+        workout = exampleExerciseSet.workout,
+        targetSet = exampleExerciseSet.id,
+        completed = base.plus(Duration.ofDays(day.toLong())).plusSeconds(setIndex * 120L),
+        exercise = exampleExerciseSet.exerciseName
+      )
+    }
+  }
+}
+
 @OptIn(FlowPreview::class)
 @Composable
-@Preview(heightDp = 400, apiLevel = 36)
-private fun PreviewExerciseSetDetails() {
+private fun PreviewExerciseSetDetails(
+  heightDp: Int = 400,
+  editing: Boolean = false,
+  recentSets: List<SetRecord> = previewRecentSets
+) {
   var numCompleted by remember { mutableIntStateOf(0) }
   var currentIndex by remember { mutableIntStateOf(5) }
+  var sets by remember { mutableIntStateOf(exampleExerciseSet.sets) }
   val records = remember { mutableStateListOf<Record>() }
   val currentRecord =
     remember {
@@ -328,27 +393,59 @@ private fun PreviewExerciseSetDetails() {
         )
       )
     }
-  androidx.compose.material.MaterialTheme(Theme.lightColors) {
-    Column(
-      Modifier
-        .padding(16.dp)
-        .fillMaxSize()
-    ) {
-      ExerciseSetView(
-        setWithRecord = ExerciseSetWithRecord(
-          exampleExerciseSet,
-          currentRecord,
-          numCompleted = 1,
-          setRecords = records,
-          allSets = emptyFlow()
-        ),
-        currentIndex = currentIndex,
-        maxIndex = 5,
-        updateIndex = { newIndex, _ -> currentIndex = newIndex },
-        onSave = { numCompleted += 1 },
-        onStartEditWeight = {},
-        showNavigationButtons = false
-      )
+  CompositionLocalProvider(
+    LocalFeatures provides ConfigProvider.Companion.RemoteConfig(
+      mapOf(ConfigProvider.Companion.Feature.RECORD_CHART_TYPE to "effort")
+    )
+  ) {
+    MaterialTheme(Theme.lightColors) {
+      Column(
+        Modifier
+          .padding(16.dp)
+          .height(heightDp.dp)
+          .fillMaxWidth()
+      ) {
+        ExerciseSetView(
+          setWithRecord = ExerciseSetWithRecord(
+            exampleExerciseSet.copy(sets = sets),
+            currentRecord,
+            numCompleted = 1,
+            setRecords = records,
+            allSets = emptyFlow(),
+            recentSets = flowOf(recentSets)
+          ),
+          currentIndex = currentIndex,
+          maxIndex = 5,
+          updateIndex = { newIndex, _ -> currentIndex = newIndex },
+          onSave = { numCompleted += 1 },
+          onStartEditWeight = {},
+          showNavigationButtons = false,
+          editing = editing,
+          onUpdateCustomTargets = if (editing) {
+            { newSets, _, _ -> sets = newSets }
+          } else {
+            null
+          }
+        )
+      }
     }
   }
+}
+
+@Preview(heightDp = 400, apiLevel = 36)
+@Composable
+private fun PreviewExerciseSetDetailsStripShown() {
+  PreviewExerciseSetDetails(heightDp = 400)
+}
+
+@Preview(heightDp = 300, apiLevel = 36)
+@Composable
+private fun PreviewExerciseSetDetailsStripOmitted() {
+  PreviewExerciseSetDetails(heightDp = 300)
+}
+
+@Preview(heightDp = 400, apiLevel = 36)
+@Composable
+private fun PreviewExerciseSetDetailsEditing() {
+  PreviewExerciseSetDetails(heightDp = 400, editing = true)
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
@@ -49,6 +49,7 @@ import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import kotlin.math.roundToInt
 
 private val MinSlotWidth = 20.dp
 private const val MIN_WINDOW = 5
@@ -107,8 +108,27 @@ fun SetTrendStrip(
 
     val points = remember(windowed) {
       windowed.mapIndexed { index, scored ->
-        EffortPoint(index.toFloat(), scored.source.weight.toFloat(), scored.size, scored.zone)
+        EffortPoint(
+          index.toFloat(),
+          scored.source.weight.toFloat(),
+          scored.size,
+          scored.zone,
+          emphasized = index == windowed.lastIndex
+        )
       }
+    }
+    // A faint dashed rule wherever the window crosses into a new session, so "these 3 are
+    // today, that one's from last time" reads at a glance instead of needing the header's
+    // single zone label to carry it.
+    val sessionGapMarks = remember(windowed) {
+      windowed.zipWithNext().mapIndexedNotNull { index, (a, b) ->
+        if (a.sessionIndex != b.sessionIndex) index + 0.5f else null
+      }
+    }
+    val yLabels = remember(points) {
+      val minWeight = points.minOf { it.weight }
+      val maxWeight = points.maxOf { it.weight }
+      listOf(minWeight, maxWeight).distinct().map { it to it.roundToInt().toString() }
     }
     // Split by source rather than text-labeling the two - EffortChart draws dashedTrend
     // beneath trend, so the dash itself is the only signal a segment is the coarser,
@@ -191,6 +211,8 @@ fun SetTrendStrip(
           points = points,
           trend = realTrend,
           dashedTrend = bootstrapTrend,
+          yLabels = yLabels,
+          gapMarks = sessionGapMarks,
           compact = true
         )
       }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
@@ -101,7 +101,7 @@ fun SetTrendStrip(
     // scoreWithBootstrap augments score()'s output rather than replacing it - every session
     // past EffortConfig.minPriorSessions behaves identically, and a first-ever session stays
     // all-COLD regardless of its own set count (no prior session exists yet to bootstrap
-    // from). See docs/exercise-history-chart.md "Bootstrap trend (strip-only)".
+    // from).
     val series = remember(merged) { EffortModel.scoreWithBootstrap(merged) }
     val windowed = remember(series, window) { series.sets.takeLast(window) }
     if (windowed.isEmpty()) return@BoxWithConstraints

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
@@ -1,6 +1,7 @@
 package com.litus_animae.refitted.ui.compose.exercise.set
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -59,13 +60,15 @@ private const val MAX_WINDOW = 14
  *
  * [history] is the bounded recentSets flow; [todaysRecords] are the in-memory sets completed
  * this session so a just-finished set appears immediately instead of waiting on Room's
- * write/invalidation round-trip to reach [history].
+ * write/invalidation round-trip to reach [history]. [onClick] opens the full set-history
+ * drawer - this strip is a glance, not the place to read the whole history.
  */
 @Composable
 fun SetTrendStrip(
   modifier: Modifier = Modifier,
   history: Flow<List<SetRecord>>,
-  todaysRecords: List<Record>
+  todaysRecords: List<Record>,
+  onClick: () -> Unit = {}
 ) {
   val recorded by history.collectAsState(initial = emptyList(), Dispatchers.IO)
 
@@ -129,7 +132,7 @@ fun SetTrendStrip(
       )
     }
 
-    Card(Modifier.fillMaxSize(), elevation = 2.dp) {
+    Card(Modifier.fillMaxSize().clickable(onClick = onClick), elevation = 2.dp) {
       Column(Modifier.fillMaxSize()) {
         // Doubles as the chart's only legend: it names the color of the bubble the user
         // just earned, in the moment they earn it, rather than a static key for all five.

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
@@ -1,0 +1,102 @@
+package com.litus_animae.refitted.ui.compose.exercise.set
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Card
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.litus_animae.refitted.data.effort.EffortModel
+import com.litus_animae.refitted.data.effort.toEffortSet
+import com.litus_animae.refitted.data.models.Record
+import com.litus_animae.refitted.data.models.SetRecord
+import com.litus_animae.refitted.ui.compose.charts.EffortChart
+import com.litus_animae.refitted.ui.compose.charts.EffortPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+private val MinSlotWidth = 20.dp
+private const val MIN_WINDOW = 5
+private const val MAX_WINDOW = 14
+
+/**
+ * Compact effort trend for the most recent sets, sized to however many bubbles actually fit
+ * legibly in [modifier]'s measured width rather than a fixed count.
+ *
+ * [history] is the bounded recentSets flow; [todaysRecords] are the in-memory sets completed
+ * this session so a just-finished set appears immediately instead of waiting on Room's
+ * write/invalidation round-trip to reach [history].
+ */
+@Composable
+fun SetTrendStrip(
+  modifier: Modifier = Modifier,
+  history: Flow<List<SetRecord>>,
+  todaysRecords: List<Record>
+) {
+  val recorded by history.collectAsState(initial = emptyList(), Dispatchers.IO)
+
+  // Record.completed on an in-memory set can be stale (copied from the last stored record,
+  // possibly a prior day) while the SetRecord Room eventually persists stamps Instant.now() -
+  // so today's sets are matched by position against however many of today's history rows have
+  // already round-tripped back through recentSets, never by comparing timestamps.
+  val merged = remember(recorded, todaysRecords) {
+    val zone = ZoneId.systemDefault()
+    val today = LocalDate.now(zone)
+    val historyToday = recorded.count { it.completed.atZone(zone).toLocalDate() == today }
+    val unseen = if (todaysRecords.size > historyToday) {
+      todaysRecords.drop(historyToday).map { it.toEffortSet().copy(completed = Instant.now()) }
+    } else {
+      emptyList()
+    }
+    recorded.map { it.toEffortSet() } + unseen
+  }
+
+  BoxWithConstraints(modifier) {
+    val window = if (maxWidth != Dp.Infinity) {
+      (((maxWidth - 12.dp).value / MinSlotWidth.value).toInt()).coerceIn(MIN_WINDOW, MAX_WINDOW)
+    } else {
+      MIN_WINDOW
+    }
+
+    if (merged.isEmpty()) return@BoxWithConstraints
+
+    val series = remember(merged) { EffortModel.score(merged) }
+    val windowed = remember(series, window) { series.sets.takeLast(window) }
+    if (windowed.isEmpty()) return@BoxWithConstraints
+
+    val points = remember(windowed) {
+      windowed.mapIndexed { index, scored ->
+        EffortPoint(index.toFloat(), scored.source.weight.toFloat(), scored.size, scored.zone)
+      }
+    }
+    val trend = remember(windowed, series) {
+      val expectedWeightBySession = series.trend.associateBy({ it.sessionIndex }, { it.expectedWeight })
+      val runs = mutableListOf<MutableList<Pair<Float, Float>>>()
+      var current: MutableList<Pair<Float, Float>>? = null
+      windowed.forEachIndexed { index, scored ->
+        val expectedWeight = expectedWeightBySession[scored.sessionIndex]
+        if (expectedWeight == null) {
+          current = null
+        } else {
+          val run = current ?: mutableListOf<Pair<Float, Float>>().also {
+            current = it
+            runs.add(it)
+          }
+          run.add(index.toFloat() to expectedWeight.toFloat())
+        }
+      }
+      runs
+    }
+
+    Card(Modifier.fillMaxSize(), elevation = 2.dp) {
+      EffortChart(Modifier.fillMaxSize(), points = points, trend = trend, compact = true)
+    }
+  }
+}

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
@@ -16,6 +16,7 @@ import com.litus_animae.refitted.data.models.Record
 import com.litus_animae.refitted.data.models.SetRecord
 import com.litus_animae.refitted.ui.compose.charts.EffortChart
 import com.litus_animae.refitted.ui.compose.charts.EffortPoint
+import com.litus_animae.refitted.ui.compose.charts.buildTrendRuns
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import java.time.Instant
@@ -78,21 +79,10 @@ fun SetTrendStrip(
     }
     val trend = remember(windowed, series) {
       val expectedWeightBySession = series.trend.associateBy({ it.sessionIndex }, { it.expectedWeight })
-      val runs = mutableListOf<MutableList<Pair<Float, Float>>>()
-      var current: MutableList<Pair<Float, Float>>? = null
-      windowed.forEachIndexed { index, scored ->
-        val expectedWeight = expectedWeightBySession[scored.sessionIndex]
-        if (expectedWeight == null) {
-          current = null
-        } else {
-          val run = current ?: mutableListOf<Pair<Float, Float>>().also {
-            current = it
-            runs.add(it)
-          }
-          run.add(index.toFloat() to expectedWeight.toFloat())
-        }
-      }
-      runs
+      buildTrendRuns(
+        windowed.mapIndexed { index, scored -> index.toFloat() to scored.sessionIndex },
+        expectedWeightBySession
+      )
     }
 
     Card(Modifier.fillMaxSize(), elevation = 2.dp) {

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
@@ -1,22 +1,39 @@
 package com.litus_animae.refitted.ui.compose.exercise.set
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.litus_animae.refitted.data.effort.EffortModel
 import com.litus_animae.refitted.data.effort.toEffortSet
 import com.litus_animae.refitted.data.models.Record
 import com.litus_animae.refitted.data.models.SetRecord
+import com.litus_animae.refitted.ui.R
 import com.litus_animae.refitted.ui.compose.charts.EffortChart
 import com.litus_animae.refitted.ui.compose.charts.EffortPoint
 import com.litus_animae.refitted.ui.compose.charts.buildTrendRuns
+import com.litus_animae.refitted.ui.compose.charts.zoneColor
+import com.litus_animae.refitted.ui.compose.charts.zoneLabelRes
+import com.litus_animae.refitted.ui.compose.util.Theme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import java.time.Instant
@@ -86,7 +103,48 @@ fun SetTrendStrip(
     }
 
     Card(Modifier.fillMaxSize(), elevation = 2.dp) {
-      EffortChart(Modifier.fillMaxSize(), points = points, trend = trend, compact = true)
+      Column(Modifier.fillMaxSize()) {
+        // Doubles as the chart's only legend: it names the color of the bubble the user
+        // just earned, in the moment they earn it, rather than a static key for all five.
+        Row(
+          Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 2.dp),
+          horizontalArrangement = Arrangement.SpaceBetween,
+          verticalAlignment = Alignment.CenterVertically
+        ) {
+          Text(stringResource(R.string.effort_label), style = MaterialTheme.typography.caption)
+          val latestZone = windowed.last().zone
+          Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+          ) {
+            Box(
+              Modifier
+                .size(8.dp)
+                .background(
+                  zoneColor(
+                    latestZone,
+                    MaterialTheme.colors.primary,
+                    Theme.goodAttention,
+                    Theme.timerAmber,
+                    MaterialTheme.colors.onSurface.copy(alpha = 0.25f)
+                  ),
+                  CircleShape
+                )
+            )
+            Text(stringResource(zoneLabelRes(latestZone)), style = MaterialTheme.typography.caption)
+          }
+        }
+        EffortChart(
+          Modifier
+            .fillMaxWidth()
+            .weight(1f),
+          points = points,
+          trend = trend,
+          compact = true
+        )
+      }
     }
   }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
@@ -8,8 +8,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
@@ -21,9 +24,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.litus_animae.refitted.data.effort.EffortModel
+import com.litus_animae.refitted.data.effort.EffortZone
+import com.litus_animae.refitted.data.effort.ExpectationSource
 import com.litus_animae.refitted.data.effort.toEffortSet
 import com.litus_animae.refitted.data.models.Record
 import com.litus_animae.refitted.data.models.SetRecord
@@ -33,9 +39,12 @@ import com.litus_animae.refitted.ui.compose.charts.EffortPoint
 import com.litus_animae.refitted.ui.compose.charts.buildTrendRuns
 import com.litus_animae.refitted.ui.compose.charts.zoneColor
 import com.litus_animae.refitted.ui.compose.charts.zoneLabelRes
+import com.litus_animae.refitted.ui.compose.exercise.exampleExerciseSet
 import com.litus_animae.refitted.ui.compose.util.Theme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -85,7 +94,11 @@ fun SetTrendStrip(
 
     if (merged.isEmpty()) return@BoxWithConstraints
 
-    val series = remember(merged) { EffortModel.score(merged) }
+    // scoreWithBootstrap augments score()'s output rather than replacing it - every session
+    // past EffortConfig.minPriorSessions behaves identically, and a first-ever session stays
+    // all-COLD regardless of its own set count (no prior session exists yet to bootstrap
+    // from). See docs/exercise-history-chart.md "Bootstrap trend (strip-only)".
+    val series = remember(merged) { EffortModel.scoreWithBootstrap(merged) }
     val windowed = remember(series, window) { series.sets.takeLast(window) }
     if (windowed.isEmpty()) return@BoxWithConstraints
 
@@ -94,8 +107,22 @@ fun SetTrendStrip(
         EffortPoint(index.toFloat(), scored.source.weight.toFloat(), scored.size, scored.zone)
       }
     }
-    val trend = remember(windowed, series) {
-      val expectedWeightBySession = series.trend.associateBy({ it.sessionIndex }, { it.expectedWeight })
+    // Split by source rather than text-labeling the two - EffortChart draws dashedTrend
+    // beneath trend, so the dash itself is the only signal a segment is the coarser,
+    // strip-only stand-in rather than the real session-based fit.
+    val realTrend = remember(windowed, series) {
+      val expectedWeightBySession = series.trend
+        .filter { it.expectationSource == ExpectationSource.SESSION }
+        .associateBy({ it.sessionIndex }, { it.expectedWeight })
+      buildTrendRuns(
+        windowed.mapIndexed { index, scored -> index.toFloat() to scored.sessionIndex },
+        expectedWeightBySession
+      )
+    }
+    val bootstrapTrend = remember(windowed, series) {
+      val expectedWeightBySession = series.trend
+        .filter { it.expectationSource == ExpectationSource.BOOTSTRAP }
+        .associateBy({ it.sessionIndex }, { it.expectedWeight })
       buildTrendRuns(
         windowed.mapIndexed { index, scored -> index.toFloat() to scored.sessionIndex },
         expectedWeightBySession
@@ -115,25 +142,43 @@ fun SetTrendStrip(
         ) {
           Text(stringResource(R.string.effort_label), style = MaterialTheme.typography.caption)
           val latestZone = windowed.last().zone
+          // weight(1f) claims whatever the "Effort" label didn't, so the countdown text (much
+          // longer than a zone label) is guaranteed the 8dp gap and a bound on its own width
+          // instead of butting straight up against "Effort" under SpaceBetween.
           Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp)
+            Modifier
+              .weight(1f)
+              .padding(start = 8.dp),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically
           ) {
-            Box(
-              Modifier
-                .size(8.dp)
-                .background(
-                  zoneColor(
-                    latestZone,
-                    MaterialTheme.colors.primary,
-                    Theme.goodAttention,
-                    Theme.timerAmber,
-                    MaterialTheme.colors.onSurface.copy(alpha = 0.25f)
-                  ),
-                  CircleShape
-                )
-            )
-            Text(stringResource(zoneLabelRes(latestZone)), style = MaterialTheme.typography.caption)
+            if (latestZone == EffortZone.COLD) {
+              // Only reachable during a first-ever session - even one prior session with
+              // enough sets unlocks the bootstrap trend immediately, so this is a real state
+              // worth naming rather than an unexplained "New" label.
+              Text(
+                stringResource(R.string.strip_trend_locked),
+                style = MaterialTheme.typography.caption,
+                color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+              )
+            } else {
+              Box(
+                Modifier
+                  .size(8.dp)
+                  .background(
+                    zoneColor(
+                      latestZone,
+                      MaterialTheme.colors.primary,
+                      Theme.goodAttention,
+                      Theme.timerAmber,
+                      MaterialTheme.colors.onSurface.copy(alpha = 0.25f)
+                    ),
+                    CircleShape
+                  )
+              )
+              Spacer(Modifier.width(4.dp))
+              Text(stringResource(zoneLabelRes(latestZone)), style = MaterialTheme.typography.caption)
+            }
           }
         }
         EffortChart(
@@ -141,10 +186,60 @@ fun SetTrendStrip(
             .fillMaxWidth()
             .weight(1f),
           points = points,
-          trend = trend,
+          trend = realTrend,
+          dashedTrend = bootstrapTrend,
           compact = true
         )
       }
     }
   }
+}
+
+private fun previewSets(daysAgo: List<Long>, setsPerDay: Int): List<SetRecord> {
+  val base = Instant.now().minus(Duration.ofDays(daysAgo.max()))
+  return daysAgo.flatMap { day ->
+    (0 until setsPerDay).map { setIndex ->
+      SetRecord(
+        weight = 95.0 + day,
+        reps = 8,
+        workout = exampleExerciseSet.workout,
+        targetSet = exampleExerciseSet.id,
+        completed = base.plus(Duration.ofDays(daysAgo.max() - day)).plusSeconds(setIndex * 120L),
+        exercise = exampleExerciseSet.exerciseName
+      )
+    }
+  }
+}
+
+/** A first-ever session: every dot COLD regardless of set count, countdown caption shown. */
+@Preview
+@Composable
+private fun PreviewSetTrendStripFirstSession() {
+  SetTrendStrip(
+    Modifier.width(300.dp).height(88.dp),
+    history = flowOf(previewSets(daysAgo = listOf(0L), setsPerDay = 5)),
+    todaysRecords = emptyList()
+  )
+}
+
+/** A second session, first had 3+ sets: bootstrap trend dashed, dots colored immediately. */
+@Preview
+@Composable
+private fun PreviewSetTrendStripBootstrap() {
+  SetTrendStrip(
+    Modifier.width(300.dp).height(88.dp),
+    history = flowOf(previewSets(daysAgo = listOf(7L, 0L), setsPerDay = 3)),
+    todaysRecords = emptyList()
+  )
+}
+
+/** Long real history: solid trend, no dash. */
+@Preview
+@Composable
+private fun PreviewSetTrendStripRealTrend() {
+  SetTrendStrip(
+    Modifier.width(300.dp).height(88.dp),
+    history = flowOf(previewSets(daysAgo = (0L..9L).map { it * 3 }.reversed(), setsPerDay = 3)),
+    todaysRecords = emptyList()
+  )
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/state/SetsRecords.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/state/SetsRecords.kt
@@ -10,13 +10,26 @@ import com.litus_animae.refitted.data.models.Record
 import com.litus_animae.refitted.data.models.SetRecord
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+/**
+ * The set-history drawer's data source. [paged] backs the scrolling list (unbounded
+ * scrollback); [recent] backs any chart drawn from it - a bounded, non-paged flow so a
+ * trend fit sees a stable window of history rather than however many pages happen to be
+ * loaded under the list at the time.
+ */
+data class SetHistory(
+  val paged: Flow<PagingData<SetRecord>> = emptyFlow(),
+  val recent: Flow<List<SetRecord>> = emptyFlow()
+)
 
 data class ExerciseSetWithRecord(
   val exerciseSet: ExerciseSet,
   val currentRecord: MutableState<Record>,
   val numCompleted: Int,
   val setRecords: SnapshotStateList<Record>,
-  val allSets: Flow<PagingData<SetRecord>>
+  val allSets: Flow<PagingData<SetRecord>>,
+  val recentSets: Flow<List<SetRecord>> = emptyFlow()
 ) {
   fun saveRecordInState(
     savedRecord: Record
@@ -86,7 +99,8 @@ fun recordsByExerciseId(allRecords: List<ExerciseRecord>): Map<String, ExerciseS
         currentRecord,
         effectiveNumCompleted,
         rememberedSetRecords,
-        currentSetRecord.allSets
+        currentSetRecord.allSets,
+        currentSetRecord.recentSets
       )
 
       state[currentSet.id] = exerciseSetWithRecord

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/state/SetsRecords.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/state/SetsRecords.kt
@@ -13,14 +13,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
 /**
- * The set-history drawer's data source. [paged] backs the scrolling list (unbounded
- * scrollback); [recent] backs any chart drawn from it - a bounded, non-paged flow so a
- * trend fit sees a stable window of history rather than however many pages happen to be
- * loaded under the list at the time.
+ * The set-history drawer's data source. The pager's initialLoadSize is large (see
+ * RoomCacheExerciseRepository) so both the grouped list and the effort chart built from it
+ * see a full history window on first composition - later pages only refine a causal,
+ * recency-weighted fit rather than visibly changing it.
  */
 data class SetHistory(
-  val paged: Flow<PagingData<SetRecord>> = emptyFlow(),
-  val recent: Flow<List<SetRecord>> = emptyFlow()
+  val paged: Flow<PagingData<SetRecord>> = emptyFlow()
 )
 
 data class ExerciseSetWithRecord(

--- a/ui/src/main/res/values/changelog.xml
+++ b/ui/src/main/res/values/changelog.xml
@@ -5,6 +5,8 @@
         <item>**v1.4.0</item>
         <item>Build your own workout: create a custom plan, then add your own days and exercises</item>
         <item>Edit mode lets you adjust sets, reps, rest, and notes on a custom workout</item>
+        <item>Effort chart: see how each set compares to your training trend, right on the exercise screen</item>
+        <item>Set history now groups your sets by session, with per-session totals and PR badges</item>
         <item>Calendar now aligns to real dates</item>
         <item>**v1.3.0</item>
         <item>Updated Exercise UI</item>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -49,12 +49,17 @@
     <string name="reps_label">Reps</string>
     <string name="doubled_label">Barbell\nMode?</string>
     <string name="effort_label">Effort</string>
-    <string name="effort_chart_subtitle">Best set per session, vs. expected</string>
+    <string name="effort_chart_subtitle">Bubble size = effort vs. your trend</string>
     <string name="effort_zone_cold">New</string>
-    <string name="effort_zone_below">Below</string>
+    <string name="effort_zone_below">Below trend</string>
     <string name="effort_zone_on_curve">On curve</string>
-    <string name="effort_zone_growth">Growth</string>
-    <string name="effort_zone_implausible">Spike</string>
+    <string name="effort_zone_growth">Growth zone</string>
+    <string name="effort_zone_implausible">Outlier</string>
+    <string name="strip_trend_locked">Log a full session to unlock a trend</string>
+    <plurals name="sessions_until_trend">
+        <item quantity="one">%1$d more session until your trend appears</item>
+        <item quantity="other">%1$d more sessions until your trend appears</item>
+    </plurals>
     <plurals name="complete_superset_part_x">
         <item quantity="one">Complete Superset Part %1$d</item>
         <item quantity="other">Complete Superset Part %1$d</item>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -48,6 +48,13 @@
     <string name="weight_label">Weight</string>
     <string name="reps_label">Reps</string>
     <string name="doubled_label">Barbell\nMode?</string>
+    <string name="effort_label">Effort</string>
+    <string name="effort_chart_subtitle">Best set per session, vs. expected</string>
+    <string name="effort_zone_cold">New</string>
+    <string name="effort_zone_below">Below</string>
+    <string name="effort_zone_on_curve">On curve</string>
+    <string name="effort_zone_growth">Growth</string>
+    <string name="effort_zone_implausible">Spike</string>
     <plurals name="complete_superset_part_x">
         <item quantity="one">Complete Superset Part %1$d</item>
         <item quantity="other">Complete Superset Part %1$d</item>


### PR DESCRIPTION
## Summary
- New effort scoring model (`:data`) fits an adaptive, causal trend against session history and scores each set's demonstrated capacity against it
- `record_chart_type = "effort"` renders that as a bubble chart in both the set-history drawer (session-grouped list, adaptive axis granularity, PR badges) and a compact trend strip on the exercise screen (bootstrap trend for exercises with too few sessions yet, tap to open the full history)
- Drawer reflows chart-left/list-right in landscape
- Changelog updated

## Test plan
On device with `record_chart_type = "effort"`:
- Strip renders on the exercise screen and colors in as sessions accumulate
- Tapping the strip opens the drawer
- Drawer groups sets by session with PR badges
- Rotating to landscape splits chart/list side-by-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)