### PR TITLE
Add sign-in CTA to exercise picker for unlocking admin plans

### DIFF
--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/AuthButton.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/AuthButton.kt
@@ -52,7 +52,8 @@ internal fun AuthButton(
   handleAuthFailure: (GetCredentialException) -> Unit,
   handleDeAuth: () -> Unit,
   authedEmail: String?,
-  webClientId: String
+  webClientId: String,
+  ctaText: String = "Sign in for more workouts"
 ) {
   val context: Context = LocalContext.current
   val credentialManager = remember(context) { CredentialManager.create(context) }
@@ -85,7 +86,7 @@ internal fun AuthButton(
       ) {
         if (it == null) {
           Text(
-            "Sign in for more workouts",
+            ctaText,
             Modifier
               .fillMaxWidth()
               .padding(end = 10.dp),

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
@@ -1,11 +1,16 @@
 package com.litus_animae.refitted.ui.compose
 
 import android.net.Uri
+import android.util.Log
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.credentials.CustomCredential
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
@@ -13,6 +18,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.litus_animae.refitted.ui.compose.calendar.Calendar
 import com.litus_animae.refitted.ui.compose.exercise.Exercise
 import com.litus_animae.refitted.ui.compose.exercise.add.ExercisePickerList
@@ -81,6 +87,7 @@ fun Top() {
     composable("add-exercise/{workout}/{day}/{muscle}") {
       val exerciseModel: ExerciseViewModel = hiltViewModel(it)
       val workoutModel: WorkoutViewModel = hiltViewModel(it)
+      val userModel: UserViewModel = hiltViewModel(it)
       val workoutId = it.arguments?.getString("workout")
       val day = it.arguments?.getString("day")
       val muscle = it.arguments?.getString("muscle")?.let(Uri::decode)
@@ -93,6 +100,15 @@ fun Top() {
         // runs - reusing it rather than a separate sync path keeps this screen's "refresh the
         // plan list" in lockstep with the drawer's.
         val workoutPlansPagingItems = workoutModel.workouts.collectAsLazyPagingItems()
+        val currentEmail by userModel.userEmail.collectAsStateWithLifecycle(initialValue = null)
+        // Reload accessibleWorkouts once sign-in actually completes, so newly-unlocked admin
+        // plans show up without the user having to tap the refresh icon themselves.
+        var signInClicked by remember { mutableStateOf(false) }
+        LaunchedEffect(currentEmail) {
+          if (signInClicked) {
+            workoutPlansPagingItems.refresh()
+          }
+        }
         ExercisePickerList(
           muscle = muscle,
           // Exclude the plan being built itself - a custom plan is assembled from admin
@@ -113,7 +129,24 @@ fun Top() {
           },
           onBack = { controller.popBackStack() },
           onRefreshWorkouts = { workoutPlansPagingItems.refresh() },
-          isRefreshingWorkouts = workoutPlansPagingItems.loadState.refresh is LoadState.Loading
+          isRefreshingWorkouts = workoutPlansPagingItems.loadState.refresh is LoadState.Loading,
+          authedEmail = currentEmail,
+          onSignInSuccess = { response ->
+            signInClicked = true
+            when (val credential = response.credential) {
+              is CustomCredential -> {
+                if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+                  userModel.handleSignIn(credential.data)
+                } else {
+                  Log.e("AddExercisePicker", "Unexpected type of credential")
+                }
+              }
+
+              else -> Log.e("AddExercisePicker", "Unexpected type of credential")
+            }
+          },
+          onSignInFailure = { Log.e("AddExercisePicker", "Sign in failed", it) },
+          webClientId = userModel.googleWebClientId
         )
       } else {
         controller.navigate("calendar")

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -61,10 +62,13 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.credentials.GetCredentialResponse
+import androidx.credentials.exceptions.GetCredentialException
 import com.litus_animae.refitted.data.models.Exercise
 import com.litus_animae.refitted.data.models.MuscleGroup
 import com.litus_animae.refitted.data.models.PlanKind
 import com.litus_animae.refitted.data.models.WorkoutPlan
+import com.litus_animae.refitted.ui.compose.AuthButton
 
 private val muscleGroups = MuscleGroup.displayNames()
 
@@ -164,6 +168,11 @@ fun ExercisePickerList(
   /** Re-syncs [accessibleWorkouts] itself (new/removed plans) - separate from a section's own onLoadWorkout, which only refreshes that plan's exercises. */
   onRefreshWorkouts: () -> Unit,
   isRefreshingWorkouts: Boolean,
+  /** Null when signed out - shows a "sign in for more exercises" CTA below the list. */
+  authedEmail: String?,
+  onSignInSuccess: (GetCredentialResponse) -> Unit,
+  onSignInFailure: (GetCredentialException) -> Unit,
+  webClientId: String,
   modifier: Modifier = Modifier
 ) {
   val accessibleNames = accessibleWorkouts.map { it.workout }.toSet()
@@ -208,6 +217,21 @@ fun ExercisePickerList(
           }
         }
       )
+    },
+    bottomBar = {
+      if (authedEmail == null) {
+        AuthButton(
+          Modifier
+            .windowInsetsPadding(WindowInsets.navigationBars.union(WindowInsets.displayCutout))
+            .padding(16.dp),
+          handleAuthSuccess = onSignInSuccess,
+          handleAuthFailure = onSignInFailure,
+          handleDeAuth = {},
+          authedEmail = null,
+          webClientId = webClientId,
+          ctaText = "Sign in for more exercises"
+        )
+      }
     }
   ) { contentPadding ->
     LazyColumn(Modifier.padding(contentPadding).fillMaxSize()) {
@@ -508,7 +532,11 @@ private fun PreviewExercisePickerList() {
       onPick = {},
       onBack = {},
       onRefreshWorkouts = {},
-      isRefreshingWorkouts = false
+      isRefreshingWorkouts = false,
+      authedEmail = null,
+      onSignInSuccess = {},
+      onSignInFailure = {},
+      webClientId = ""
     )
   }
 }


### PR DESCRIPTION
## Summary
Adds a "Sign in for more exercises" call-to-action button to the exercise picker screen when users are signed out, allowing them to unlock admin workout plans without manually navigating to sign in elsewhere.

## Key Changes

- **Top.kt**: 
  - Integrated `UserViewModel` to track authentication state via `userEmail` flow
  - Added `LaunchedEffect` to refresh accessible workouts when sign-in completes, ensuring newly-unlocked admin plans appear immediately
  - Wired sign-in success/failure handlers to `ExercisePickerList`, passing `authedEmail` and `webClientId`

- **AddExercisePicker.kt**:
  - Added new parameters: `authedEmail`, `onSignInSuccess`, `onSignInFailure`, and `webClientId`
  - Implemented bottom bar that displays `AuthButton` with "Sign in for more exercises" CTA when user is signed out (`authedEmail == null`)
  - Applied proper insets padding to bottom bar for navigation and display cutout areas
  - Updated preview to include new parameters

- **AuthButton.kt**:
  - Made CTA text customizable via new `ctaText` parameter (defaults to "Sign in for more workouts")
  - Allows reuse of auth button across different screens with context-appropriate messaging

## Implementation Details

The sign-in flow leverages the existing `UserViewModel` and `AuthButton` infrastructure. When a user successfully signs in from the exercise picker, the `signInClicked` flag triggers a refresh of `workoutPlansPagingItems`, ensuring the paging list immediately reflects newly-accessible admin plans without requiring manual intervention.

https://claude.ai/code/session_011rEwG88E45FxizcY6sVWr5