### PR TITLE
Migrate ExercisePaginationStabilityTest to Compose v2 test API

### DIFF
--- a/app/src/androidTest/kotlin/com/litus_animae/refitted/compose/exercise/ExercisePaginationStabilityTest.kt
+++ b/app/src/androidTest/kotlin/com/litus_animae/refitted/compose/exercise/ExercisePaginationStabilityTest.kt
@@ -2,7 +2,7 @@ package com.litus_animae.refitted.compose.exercise
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick


### PR DESCRIPTION
## Summary

Migrates the deprecated Compose v1 test API to the v2 version in `ExercisePaginationStabilityTest.kt`.

- Updated import from `androidx.compose.ui.test.junit4.createAndroidComposeRule` to `androidx.compose.ui.test.junit4.v2.createAndroidComposeRule`
- v2 API uses `StandardTestDispatcher` instead of `UnconfinedTestDispatcher` for more predictable task scheduling

The test already uses proper synchronization patterns (`waitForIdle()`, `waitUntil()`), so it works correctly with the v2 API.