### PR TITLE
Merge add-exercise flow into the day screen, keep muscle filter while editing

### DIFF
--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -60,6 +60,12 @@ Presentation layer with ViewModels (business logic) and Jetpack Compose UI (view
   handoff happen in the same composition pass. See `settledSet`/`swap` in
   `PagerExerciseInstructions`.
 
+- **`ModalBottomSheetLayout`'s `sheetContent` is always composed, even while hidden** — it's
+  measured for the sheet's own animation regardless of visibility. Don't assume hidden sheet
+  content is absent from composition: gate any expensive collection or side-effects inside it
+  behind the sheet's own `sheetState.isVisible`, or they run continuously any time the host
+  screen is on-screen. See the add-exercise sheet in `exercise/Main.kt`.
+
 ## Testing
 
 ```bash

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
 
     // Core Android
     implementation(libs.androidx.lifecycle.runtime.compose.android)
+    implementation(libs.androidx.activity.compose) // BackHandler
 
     // Paging (exposed as api - ViewModels expose Flow<PagingData<T>>)
     api(libs.androidx.paging.compose)

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/Top.kt
@@ -1,44 +1,20 @@
 package com.litus_animae.refitted.ui.compose
 
-import android.net.Uri
-import android.util.Log
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.credentials.CustomCredential
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navArgument
-import androidx.paging.LoadState
-import androidx.paging.compose.collectAsLazyPagingItems
-import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.litus_animae.refitted.ui.compose.calendar.Calendar
 import com.litus_animae.refitted.ui.compose.exercise.Exercise
-import com.litus_animae.refitted.ui.compose.exercise.add.ExercisePickerList
-import com.litus_animae.refitted.ui.compose.exercise.add.MuscleGroupPickerScreen
 import com.litus_animae.refitted.ui.models.ExerciseViewModel
 import com.litus_animae.refitted.ui.models.UserViewModel
 import com.litus_animae.refitted.data.models.WorkoutPlan
 import com.litus_animae.refitted.ui.models.WorkoutViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-
-private val alternateToArg = listOf(
-  navArgument("alternateTo") {
-    type = NavType.StringType
-    nullable = true
-    defaultValue = null
-  }
-)
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @FlowPreview
@@ -55,17 +31,15 @@ fun Top() {
     }
     // "editing" gates the add-exercise affordance - only reachable from the edit-mode calendar
     // (Calendar.kt's DayEditDialog), so a plan can't be built up by tapping into a day normally.
+    // Add-exercise itself lives entirely inside Exercise() as an overlay, not a separate
+    // destination - see exercise/Main.kt.
     composable("exercise/{workout}/{day}/{editing}") {
       val exerciseModel: ExerciseViewModel = hiltViewModel(it)
       val workoutModel: WorkoutViewModel = hiltViewModel(it)
+      val userModel: UserViewModel = hiltViewModel(it)
       val workoutId = it.arguments?.getString("workout")
       val day = it.arguments?.getString("day")
       val editing = it.arguments?.getString("editing")?.toBoolean() == true
-      // Consumed once per return to this destination - set by the add-exercise flow below
-      // just before popping back here, so the pager can land on it instead of page 0.
-      val scrollToExerciseName = remember(it) {
-        it.savedStateHandle.remove<String>("justAddedExercise")
-      }
       if (workoutId != null && day != null) {
         Exercise(
           day = day,
@@ -73,112 +47,7 @@ fun Top() {
           editing = editing,
           exerciseModel = exerciseModel,
           workoutModel = workoutModel,
-          onAddExercise = { controller.navigate("add-exercise/$workoutId/$day") },
-          onAddAlternate = { set ->
-            controller.navigate(
-              "add-exercise/$workoutId/$day?alternateTo=${Uri.encode(set.primaryStep)}"
-            )
-          },
-          scrollToExerciseName = scrollToExerciseName
-        )
-      } else {
-        controller.navigate("calendar")
-      }
-    }
-    // A non-null "alternateTo" carries the base step the picked exercise should become an
-    // alternate of - the picker itself is identical either way, only the commit differs.
-    composable("add-exercise/{workout}/{day}?alternateTo={alternateTo}", arguments = alternateToArg) {
-      val workoutId = it.arguments?.getString("workout")
-      val day = it.arguments?.getString("day")
-      val alternateTo = it.arguments?.getString("alternateTo")?.let(Uri::decode)
-      if (workoutId != null && day != null) {
-        MuscleGroupPickerScreen(
-          // TODO localize
-          title = if (alternateTo != null) "Add alternate" else "Add exercise",
-          onContinue = { muscle ->
-            val alternateQuery =
-              if (alternateTo != null) "?alternateTo=${Uri.encode(alternateTo)}" else ""
-            controller.navigate("add-exercise/$workoutId/$day/${Uri.encode(muscle)}$alternateQuery")
-          },
-          onClose = { controller.popBackStack() }
-        )
-      } else {
-        controller.navigate("calendar")
-      }
-    }
-    composable(
-      "add-exercise/{workout}/{day}/{muscle}?alternateTo={alternateTo}",
-      arguments = alternateToArg
-    ) {
-      val exerciseModel: ExerciseViewModel = hiltViewModel(it)
-      val workoutModel: WorkoutViewModel = hiltViewModel(it)
-      val userModel: UserViewModel = hiltViewModel(it)
-      val workoutId = it.arguments?.getString("workout")
-      val day = it.arguments?.getString("day")
-      val muscle = it.arguments?.getString("muscle")?.let(Uri::decode)
-      val alternateTo = it.arguments?.getString("alternateTo")?.let(Uri::decode)
-      if (workoutId != null && day != null && muscle != null) {
-        val localExercises by remember(muscle) { exerciseModel.exercisesByMuscle(muscle) }
-          .collectAsStateWithLifecycle(initialValue = emptyList())
-        val accessibleWorkouts by exerciseModel.accessibleWorkouts
-          .collectAsStateWithLifecycle(initialValue = emptyList())
-        // The plan list itself (accessibleWorkouts) only updates when this same paging refresh
-        // runs - reusing it rather than a separate sync path keeps this screen's "refresh the
-        // plan list" in lockstep with the drawer's.
-        val workoutPlansPagingItems = workoutModel.workouts.collectAsLazyPagingItems()
-        val currentEmail by userModel.userEmail.collectAsStateWithLifecycle(initialValue = null)
-        // Reload accessibleWorkouts once sign-in actually completes, so newly-unlocked admin
-        // plans show up without the user having to tap the refresh icon themselves.
-        var signInClicked by remember { mutableStateOf(false) }
-        LaunchedEffect(currentEmail) {
-          if (signInClicked) {
-            workoutPlansPagingItems.refresh()
-          }
-        }
-        ExercisePickerList(
-          muscle = muscle,
-          // Exclude the plan being built itself - a custom plan is assembled from admin
-          // content, so any local rows under its own name just duplicate an admin section.
-          localExercisesByWorkout = localExercises
-            .filter { it.workout != workoutId }
-            .groupBy { it.workout },
-          accessibleWorkouts = accessibleWorkouts,
-          remoteExercisesByWorkout = exerciseModel.remoteExercisesByWorkout,
-          loadingWorkouts = exerciseModel.loadingWorkouts,
-          onLoadWorkout = { workout -> exerciseModel.loadRemoteExercises(workout, muscle) },
-          onPick = { exercise ->
-            if (alternateTo != null) {
-              exerciseModel.addAlternateExercise(
-                workoutId, day, alternateTo, exercise.id, exercise.description
-              )
-            } else {
-              exerciseModel.addExercise(workoutId, day, exercise.id, exercise.description)
-            }
-            controller.getBackStackEntry("exercise/{workout}/{day}/{editing}")
-              .savedStateHandle["justAddedExercise"] = exercise.name
-            // Pop the whole add-exercise sub-flow at once, back to the day screen.
-            controller.popBackStack("exercise/{workout}/{day}/{editing}", inclusive = false)
-          },
-          onBack = { controller.popBackStack() },
-          onRefreshWorkouts = { workoutPlansPagingItems.refresh() },
-          isRefreshingWorkouts = workoutPlansPagingItems.loadState.refresh is LoadState.Loading,
-          authedEmail = currentEmail,
-          onSignInSuccess = { response ->
-            signInClicked = true
-            when (val credential = response.credential) {
-              is CustomCredential -> {
-                if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
-                  userModel.handleSignIn(credential.data)
-                } else {
-                  Log.e("AddExercisePicker", "Unexpected type of credential")
-                }
-              }
-
-              else -> Log.e("AddExercisePicker", "Unexpected type of credential")
-            }
-          },
-          onSignInFailure = { Log.e("AddExercisePicker", "Sign in failed", it) },
-          webClientId = userModel.googleWebClientId
+          userModel = userModel
         )
       } else {
         controller.navigate("calendar")

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
@@ -1,5 +1,6 @@
 package com.litus_animae.refitted.ui.compose.exercise
 
+import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -33,19 +34,26 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.dp
+import androidx.credentials.CustomCredential
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.paging.LoadState
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.litus_animae.refitted.ui.R
+import com.litus_animae.refitted.ui.compose.exercise.add.AddExercisePanel
 import com.litus_animae.refitted.ui.compose.exercise.input.WeightButtons
 import com.litus_animae.refitted.ui.compose.state.SetHistory
 import com.litus_animae.refitted.ui.compose.state.Weight
-import com.litus_animae.refitted.data.models.ExerciseSet
 import com.litus_animae.refitted.ui.models.ExerciseViewModel
+import com.litus_animae.refitted.ui.models.UserViewModel
 import com.litus_animae.refitted.ui.models.WorkoutViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -60,15 +68,15 @@ fun Exercise(
   editing: Boolean = false,
   exerciseModel: ExerciseViewModel = viewModel(),
   workoutModel: WorkoutViewModel = viewModel(),
-  onAddExercise: () -> Unit = {},
-  onAddAlternate: (ExerciseSet) -> Unit = {},
-  scrollToExerciseName: String? = null
+  userModel: UserViewModel = viewModel()
 ) {
   val title = stringResource(id = R.string.app_name)
   val dayWord = stringResource(id = R.string.day)
   val scaffoldState = rememberScaffoldState()
   val scaffoldScope = rememberCoroutineScope()
   val sheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
+  val addExerciseSheetState =
+    rememberModalBottomSheetState(ModalBottomSheetValue.Hidden, skipHalfExpanded = true)
 
   val loadedWorkoutPlan by workoutModel.currentWorkout.collectAsState(
     initial = workoutModel.savedStateLastWorkoutPlan,
@@ -82,6 +90,11 @@ fun Exercise(
   val (historyList, setHistoryList) = remember {
     mutableStateOf(SetHistory())
   }
+  // Which existing step (if any) the picked exercise should become an alternate of - null
+  // means "add exercise", non-null means "add alternate" for that step.
+  var alternateToStep by rememberSaveable { mutableStateOf<String?>(null) }
+  // Lands the pager on the exercise just added - consumed once by PagerExerciseView.
+  var scrollToExerciseName by rememberSaveable { mutableStateOf<String?>(null) }
   Scaffold(
     // navigationBars alone leaves a side-mounted camera cutout unhandled once rotated to
     // landscape — the two-pane exercise layout then splits content right up against it.
@@ -119,7 +132,10 @@ fun Exercise(
             // collapsed, it is an overflow menu and belongs last instead.
             if (!collapsed) contextMenu(false)
             if (showAddExercise) {
-              IconButton(onAddExercise) {
+              IconButton({
+                alternateToStep = null
+                scaffoldScope.launch { addExerciseSheetState.show() }
+              }) {
                 // TODO localize
                 Icon(Icons.Default.Add, "add exercise")
               }
@@ -148,31 +164,113 @@ fun Exercise(
   ) {
     var sheetWeight by remember { mutableStateOf(Weight(0.0)) }
     ModalBottomSheetLayout(
+      sheetState = addExerciseSheetState,
       sheetContent = {
-        Box(Modifier.padding(top = 10.dp, bottom = 10.dp)) {
-          WeightButtons(
-            sheetWeight
+        // sheetContent composes continuously even while hidden - gate the collection this
+        // panel needs behind visibility so browsing a library's cost only starts once the
+        // user actually opens the sheet (see ui/CLAUDE.md's Compose Gotchas).
+        if (addExerciseSheetState.isVisible) {
+          val selectedMuscle by exerciseModel.selectedMuscle.collectAsStateWithLifecycle()
+          val localExercises by remember(selectedMuscle) {
+            exerciseModel.exercisesByMuscle(selectedMuscle)
+          }.collectAsStateWithLifecycle(initialValue = emptyList())
+          val accessibleWorkouts by exerciseModel.accessibleWorkouts
+            .collectAsStateWithLifecycle(initialValue = emptyList())
+          // The plan list itself (accessibleWorkouts) only updates when this same paging refresh
+          // runs - reusing it rather than a separate sync path keeps this screen's "refresh the
+          // plan list" in lockstep with the drawer's.
+          val workoutPlansPagingItems = workoutModel.workouts.collectAsLazyPagingItems()
+          val currentEmail by userModel.userEmail.collectAsStateWithLifecycle(initialValue = null)
+          // Reload accessibleWorkouts once sign-in actually completes, so newly-unlocked admin
+          // plans show up without the user having to tap the refresh icon themselves.
+          var signInClicked by remember { mutableStateOf(false) }
+          LaunchedEffect(currentEmail) {
+            if (signInClicked) {
+              workoutPlansPagingItems.refresh()
+            }
+          }
+          AddExercisePanel(
+            title = if (alternateToStep != null) "Add alternate" else "Add exercise",
+            muscle = selectedMuscle,
+            onMuscleSelected = exerciseModel::selectMuscle,
+            // Exclude the plan being built itself - a custom plan is assembled from admin
+            // content, so any local rows under its own name just duplicate an admin section.
+            localExercisesByWorkout = localExercises
+              .filter { it.workout != workoutId }
+              .groupBy { it.workout },
+            accessibleWorkouts = accessibleWorkouts,
+            remoteExercisesByWorkout = exerciseModel.remoteExercisesByWorkout,
+            loadingWorkouts = exerciseModel.loadingWorkouts,
+            onLoadWorkout = { workout -> exerciseModel.loadRemoteExercises(workout, selectedMuscle) },
+            onPick = { exercise ->
+              val baseStep = alternateToStep
+              if (baseStep != null) {
+                exerciseModel.addAlternateExercise(
+                  workoutId, day, baseStep, exercise.id, exercise.description
+                )
+              } else {
+                exerciseModel.addExercise(workoutId, day, exercise.id, exercise.description)
+              }
+              scrollToExerciseName = exercise.name
+              scaffoldScope.launch { addExerciseSheetState.hide() }
+            },
+            onClose = { scaffoldScope.launch { addExerciseSheetState.hide() } },
+            onRefreshWorkouts = { workoutPlansPagingItems.refresh() },
+            isRefreshingWorkouts = workoutPlansPagingItems.loadState.refresh is LoadState.Loading,
+            authedEmail = currentEmail,
+            onSignInSuccess = { response ->
+              signInClicked = true
+              when (val credential = response.credential) {
+                is CustomCredential -> {
+                  if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+                    userModel.handleSignIn(credential.data)
+                  } else {
+                    Log.e("Exercise", "Unexpected type of credential")
+                  }
+                }
+
+                else -> Log.e("Exercise", "Unexpected type of credential")
+              }
+            },
+            onSignInFailure = { Log.e("Exercise", "Sign in failed", it) },
+            webClientId = userModel.googleWebClientId
           )
         }
-      },
-      sheetState = sheetState
+      }
     ) {
-      PagerExerciseView(exerciseModel,
-        workoutPlan = loadedWorkoutPlan,
-        contentPadding = it,
-        setHistoryList = { setHistoryList(it) },
-        setContextMenu = { contextMenu = it },
-        onAlternateChange = { workoutModel.setGlobalIndexIfEnabled(loadedWorkoutPlan, it) },
-        onStartEditWeight = {
-          sheetWeight = it
-          scaffoldScope.launch { sheetState.show() }
+      ModalBottomSheetLayout(
+        sheetContent = {
+          Box(Modifier.padding(top = 10.dp, bottom = 10.dp)) {
+            WeightButtons(
+              sheetWeight
+            )
+          }
         },
-        onSetSaved = { workoutModel.alignToDayIfUnaligned(loadedWorkoutPlan, day.toIntOrNull() ?: 1) },
-        onOpenHistory = { scaffoldScope.launch { scaffoldState.drawerState.open() } },
-        editing = editing,
-        onAddExercise = onAddExercise,
-        onAddAlternate = onAddAlternate,
-        scrollToExerciseName = scrollToExerciseName)
+        sheetState = sheetState
+      ) {
+        PagerExerciseView(exerciseModel,
+          workoutPlan = loadedWorkoutPlan,
+          contentPadding = it,
+          setHistoryList = { setHistoryList(it) },
+          setContextMenu = { contextMenu = it },
+          onAlternateChange = { workoutModel.setGlobalIndexIfEnabled(loadedWorkoutPlan, it) },
+          onStartEditWeight = {
+            sheetWeight = it
+            scaffoldScope.launch { sheetState.show() }
+          },
+          onSetSaved = { workoutModel.alignToDayIfUnaligned(loadedWorkoutPlan, day.toIntOrNull() ?: 1) },
+          onOpenHistory = { scaffoldScope.launch { scaffoldState.drawerState.open() } },
+          editing = editing,
+          onAddExercise = {
+            alternateToStep = null
+            scaffoldScope.launch { addExerciseSheetState.show() }
+          },
+          onAddAlternate = { set ->
+            alternateToStep = set.primaryStep
+            scaffoldScope.launch { addExerciseSheetState.show() }
+          },
+          scrollToExerciseName = scrollToExerciseName)
+      }
     }
   }
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -96,7 +96,7 @@ fun PagerExerciseView(
   // Land on an exercise just added from the add-exercise flow instead of wherever the pager
   // otherwise starts - fires once the newly-inserted row has actually loaded, then clears
   // itself so later unrelated recompositions of `instructions` don't re-trigger the scroll.
-  var pendingScrollTarget by remember { mutableStateOf(scrollToExerciseName) }
+  var pendingScrollTarget by remember(scrollToExerciseName) { mutableStateOf(scrollToExerciseName) }
   LaunchedEffect(instructions, pendingScrollTarget) {
     val target = pendingScrollTarget ?: return@LaunchedEffect
     val targetIndex = instructions.indexOfFirst { instruction ->

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
@@ -168,9 +168,7 @@ fun AddExerciseList(
     topBar = {
       TopAppBar(
         title = { Text(title) },
-        windowInsets = AppBarDefaults.topAppBarWindowInsets.union(
-          WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)
-        ),
+        windowInsets = WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal),
         backgroundColor = MaterialTheme.colors.primary,
         navigationIcon = {
           // There's no picker screen left to step back to - this closes the whole add-exercise

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/add/AddExercisePicker.kt
@@ -1,6 +1,12 @@
 package com.litus_animae.refitted.ui.compose.exercise.add
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -32,7 +38,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.AppBarDefaults
-import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
@@ -45,7 +50,6 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ExpandMore
@@ -73,77 +77,44 @@ import com.litus_animae.refitted.ui.compose.AuthButton
 private val muscleGroups = MuscleGroup.displayNames()
 
 /**
- * Target-muscle screen (design 1i): body diagram + chips, both driving the same selection.
- * A separate nav destination from [ExercisePickerList] so system/gesture back steps one
- * screen at a time instead of leaving the whole add-exercise flow.
+ * Target-muscle picker content (design 1i): body diagram + chips, both driving the same
+ * selection. Applies instantly - there's no confirm step, the caller closes the panel itself
+ * once [onSelect] fires.
  */
 @Composable
-fun MuscleGroupPickerScreen(
-  onContinue: (String) -> Unit,
-  onClose: () -> Unit,
-  modifier: Modifier = Modifier,
-  // TODO localize
-  title: String = "Add exercise"
+fun MuscleGroupPicker(
+  selected: String,
+  onSelect: (String) -> Unit,
+  modifier: Modifier = Modifier
 ) {
-  var selected by rememberSaveable { mutableStateOf(muscleGroups.first()) }
-  Scaffold(
-    contentWindowInsets = WindowInsets.navigationBars.union(WindowInsets.displayCutout),
-    modifier = modifier,
-    topBar = {
-      TopAppBar(
-        title = { Text(title) },
-        windowInsets = AppBarDefaults.topAppBarWindowInsets.union(
-          WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)
-        ),
-        backgroundColor = MaterialTheme.colors.primary,
-        navigationIcon = {
-          // TODO localize
-          IconButton(onClick = onClose) { Icon(Icons.Default.Close, "close") }
-        }
-      )
+  Column(
+    modifier
+      .verticalScroll(rememberScrollState())
+      .padding(16.dp)
+  ) {
+    CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+      // TODO localize
+      Text("Tap the muscle group to target", style = MaterialTheme.typography.body2)
     }
-  ) { contentPadding ->
-    Column(modifier.padding(contentPadding).fillMaxSize()) {
-      Column(
-        Modifier
-          .weight(1f)
-          .verticalScroll(rememberScrollState())
-          .padding(16.dp)
-      ) {
-        CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
-          // TODO localize
-          Text("Tap the muscle group to target", style = MaterialTheme.typography.body2)
-        }
-        Spacer(Modifier.height(14.dp))
-        BodyDiagram(selected = selected, onSelect = { selected = it }, modifier = Modifier.fillMaxWidth())
-        Spacer(Modifier.height(14.dp))
-        FlowRow(
-          horizontalArrangement = Arrangement.spacedBy(8.dp),
-          verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-          muscleGroups.forEach { muscle ->
-            MuscleChip(muscle, selected = muscle == selected, onClick = { selected = muscle })
-          }
-        }
-      }
-      Button(
-        onClick = { onContinue(selected) },
-        modifier = Modifier
-          .fillMaxWidth()
-          .padding(16.dp)
-      ) {
-        // TODO localize
-        Text("Continue — $selected")
+    Spacer(Modifier.height(14.dp))
+    BodyDiagram(selected = selected, onSelect = onSelect, modifier = Modifier.fillMaxWidth())
+    Spacer(Modifier.height(14.dp))
+    FlowRow(
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
+      verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+      muscleGroups.forEach { muscle ->
+        MuscleChip(muscle, selected = muscle == selected, onClick = { onSelect(muscle) })
       }
     }
   }
 }
 
-/** A section of [ExercisePickerList] - one accessible plan, ordered by [kind] then name. */
+/** A section of [AddExerciseList] - one accessible plan, ordered by [kind] then name. */
 private data class PickerSection(val name: String, val kind: PlanKind, val isRemoteSource: Boolean)
 
 /**
- * Exercise-list screen (design 1j) - plans the user can pull exercises from, as sections, equipment
+ * Exercise-list content (design 1j) - plans the user can pull exercises from, as sections, equipment
  * libraries ([PlanKind.LOCATION]/[PlanKind.EQUIPMENT]) first and admin programs after a divider.
  * Locally-synced matches ([localExercisesByWorkout]) render immediately; other accessible
  * (admin-authored) plans render a "Load exercises" row that triggers an on-demand remote query
@@ -153,11 +124,14 @@ private data class PickerSection(val name: String, val kind: PlanKind, val isRem
  * nothing of their own to load remotely. Picking an exercise reuses its exact id so its record
  * history carries over ([onPick]). Every section starts collapsed - [onRefreshWorkouts] is a
  * separate top-bar action re-syncing the plan list itself (new/removed plans), not any one
- * plan's exercises.
+ * plan's exercises. The current [muscle] is shown as a tappable header ([onMuscleTap]) rather
+ * than a plain title - it's a live filter now, not something picked on a screen before this one.
  */
 @Composable
-fun ExercisePickerList(
+fun AddExerciseList(
+  title: String,
   muscle: String,
+  onMuscleTap: () -> Unit,
   localExercisesByWorkout: Map<String, List<Exercise>>,
   accessibleWorkouts: List<WorkoutPlan>,
   /** Keyed by (workout, muscle) - a workout's cached rows are only ever for this screen's own muscle. */
@@ -165,7 +139,7 @@ fun ExercisePickerList(
   loadingWorkouts: Map<Pair<String, String>, Boolean>,
   onLoadWorkout: (String) -> Unit,
   onPick: (Exercise) -> Unit,
-  onBack: () -> Unit,
+  onClose: () -> Unit,
   /** Re-syncs [accessibleWorkouts] itself (new/removed plans) - separate from a section's own onLoadWorkout, which only refreshes that plan's exercises. */
   onRefreshWorkouts: () -> Unit,
   isRefreshingWorkouts: Boolean,
@@ -193,13 +167,16 @@ fun ExercisePickerList(
     modifier = modifier,
     topBar = {
       TopAppBar(
-        title = { Text(muscle) },
+        title = { Text(title) },
         windowInsets = AppBarDefaults.topAppBarWindowInsets.union(
           WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)
         ),
         backgroundColor = MaterialTheme.colors.primary,
         navigationIcon = {
-          IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, "back") }
+          // There's no picker screen left to step back to - this closes the whole add-exercise
+          // sheet, so it reads as "close" rather than "back".
+          // TODO localize
+          IconButton(onClick = onClose) { Icon(Icons.Default.Close, "close") }
         },
         actions = {
           if (isRefreshingWorkouts) {
@@ -236,6 +213,9 @@ fun ExercisePickerList(
     }
   ) { contentPadding ->
     LazyColumn(Modifier.padding(contentPadding).fillMaxSize()) {
+      item(key = "muscle-header") {
+        SelectedMuscleHeader(muscle, onClick = onMuscleTap)
+      }
       sections.forEachIndexed { index, section ->
         val workout = section.name
         if (index == firstProgramIndex && index > 0) {
@@ -384,6 +364,117 @@ fun ExercisePickerList(
 }
 
 @Composable
+private fun SelectedMuscleHeader(muscle: String, onClick: () -> Unit) {
+  Column {
+    Row(
+      Modifier
+        .fillMaxWidth()
+        .clickable(onClickLabel = "change target muscle", onClick = onClick)
+        .padding(start = 10.dp, end = 10.dp, top = 10.dp, bottom = 10.dp),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+          // TODO localize
+          Text("Target muscle", style = MaterialTheme.typography.overline)
+        }
+        Spacer(Modifier.width(8.dp))
+        Text(muscle, style = MaterialTheme.typography.subtitle1)
+      }
+      Icon(Icons.Default.ExpandMore, contentDescription = null)
+    }
+    Divider()
+  }
+}
+
+/**
+ * Combines [AddExerciseList] with an [AnimatedVisibility] overlay of [MuscleGroupPicker] -
+ * a plain `Box` overlay rather than a second nested `ModalBottomSheetLayout`, so its swipe/anchor
+ * math never runs against an already-clamped outer sheet (see ui/CLAUDE.md's guidance on hosting
+ * overlays in an unclipped ancestor instead of layering more sheet/Popup machinery). System/gesture
+ * back closes just the picker first via the [BackHandler] below, which - because it only composes
+ * while [pickingMuscle] is true, itself nested inside the outer sheet's own content - registers
+ * (and so takes priority) after that sheet's own built-in back handling.
+ */
+@Composable
+fun AddExercisePanel(
+  title: String,
+  muscle: String,
+  onMuscleSelected: (String) -> Unit,
+  localExercisesByWorkout: Map<String, List<Exercise>>,
+  accessibleWorkouts: List<WorkoutPlan>,
+  remoteExercisesByWorkout: Map<Pair<String, String>, List<Exercise>>,
+  loadingWorkouts: Map<Pair<String, String>, Boolean>,
+  onLoadWorkout: (String) -> Unit,
+  onPick: (Exercise) -> Unit,
+  onClose: () -> Unit,
+  onRefreshWorkouts: () -> Unit,
+  isRefreshingWorkouts: Boolean,
+  authedEmail: String?,
+  onSignInSuccess: (GetCredentialResponse) -> Unit,
+  onSignInFailure: (GetCredentialException) -> Unit,
+  webClientId: String,
+  modifier: Modifier = Modifier
+) {
+  var pickingMuscle by rememberSaveable { mutableStateOf(false) }
+
+  BackHandler(enabled = pickingMuscle) { pickingMuscle = false }
+
+  Box(modifier.fillMaxSize()) {
+    AddExerciseList(
+      title = title,
+      muscle = muscle,
+      onMuscleTap = { pickingMuscle = true },
+      localExercisesByWorkout = localExercisesByWorkout,
+      accessibleWorkouts = accessibleWorkouts,
+      remoteExercisesByWorkout = remoteExercisesByWorkout,
+      loadingWorkouts = loadingWorkouts,
+      onLoadWorkout = onLoadWorkout,
+      onPick = onPick,
+      onClose = onClose,
+      onRefreshWorkouts = onRefreshWorkouts,
+      isRefreshingWorkouts = isRefreshingWorkouts,
+      authedEmail = authedEmail,
+      onSignInSuccess = onSignInSuccess,
+      onSignInFailure = onSignInFailure,
+      webClientId = webClientId
+    )
+    AnimatedVisibility(
+      visible = pickingMuscle,
+      enter = fadeIn() + slideInVertically(initialOffsetY = { it / 4 }),
+      exit = fadeOut() + slideOutVertically(targetOffsetY = { it / 4 })
+    ) {
+      Surface(Modifier.fillMaxSize()) {
+        Column {
+          Row(
+            Modifier
+              .fillMaxWidth()
+              .padding(start = 16.dp, end = 4.dp, top = 4.dp, bottom = 4.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+          ) {
+            // TODO localize
+            Text("Target muscle", style = MaterialTheme.typography.h6)
+            IconButton(onClick = { pickingMuscle = false }) {
+              Icon(Icons.Default.Close, "close")
+            }
+          }
+          MuscleGroupPicker(
+            selected = muscle,
+            onSelect = {
+              onMuscleSelected(it)
+              pickingMuscle = false
+            },
+            modifier = Modifier.weight(1f)
+          )
+        }
+      }
+    }
+  }
+}
+
+@Composable
 private fun MuscleChip(label: String, selected: Boolean, onClick: () -> Unit) {
   Surface(
     shape = RoundedCornerShape(16.dp),
@@ -500,16 +591,18 @@ private fun BodyFigure(parts: List<BodyPart>, selected: String, onSelect: (Strin
 @Composable
 private fun PreviewMuscleGroupPicker() {
   MaterialTheme {
-    MuscleGroupPickerScreen(onContinue = {}, onClose = {})
+    MuscleGroupPicker(selected = "Chest", onSelect = {})
   }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun PreviewExercisePickerList() {
+private fun PreviewAddExerciseList() {
   MaterialTheme {
-    ExercisePickerList(
+    AddExerciseList(
+      title = "Add exercise",
       muscle = "Chest",
+      onMuscleTap = {},
       localExercisesByWorkout = mapOf(
         "Push Pull Legs" to listOf(
           Exercise("Push Pull Legs", "Chest_Barbell Bench Press"),
@@ -531,7 +624,7 @@ private fun PreviewExercisePickerList() {
       loadingWorkouts = emptyMap(),
       onLoadWorkout = {},
       onPick = {},
-      onBack = {},
+      onClose = {},
       onRefreshWorkouts = {},
       isRefreshingWorkouts = false,
       authedEmail = null,

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -14,6 +14,7 @@ import com.litus_animae.refitted.data.ExerciseRepository
 import com.litus_animae.refitted.data.WorkoutPlanRepository
 import com.litus_animae.refitted.data.models.Exercise
 import com.litus_animae.refitted.data.models.ExerciseSet
+import com.litus_animae.refitted.data.models.MuscleGroup
 import com.litus_animae.refitted.data.models.SetRecord
 import com.litus_animae.refitted.util.LogUtil
 import com.litus_animae.refitted.util.maybeZipWithNext
@@ -293,6 +294,15 @@ class ExerciseViewModel @Inject constructor(
   val accessibleWorkouts = workoutPlanRepo.accessibleWorkouts
 
   fun exercisesByMuscle(muscle: String): Flow<List<Exercise>> = exerciseRepo.exercisesByMuscle(muscle)
+
+  // Scoped to this ViewModel's nav back-stack entry (the day being edited) - carries over
+  // between successive add-exercise sheet opens, resets once the day screen itself is left.
+  private val _selectedMuscle = MutableStateFlow(MuscleGroup.displayNames().first())
+  val selectedMuscle: StateFlow<String> = _selectedMuscle.asStateFlow()
+
+  fun selectMuscle(muscle: String) {
+    _selectedMuscle.value = muscle
+  }
 
   // Keyed by (workout, muscle) - not workout alone - so switching muscle within one session
   // never shows a stale result cached under the same workout for a different muscle.

--- a/ui/src/main/res/values/changelog.xml
+++ b/ui/src/main/res/values/changelog.xml
@@ -3,7 +3,6 @@
     <string name="changelog_version_header">**</string>
     <string-array name="changelog">
         <item>**v1.4.2</item>
-        <item>Adding an exercise is quicker: pick your target muscle right from the exercise list, no extra screens, and it stays put while you add more</item>
         <item>**v1.4.1</item>
         <item>Give any exercise in a custom workout an alternate, then swap between them as you train</item>
         <item>Rename or delete your custom plans, from the workout list or the calendar menu</item>

--- a/ui/src/main/res/values/changelog.xml
+++ b/ui/src/main/res/values/changelog.xml
@@ -3,6 +3,7 @@
     <string name="changelog_version_header">**</string>
     <string-array name="changelog">
         <item>**v1.4.2</item>
+        <item>Adding an exercise is quicker: pick your target muscle right from the exercise list, no extra screens, and it stays put while you add more</item>
         <item>**v1.4.1</item>
         <item>Give any exercise in a custom workout an alternate, then swap between them as you train</item>
         <item>Rename or delete your custom plans, from the workout list or the calendar menu</item>


### PR DESCRIPTION
## Summary

- The muscle-group filter now carries over between successive "add exercise" taps while editing a day, instead of resetting to the alphabetically-first muscle every time. It's plain `ExerciseViewModel` state scoped to the day-editing nav entry (`ExerciseViewModel.kt`) — no durable persistence, since it only needs to survive within one editing session.
- "Add exercise" is no longer two separate full-screen nav pushes (`add-exercise/*` routes removed from `Top.kt`). It's now a `ModalBottomSheetLayout` hosted directly on the day/edit screen (`exercise/Main.kt`), alongside the existing weight-input sheet.
- The muscle picker (body diagram + chips) is kept, but changing it is now an in-sheet overlay opened by tapping the current muscle in the list header — applies instantly, no "Continue" button.
- `AddExercisePicker.kt` reshaped: `MuscleGroupPickerScreen`/`ExercisePickerList` (two screens) → `MuscleGroupPicker`/`AddExerciseList`/`AddExercisePanel` (composable content pieces combined in one sheet).

## Test plan

No `:ui` test source set exists in this repo and CI's Android job only runs `assembleRelease`, so this needs manual on-device verification:

- [ ] Open a custom day in edit mode, tap add-exercise — sheet opens over the day screen (not a new full screen)
- [ ] Tap the muscle header — body diagram/chip overlay opens; picking a muscle applies instantly with no Continue tap
- [ ] Add an exercise — pager lands on/scrolls to it
- [ ] Add a second exercise without leaving the day screen — sheet reopens on the previously-picked muscle instead of resetting
- [ ] "Add alternate" from an existing step still targets the right base step
- [ ] System/gesture back closes the muscle overlay first, then the sheet, before reaching the day screen
- [ ] Switching muscles while a remote fetch is in flight doesn't leak stale cross-muscle results
- [ ] Leave the day screen and come back in — filter resets to default (not remembered past that point, as intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BAWCbXstBuQofkjz3hoF2Z)_