### PR TITLE
Effort chart: honest layoffs, cadence-aware detraining, and a band instead of a line

### DIFF
--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortConfig.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortConfig.kt
@@ -35,6 +35,12 @@ data class EffortConfig(
   val detrainGraceDays: Double = 10.0,
   val detrainHalfLifeDays: Double = 60.0,
   val detrainFloor: Double = 0.6,
+  // How much of that haircut is also charged as uncertainty. Cutting the expectation without
+  // widening the band around it makes the model *more* confident the longer someone has been
+  // away - the residual floor is a fraction of the expectation, so it shrinks right along with
+  // it - and a comeback then reads IMPLAUSIBLE for the crime of being predictable. Only ever
+  // non-zero when detrainFactor is, so every session inside the grace period is untouched.
+  val layoffUncertaintyWeight: Double = 0.75,
   val minPriorSessions: Int = 3,
   val residualScaleFloorFraction: Double = 0.05,
   val maxExtrapolationDays: Long = 14,

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortConfig.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortConfig.kt
@@ -33,6 +33,13 @@ data class EffortConfig(
   // something, not everything. Applied to the prediction only: the comeback session still folds
   // in at its true capacity, so the curve re-anchors to reality rather than to the haircut.
   val detrainGraceDays: Double = 10.0,
+  // The grace above is a floor, not the whole story: it also scales with the cadence this
+  // exercise is actually trained on. A flat calendar constant made an exercise's own rotation
+  // look like detraining - alternating pull-ups and pull-downs leaves 14 days between sessions
+  // of each, so both sat permanently past a 10-day grace and a *flat plateau* on that rotation
+  // scored GROWTH. At 1.5x, a 14-day rotation gets 21 days free and a 28-day one gets 42, while
+  // a gap genuinely abnormal for the exercise still detrains. Zero restores the flat constant.
+  val cadenceGraceMultiple: Double = 1.5,
   val detrainHalfLifeDays: Double = 60.0,
   val detrainFloor: Double = 0.6,
   // How much of that haircut is also charged as uncertainty. Cutting the expectation without

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortConfig.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortConfig.kt
@@ -20,6 +20,19 @@ data class EffortConfig(
   // Upper bound on the fit's typical-reps estimate, which the hard clamp used to supply.
   val repSoftCapMax: Double = 40.0,
   val epleyDivisor: Double = 30.0,
+  // What an unloadable movement is already moving before anything is added to it. Capacity is
+  // multiplicative, so without this the floor in EffortModel.capacity made 0 lb and 5 lb read
+  // as 1 and 5: adding a first 5 lb dumbbell to a set of pull-ups quadrupled demonstrated
+  // capacity and scored IMPLAUSIBLE, which is precisely the progression the chart exists to
+  // encourage. It also pinned expectedWeight near 1 lb no matter how the reps went, so the
+  // trend line carried no information for bodyweight at all.
+  //
+  // Deliberately one constant rather than a per-movement table or a stored bodyweight: it
+  // largely cancels out of z, which compares a lifter to their own history, and what it really
+  // sets is how a rep trades against a pound - at 100 with 10 reps, roughly 3.3 lb per rep -
+  // which is what decides when adding load is justified rather than another rep. Applied only
+  // to exercises that have logged an unweighted set; everything else keeps a baseline of zero.
+  val bodyweightBaselineLoad: Double = 100.0,
   val halfLifeSessions: Double = 9.0,
   // History ages by calendar time as well as by session count. Without this, nine sessions
   // spread over three weeks weigh exactly the same as nine spread over two years. A normal

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
@@ -4,6 +4,7 @@ import java.time.Duration
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import kotlin.math.abs
+import kotlin.math.exp
 import kotlin.math.ln
 import kotlin.math.max
 import kotlin.math.min
@@ -142,12 +143,29 @@ object EffortModel {
   }
 
   /**
-   * How far the expectation is cut back for time away. Ordinary rest days and a missed week sit
-   * inside the grace period and cost nothing; past that it decays on its own half-life and
-   * floors well short of zero.
+   * How long a gap has to be, for this exercise, before it counts as time away at all.
+   *
+   * A flat calendar constant treats an exercise's own rotation as detraining: alternating
+   * pull-ups and pull-downs puts every session 14 days after the last, so both were permanently
+   * scored as partly detrained and a *flat plateau* on that rotation read GROWTH - zero progress
+   * reported as growth, which defeats the point of the chart. Scaling the grace by the cadence
+   * the lifter has actually established makes a normal-for-you gap free while a gap that is
+   * abnormal *for this exercise* still detrains.
    */
-  private fun detrainFactor(layoffDays: Double, config: EffortConfig): Double {
-    val excess = (layoffDays - config.detrainGraceDays).coerceAtLeast(0.0)
+  private fun graceDays(typicalGapDays: Double, config: EffortConfig): Double =
+    max(config.detrainGraceDays, config.cadenceGraceMultiple * typicalGapDays)
+
+  /**
+   * How far the expectation is cut back for time away. Ordinary rest days, a missed week, and
+   * anything inside this exercise's own rhythm sit within [graceDays] and cost nothing; past
+   * that it decays on its own half-life and floors well short of zero.
+   */
+  private fun detrainFactor(
+    layoffDays: Double,
+    typicalGapDays: Double,
+    config: EffortConfig
+  ): Double {
+    val excess = (layoffDays - graceDays(typicalGapDays, config)).coerceAtLeast(0.0)
     if (excess <= 0.0 || config.detrainHalfLifeDays <= 0.0) return 1.0
     return 0.5.pow(excess / config.detrainHalfLifeDays).coerceAtLeast(config.detrainFloor)
   }
@@ -287,6 +305,19 @@ object EffortModel {
     var sumRepsW = 0.0
     var sumRepsWr = 0.0
 
+    // Typical-gap accumulators, so the detrain grace can scale with the cadence this exercise
+    // is actually trained on. The very first session has nothing before it and contributes no
+    // gap, which is why this is weighted separately from the regression's own sumW.
+    //
+    // Accumulated in log space, so the estimate is a geometric mean. Two reasons: gaps are a
+    // ratio quantity (twice as long is the meaningful step, not a day longer), and a single
+    // enormous outlier has to not swallow the estimate - ten 4-day gaps and one 730-day one
+    // average arithmetically to 70 days, and geometrically to 6.4. That robustness is what
+    // lets the layoff itself stay in the average instead of needing to be classified out,
+    // which is circular: the classification is what the average is for.
+    var sumGapW = 0.0
+    var sumGapWlog = 0.0
+
     var priorSessionCount = 0
     var lastPriorX = 0.0
     var runningBest = 0.0
@@ -312,6 +343,12 @@ object EffortModel {
       }
       val sessionValue = bestCapacity * sustainFactor(capacities, peakIndex, bestCapacity, config)
 
+      // Hoisted out of the prediction block: the fold-in below needs the same verdict on
+      // whether this gap was time away or just this exercise's rhythm.
+      val typicalGapDays = if (sumGapW > 0.0) exp(sumGapWlog / sumGapW) else 0.0
+      val detrain = detrainFactor(session.layoffDays, typicalGapDays, config)
+      val followedLayoff = detrain < 1.0
+
       var expectedCapacity: Double? = null
       var expectedWeight: Double? = null
       var residualScale: Double? = null
@@ -335,7 +372,7 @@ object EffortModel {
         // bounds the *level*, which nothing did before - the curve used to freeze where it was
         // left, so coming back from months off read BELOW on every set until it was clawed back.
         val undetrained = shrunk.coerceIn(0.5 * meanY, 1.5 * meanY)
-        val cHat = undetrained * detrainFactor(session.layoffDays, config)
+        val cHat = undetrained * detrain
         expectedCapacity = cHat
 
         val fittedResidualScale = if (sumResidualW >= 2.0) sqrt(sumResidualWe2 / sumResidualW) else 0.0
@@ -400,6 +437,11 @@ object EffortModel {
       sumW *= decay; sumWx *= decay; sumWy *= decay; sumWxx *= decay; sumWxy *= decay
       sumResidualW *= decay; sumResidualWe2 *= decay
       sumRepsW *= decay; sumRepsWr *= decay
+      // Session-count decay only, deliberately skipping the calendar term the others carry.
+      // Cadence is a per-exposure property, and aging it by the very gap being judged is
+      // self-defeating: a two-year break would age away the rhythm it needs to be measured
+      // against, leaving the break itself as the only sample and its own new "normal".
+      sumGapW *= sessionDecay; sumGapWlog *= sessionDecay
 
       val x = session.x
       sumW += 1.0
@@ -410,6 +452,16 @@ object EffortModel {
 
       sumRepsW += 1.0
       sumRepsWr += bestReps
+
+      // Read off agingDays rather than layoffDays so the gap is charged once per calendar day
+      // at either grain - at set granularity every set of a day shares the day's layoff, and
+      // billing each of them would report a five-set comeback as five gaps and inflate the
+      // cadence the grace is derived from. Zero means "no day preceded this", never a real gap:
+      // distinct sorted days are always at least one apart.
+      if (session.agingDays > 0.0) {
+        sumGapW += 1.0
+        sumGapWlog += ln(session.agingDays)
+      }
 
       if (expectedCapacity != null) {
         val e = sessionValue - expectedCapacity

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
@@ -100,11 +100,19 @@ object EffortModel {
     return HUMP_ANCHORS.last().second.toFloat()
   }
 
+  /** z below which a set reads as under its trend rather than on it. */
+  const val UNDER_EDGE_Z = -1.0
+
+  /** z at or above which a set reads as over its trend rather than on it. */
+  const val OVER_EDGE_Z = 0.5
+
+  private const val IMPLAUSIBLE_EDGE_Z = 2.0
+
   fun zoneOf(z: Double?): EffortZone = when {
     z == null -> EffortZone.COLD
-    z < -1.0 -> EffortZone.BELOW
-    z < 0.5 -> EffortZone.ON_CURVE
-    z < 2.0 -> EffortZone.GROWTH
+    z < UNDER_EDGE_Z -> EffortZone.BELOW
+    z < OVER_EDGE_Z -> EffortZone.ON_CURVE
+    z < IMPLAUSIBLE_EDGE_Z -> EffortZone.GROWTH
     else -> EffortZone.IMPLAUSIBLE
   }
 

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
@@ -14,26 +14,11 @@ import kotlin.math.sqrt
 /**
  * Scores each completed set's demonstrated capacity (weight x reps, Epley-style) against an
  * adaptive, causally-fit expectation of what a session "should" look like given training
- * history - never a static baseline, and a session's own outcome never judges itself. A set
- * scores larger (see [bubbleSize]) the closer it lands to or just above that expectation,
- * and shrinks again once it's implausibly far above - a likely fluke or typo, still worth
- * showing but not the target to chase.
+ * history - never a static baseline, and a session's own outcome never judges itself. How far
+ * a set landed from that expectation, in units of how well the model knows it, is [ScoredSet.z];
+ * [zoneOf] names the bands that value falls into.
  */
 object EffortModel {
-
-  const val NEUTRAL_SIZE = 0.45f
-
-  // z -> bubble size anchors. Piecewise-linear rather than smoothstep so "slightly above
-  // the curve" (z around 0.2-0.5) stays visually distinct from "on the curve" (z = 0).
-  private val HUMP_ANCHORS = listOf(
-    -2.0 to 0.00,
-    -1.0 to 0.30,
-    0.0 to 0.60,
-    0.5 to 0.85,
-    1.0 to 1.00,
-    1.5 to 0.90,
-    2.5 to 0.40
-  )
 
   /**
    * Epley-style estimated 1RM, the single scale weight×reps sets are compared on.
@@ -83,21 +68,6 @@ object EffortModel {
     }
     val excess = (clamped - config.repCap).toDouble()
     return config.repCap + config.repSoftCapScale * ln(1 + excess / config.repSoftCapScale)
-  }
-
-  fun bubbleSize(z: Double?): Float {
-    if (z == null) return NEUTRAL_SIZE
-    if (z <= HUMP_ANCHORS.first().first) return HUMP_ANCHORS.first().second.toFloat()
-    if (z >= HUMP_ANCHORS.last().first) return HUMP_ANCHORS.last().second.toFloat()
-    for (i in 0 until HUMP_ANCHORS.size - 1) {
-      val (x0, y0) = HUMP_ANCHORS[i]
-      val (x1, y1) = HUMP_ANCHORS[i + 1]
-      if (z <= x1) {
-        val t = (z - x0) / (x1 - x0)
-        return (y0 + t * (y1 - y0)).toFloat()
-      }
-    }
-    return HUMP_ANCHORS.last().second.toFloat()
   }
 
   /** z below which a set reads as under its trend rather than on it. */
@@ -521,7 +491,6 @@ object EffortModel {
             residualScale = residualScale,
             weightScale = setScale,
             z = z,
-            size = bubbleSize(z),
             zone = zoneOf(z)
           )
         )
@@ -674,7 +643,6 @@ object EffortModel {
               expectedWeight = fallback.expectedWeight,
               residualScale = fallback.residualScale,
               z = fallback.z,
-              size = fallback.size,
               zone = fallback.zone,
               expectationSource = ExpectationSource.BOOTSTRAP
             )

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
@@ -434,6 +434,12 @@ object EffortModel {
         val z = expectedCapacity?.let {
           ((c - it) / (residualScale ?: 1.0)).coerceIn(-config.maxAbsZ, config.maxAbsZ)
         }
+        // What one pound is worth to *this* set - its reps and the rest it followed, together.
+        // Dividing the expectation by it converts a capacity into the weight that would meet it
+        // at exactly this set's terms, which is the only version a chart plotting raw weight can
+        // compare a dot against. The session-wide, typical-reps conversion misplaces every set
+        // whose reps differ from the average, which is most of them.
+        val setScale = c / max(timed.set.weight, 1.0)
         scoredSets.add(
           ScoredSet(
             source = timed.set,
@@ -443,7 +449,9 @@ object EffortModel {
             dayOffset = session.dayOffset,
             capacity = c,
             expectation = expectedCapacity,
-            expectedWeight = expectedWeight,
+            expectedWeight = expectedCapacity?.let { it / setScale },
+            residualScale = residualScale,
+            weightScale = setScale,
             z = z,
             size = bubbleSize(z),
             zone = zoneOf(z)
@@ -586,6 +594,7 @@ object EffortModel {
             scored.copy(
               expectation = fallback.expectation,
               expectedWeight = fallback.expectedWeight,
+              residualScale = fallback.residualScale,
               z = fallback.z,
               size = fallback.size,
               zone = fallback.zone,
@@ -608,14 +617,18 @@ object EffortModel {
         realBySession[sessionIndex]?.copy(expectationSource = ExpectationSource.SESSION)
           ?: sessionScored.first().let { first ->
             val cHat = first.expectation!!
-            val wHat = first.expectedWeight!!
+            // Read the reps straight off the set rather than inverting its expectedWeight:
+            // that conversion now also carries the set's rest credit, so backing reps out of
+            // it would report a densely-packed session as having done more reps than it did.
+            // TrendPoint stays a typical-reps quantity, so its own reconstruction still holds.
+            val rHat = effectiveReps(first.source.reps, config)
             TrendPoint(
               sessionIndex = sessionIndex,
               dayOffset = first.dayOffset,
               at = first.source.completed,
               expectedCapacity = cHat,
-              typicalReps = (cHat / wHat - 1) * config.epleyDivisor,
-              expectedWeight = wHat,
+              typicalReps = rHat,
+              expectedWeight = cHat / (1 + rHat / config.epleyDivisor),
               expectationSource = ExpectationSource.BOOTSTRAP
             )
           }

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
@@ -314,7 +314,8 @@ object EffortModel {
     config: EffortConfig,
     maxExtrapolation: Double,
     baselineLoad: Double,
-    skipWarmUps: Boolean = false
+    skipWarmUps: Boolean = false,
+    recalibrateWithinSession: Boolean = false
   ): EffortSeries {
     if (sessions.isEmpty()) return EffortSeries.Empty
 
@@ -410,6 +411,11 @@ object EffortModel {
       // The expectation before the detrain haircut - what the fit says you'd be at had you
       // never stopped. The fold-in measures the comeback against it to size the real handicap.
       var undetrainedCapacity: Double? = null
+      // What the fit predicted before this session was allowed to speak for itself. Kept apart
+      // from expectedCapacity because the residual accumulator measures *prediction error*, and
+      // feeding it a level that this session helped set would report the fit as far more
+      // accurate than it is and collapse everyone's band.
+      var blindExpectation: Double? = null
 
       if (priorSessionCount >= config.minPriorSessions) {
         val xEff = min(session.x, lastPriorX + maxExtrapolation)
@@ -432,7 +438,7 @@ object EffortModel {
         val undetrained = shrunk.coerceIn(0.5 * meanY, 1.5 * meanY)
         undetrainedCapacity = undetrained
         val cHat = undetrained * detrain
-        expectedCapacity = cHat
+        blindExpectation = cHat
 
         val fittedResidualScale = if (sumResidualW >= 2.0) sqrt(sumResidualWe2 / sumResidualW) else 0.0
         val fittedOrFloor = max(fittedResidualScale, max(config.residualScaleFloorFraction * cHat, 1e-6))
@@ -442,17 +448,41 @@ object EffortModel {
         // the model had just admitted it couldn't predict. The haircut is itself the scale of what
         // isn't known, so it widens the band instead of narrowing it.
         val layoffUncertainty = config.layoffUncertaintyWeight * (undetrained - cHat)
-        residualScale = sqrt(fittedOrFloor * fittedOrFloor + layoffUncertainty * layoffUncertainty)
+        val blindScale = sqrt(fittedOrFloor * fittedOrFloor + layoffUncertainty * layoffUncertainty)
+
+        // Once the lifter is actually back, the sets in front of us say more about where they
+        // stand than any function of elapsed time can, so replace the time-based guess with what
+        // this session has demonstrated - weighted by how much of it has landed - and let the
+        // widened band close as the guess turns into a measurement.
+        //
+        // Deliberately not causal within the session: every set is scored against the same
+        // settled level, so a cautious opening set can turn out to have been light once the
+        // working sets land. That is the honest reading, and this path only ever renders the
+        // live strip, whose job is to say what to do next. score() never takes it, so the
+        // long-term history never reshuffles under the user.
+        if (recalibrateWithinSession && followedLayoff) {
+          val trust = min(1.0, capacities.size / 2.0)
+          val level = trust * capacities.average() + (1 - trust) * cHat
+          val floor = max(config.residualScaleFloorFraction * level, 1e-6)
+          val remainingDoubt =
+            config.layoffUncertaintyWeight * (undetrained - level) * (1 - trust)
+          expectedCapacity = level
+          residualScale = sqrt(floor * floor + remainingDoubt * remainingDoubt)
+        } else {
+          expectedCapacity = cHat
+          residualScale = blindScale
+        }
 
         val rHat = (sumRepsWr / sumRepsW).coerceIn(1.0, config.repSoftCapMax)
-        val wHat = cHat / (1 + rHat / config.epleyDivisor) - baselineLoad
+        val shownCapacity = expectedCapacity!!
+        val wHat = shownCapacity / (1 + rHat / config.epleyDivisor) - baselineLoad
         expectedWeight = wHat
         trendPoints.add(
           TrendPoint(
             sessionIndex = session.sessionIndex,
             dayOffset = session.dayOffset,
             at = sessionSets.first().set.completed,
-            expectedCapacity = cHat,
+            expectedCapacity = shownCapacity,
             typicalReps = rHat,
             expectedWeight = wHat
           )
@@ -560,8 +590,8 @@ object EffortModel {
         sumGapWlog += ln(session.agingDays)
       }
 
-      if (expectedCapacity != null) {
-        val e = sessionValue - expectedCapacity
+      if (blindExpectation != null) {
+        val e = sessionValue - blindExpectation
         sumResidualW += 1.0
         sumResidualWe2 += e * e
       }
@@ -598,9 +628,17 @@ object EffortModel {
     zone: ZoneId = ZoneId.systemDefault(),
     config: EffortConfig = EffortConfig.Default
   ): EffortSeries {
-    val real = score(sets, zone, config)
-    if (real.sets.isEmpty()) return real
+    if (sets.isEmpty()) return EffortSeries.Empty
     val baselineLoad = baselineLoadOf(sets, config)
+    // Not score(): the strip takes the within-session recalibration and the drawer must not.
+    val real = scoreSessions(
+      daySessions(sets, zone),
+      config,
+      config.maxExtrapolationDays.toDouble(),
+      baselineLoad = baselineLoad,
+      recalibrateWithinSession = true
+    )
+    if (real.sets.isEmpty()) return real
 
     val exploded = scoreSessions(
       explodedSessions(sets, zone),

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
@@ -334,11 +334,19 @@ object EffortModel {
         // The extrapolation clamp above bounds how far the *slope* can run after a gap; this
         // bounds the *level*, which nothing did before - the curve used to freeze where it was
         // left, so coming back from months off read BELOW on every set until it was clawed back.
-        val cHat = shrunk.coerceIn(0.5 * meanY, 1.5 * meanY) * detrainFactor(session.layoffDays, config)
+        val undetrained = shrunk.coerceIn(0.5 * meanY, 1.5 * meanY)
+        val cHat = undetrained * detrainFactor(session.layoffDays, config)
         expectedCapacity = cHat
 
         val fittedResidualScale = if (sumResidualW >= 2.0) sqrt(sumResidualWe2 / sumResidualW) else 0.0
-        residualScale = max(fittedResidualScale, max(config.residualScaleFloorFraction * cHat, 1e-6))
+        val fittedOrFloor = max(fittedResidualScale, max(config.residualScaleFloorFraction * cHat, 1e-6))
+        // Detraining lowers the bar but says nothing about how well that lower number is known,
+        // and the floor is a fraction of it - so the haircut used to tighten the band along with
+        // the target it was cutting, and an ordinary comeback scored several sigma above a number
+        // the model had just admitted it couldn't predict. The haircut is itself the scale of what
+        // isn't known, so it widens the band instead of narrowing it.
+        val layoffUncertainty = config.layoffUncertaintyWeight * (undetrained - cHat)
+        residualScale = sqrt(fittedOrFloor * fittedOrFloor + layoffUncertainty * layoffUncertainty)
 
         val rHat = (sumRepsWr / sumRepsW).coerceIn(1.0, config.repSoftCapMax)
         val wHat = cHat / (1 + rHat / config.epleyDivisor)

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
@@ -38,15 +38,34 @@ object EffortModel {
   /**
    * Epley-style estimated 1RM, the single scale weight×reps sets are compared on.
    *
-   * Floored at 1.0, not 0.0 - a bodyweight-only set (no explicit "bodyweight" flag exists,
-   * so weight = 0 is how one is logged) would otherwise multiply out to 0 regardless of
-   * reps, making every bodyweight session score identically instead of tracking rep
-   * progress. z-scoring only cares about relative capacity changes session-to-session, so
-   * this tiny floor doesn't distort anything - it just keeps reps the driver until real
-   * weight gets logged, at which point the floor stops applying.
+   * [baselineLoad] is what the movement already carries before anything is added - see
+   * [EffortConfig.bodyweightBaselineLoad] and [baselineLoadOf]. Zero for loadable work, where
+   * the logged weight is the whole load.
+   *
+   * Still floored at 1.0 for the zero-baseline case: a bodyweight set (no explicit flag exists,
+   * so weight = 0 is how one is logged) would otherwise multiply out to 0 regardless of reps,
+   * scoring every such session identically instead of tracking rep progress. With a baseline
+   * the floor never binds, which is the point - a floor keeps reps meaningful but makes the
+   * first pound added look like doubling the load.
    */
-  fun capacity(weight: Double, reps: Int, config: EffortConfig = EffortConfig.Default): Double =
-    max(weight, 1.0) * (1 + effectiveReps(reps, config) / config.epleyDivisor)
+  fun capacity(
+    weight: Double,
+    reps: Int,
+    config: EffortConfig = EffortConfig.Default,
+    baselineLoad: Double = 0.0
+  ): Double =
+    max(weight + baselineLoad, 1.0) * (1 + effectiveReps(reps, config) / config.epleyDivisor)
+
+  /**
+   * Whether this exercise's logged weights are the whole load or only what was added to it.
+   *
+   * There is no bodyweight flag on a set, so a logged zero is the only evidence available: an
+   * exercise that has ever been done unweighted is one whose weights are increments on top of
+   * a body. Decided across the whole history rather than per set, or a movement would change
+   * scale underneath itself the session a first dumbbell appears.
+   */
+  private fun baselineLoadOf(sets: List<EffortSet>, config: EffortConfig): Double =
+    if (sets.any { it.weight <= 0.0 }) config.bodyweightBaselineLoad else 0.0
 
   /**
    * Reps as the capacity scale counts them: linear up to [EffortConfig.repCap], then
@@ -189,8 +208,13 @@ object EffortModel {
     }
   }
 
-  private fun effectiveCapacity(timed: TimedSet, config: EffortConfig): Double =
-    capacity(timed.set.weight, timed.set.reps, config) * densityFactor(timed.restSeconds, config)
+  private fun effectiveCapacity(
+    timed: TimedSet,
+    config: EffortConfig,
+    baselineLoad: Double
+  ): Double =
+    capacity(timed.set.weight, timed.set.reps, config, baselineLoad) *
+      densityFactor(timed.restSeconds, config)
 
   /**
    * How much of its best a session actually held, as a multiplier on the value it feeds the
@@ -271,7 +295,12 @@ object EffortModel {
     config: EffortConfig = EffortConfig.Default
   ): EffortSeries {
     if (sets.isEmpty()) return EffortSeries.Empty
-    return scoreSessions(daySessions(sets, zone), config, config.maxExtrapolationDays.toDouble())
+    return scoreSessions(
+      daySessions(sets, zone),
+      config,
+      config.maxExtrapolationDays.toDouble(),
+      baselineLoad = baselineLoadOf(sets, config)
+    )
   }
 
   /**
@@ -284,6 +313,7 @@ object EffortModel {
     sessions: List<FitSession>,
     config: EffortConfig,
     maxExtrapolation: Double,
+    baselineLoad: Double,
     skipWarmUps: Boolean = false
   ): EffortSeries {
     if (sessions.isEmpty()) return EffortSeries.Empty
@@ -328,7 +358,7 @@ object EffortModel {
     sessions.forEach { session ->
       val sessionSets = session.sets
 
-      val capacities = sessionSets.map { effectiveCapacity(it, config) }
+      val capacities = sessionSets.map { effectiveCapacity(it, config, baselineLoad) }
       var peakIndex = 0
       var bestCapacity = capacities[0]
       var bestReps = effectiveReps(sessionSets[0].set.reps, config)
@@ -415,7 +445,7 @@ object EffortModel {
         residualScale = sqrt(fittedOrFloor * fittedOrFloor + layoffUncertainty * layoffUncertainty)
 
         val rHat = (sumRepsWr / sumRepsW).coerceIn(1.0, config.repSoftCapMax)
-        val wHat = cHat / (1 + rHat / config.epleyDivisor)
+        val wHat = cHat / (1 + rHat / config.epleyDivisor) - baselineLoad
         expectedWeight = wHat
         trendPoints.add(
           TrendPoint(
@@ -430,7 +460,7 @@ object EffortModel {
       }
 
       sessionSets.forEachIndexed { setIndex, timed ->
-        val c = effectiveCapacity(timed, config)
+        val c = effectiveCapacity(timed, config, baselineLoad)
         val z = expectedCapacity?.let {
           ((c - it) / (residualScale ?: 1.0)).coerceIn(-config.maxAbsZ, config.maxAbsZ)
         }
@@ -439,7 +469,7 @@ object EffortModel {
         // at exactly this set's terms, which is the only version a chart plotting raw weight can
         // compare a dot against. The session-wide, typical-reps conversion misplaces every set
         // whose reps differ from the average, which is most of them.
-        val setScale = c / max(timed.set.weight, 1.0)
+        val setScale = c / max(timed.set.weight + baselineLoad, 1.0)
         scoredSets.add(
           ScoredSet(
             source = timed.set,
@@ -449,7 +479,7 @@ object EffortModel {
             dayOffset = session.dayOffset,
             capacity = c,
             expectation = expectedCapacity,
-            expectedWeight = expectedCapacity?.let { it / setScale },
+            expectedWeight = expectedCapacity?.let { it / setScale - baselineLoad },
             residualScale = residualScale,
             weightScale = setScale,
             z = z,
@@ -570,6 +600,7 @@ object EffortModel {
   ): EffortSeries {
     val real = score(sets, zone, config)
     if (real.sets.isEmpty()) return real
+    val baselineLoad = baselineLoadOf(sets, config)
 
     val exploded = scoreSessions(
       explodedSessions(sets, zone),
@@ -578,6 +609,7 @@ object EffortModel {
       // calendar quantity and means nothing in this domain. Skipped warm-ups don't advance
       // lastPriorX while session.x keeps counting, so the gap here tracks set volume, not time.
       maxExtrapolation = config.maxExtrapolationSets,
+      baselineLoad = baselineLoad,
       skipWarmUps = true
     )
 
@@ -628,7 +660,7 @@ object EffortModel {
               at = first.source.completed,
               expectedCapacity = cHat,
               typicalReps = rHat,
-              expectedWeight = cHat / (1 + rHat / config.epleyDivisor),
+              expectedWeight = cHat / (1 + rHat / config.epleyDivisor) - baselineLoad,
               expectationSource = ExpectationSource.BOOTSTRAP
             )
           }

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
@@ -348,10 +348,38 @@ object EffortModel {
       val typicalGapDays = if (sumGapW > 0.0) exp(sumGapWlog / sumGapW) else 0.0
       val detrain = detrainFactor(session.layoffDays, typicalGapDays, config)
       val followedLayoff = detrain < 1.0
+      // Both halves of the comeback treatment turn on this one condition. They are a pair:
+      // sliding x without re-levelling parks the old, higher block right beside a lower
+      // comeback and fits a cliff through them, which is worse than leaving the gap alone.
+      // A prediction has to exist for the re-level to have anything to measure against, so
+      // the slide is gated on the same prior-session count rather than on sumW alone.
+      val reAnchorComeback = followedLayoff && priorSessionCount >= config.minPriorSessions
+
+      // Close the dead part of the gap in the regression's x-domain before predicting from it.
+      //
+      // Nothing happened during a layoff, but the days still counted, and x is a day offset -
+      // so the pre-layoff block sat hundreds of days to the left of the comeback with a much
+      // higher capacity, and even at the 0.4% weight the aging decay leaves it, that lever arm
+      // dominated the fit. The slope came out *negative* for ten sessions while the lifter was
+      // gaining every session. A translation moves every accumulated x by the same amount, so
+      // the slope is preserved exactly and only the arm goes away. Paired with the re-level at
+      // fold-in below: sliding alone is far worse than doing nothing, because it parks the old
+      // high capacity immediately left of a much lower comeback.
+      if (reAnchorComeback) {
+        val dead = (session.layoffDays - graceDays(typicalGapDays, config)).coerceAtLeast(0.0)
+        // sumWxx consumes the pre-shift sumWx, so it has to be updated first.
+        sumWxx += 2 * dead * sumWx + dead * dead * sumW
+        sumWx += dead * sumW
+        sumWxy += dead * sumWy
+        lastPriorX += dead
+      }
 
       var expectedCapacity: Double? = null
       var expectedWeight: Double? = null
       var residualScale: Double? = null
+      // The expectation before the detrain haircut - what the fit says you'd be at had you
+      // never stopped. The fold-in measures the comeback against it to size the real handicap.
+      var undetrainedCapacity: Double? = null
 
       if (priorSessionCount >= config.minPriorSessions) {
         val xEff = min(session.x, lastPriorX + maxExtrapolation)
@@ -372,6 +400,7 @@ object EffortModel {
         // bounds the *level*, which nothing did before - the curve used to freeze where it was
         // left, so coming back from months off read BELOW on every set until it was clawed back.
         val undetrained = shrunk.coerceIn(0.5 * meanY, 1.5 * meanY)
+        undetrainedCapacity = undetrained
         val cHat = undetrained * detrain
         expectedCapacity = cHat
 
@@ -431,12 +460,42 @@ object EffortModel {
       runningBest = max(runningBest, sessionValue)
       if (isWarmUp) return@forEach
 
+      // A layoff's real cost is only knowable once the lifter is back, so measure it rather
+      // than keeping the time-based guess: the ratio of what they actually did to what the fit
+      // said they'd be at is the handicap. Rescaling the retained history by it re-expresses
+      // the whole block at the level they returned to, which is what lets the slope carried
+      // across the gap above describe a rebuild instead of a decline.
+      //
+      // Clamped to the same floor the blind guess uses, so a session that is nothing but one
+      // light feeler set cannot re-level a whole history down to it, and to 1.0, because
+      // coming back strong is already captured by folding this session in at its true value -
+      // it must not retroactively inflate what was done years ago.
+      val handicap = undetrainedCapacity
+        ?.takeIf { reAnchorComeback }
+        ?.let { (sessionValue / it).coerceIn(config.detrainFloor, 1.0) }
+        ?: 1.0
+
       // Fold this session in *after* using it for prediction/scoring, so a session's
       // outcome (a PR or a bad day) never influences its own expectation.
-      val decay = sessionDecay * 0.5.pow(session.agingDays / config.halfLifeDays)
+      //
+      // A re-levelled history skips the calendar term: aging is what strips a stale block of
+      // influence, and once the block has been restated at today's level it is no longer
+      // stale - it is the only evidence of how fast this lifter improves. The session-count
+      // half-life still retires it over the next several sessions as real post-comeback data
+      // arrives, so it acts as a prior rather than an anchor.
+      val decay = if (reAnchorComeback) {
+        sessionDecay
+      } else {
+        sessionDecay * 0.5.pow(session.agingDays / config.halfLifeDays)
+      }
       sumW *= decay; sumWx *= decay; sumWy *= decay; sumWxx *= decay; sumWxy *= decay
       sumResidualW *= decay; sumResidualWe2 *= decay
       sumRepsW *= decay; sumRepsWr *= decay
+
+      // Level, not shape: only the capacity-valued sums move, so the fitted slope keeps its
+      // proportions and simply lands where the lifter actually is.
+      sumWy *= handicap; sumWxy *= handicap
+      sumResidualWe2 *= handicap * handicap
       // Session-count decay only, deliberately skipping the calendar term the others carry.
       // Cadence is a per-exposure property, and aging it by the very gap being judged is
       // self-defeating: a two-year break would age away the rhythm it needs to be measured

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortSeries.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortSeries.kt
@@ -54,7 +54,6 @@ data class ScoredSet(
   val residualScale: Double? = null,
   val weightScale: Double = 1.0,
   val z: Double?,
-  val size: Float,
   val zone: EffortZone,
   val expectationSource: ExpectationSource? = null
 )

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortSeries.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortSeries.kt
@@ -59,7 +59,13 @@ data class ScoredSet(
   val expectationSource: ExpectationSource? = null
 )
 
-/** The fitted expectation for one session, in both capacity and weight-at-typical-reps form. */
+/**
+ * The fitted expectation for one session, in both capacity and weight-at-typical-reps form.
+ *
+ * [expectedWeight] is *added* weight, on the same axis the sets are logged and plotted on, so
+ * on an unloadable movement it can legitimately be negative - the trend rising toward zero is
+ * how "you are not yet ready to hang a plate on this" looks.
+ */
 data class TrendPoint(
   val sessionIndex: Int,
   val dayOffset: Long,

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortSeries.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortSeries.kt
@@ -59,6 +59,40 @@ data class ScoredSet(
 )
 
 /**
+ * The same expectation this set was scored against, re-expressed as the weight that would meet
+ * it at [reps] instead of the reps this set actually used - the question a lifter about to load
+ * a bar is asking, when the program prescribes a rep count they have not done yet.
+ *
+ * The rest that preceded this set is assumed to repeat, since the next set is normally taken on
+ * the same clock. `null` whenever this set has no expectation.
+ *
+ * Strictly a weight-space conversion: [expectation] itself is untouched, because a set is scored
+ * on the capacity it actually demonstrated and a program's target has no business changing that.
+ * Doing more reps than prescribed is progress, not a miss.
+ */
+fun ScoredSet.expectedWeightAt(reps: Int, config: EffortConfig = EffortConfig.Default): Double? {
+  val expectedCapacity = expectation ?: return null
+  val here = expectedWeight ?: return null
+  // weightScale bundles this set's rep multiplier with the rest credit it earned. Dividing the
+  // rep part back out leaves the density factor on its own, so only the reps are re-stated.
+  val repPart = 1 + EffortModel.effectiveReps(source.reps, config) / config.epleyDivisor
+  val density = weightScale / repPart
+  // expectedWeight is an added weight, so whatever the movement already carries is the gap
+  // between it and the unadjusted conversion - see EffortConfig.bodyweightBaselineLoad.
+  val baselineLoad = expectedCapacity / weightScale - here
+  val target = (1 + EffortModel.effectiveReps(reps, config) / config.epleyDivisor) * density
+  return expectedCapacity / target - baselineLoad
+}
+
+/** [residualScale] in the weight units [expectedWeightAt] returns for the same [reps]. */
+fun ScoredSet.bandHalfWidthAt(reps: Int, config: EffortConfig = EffortConfig.Default): Double? {
+  val scale = residualScale ?: return null
+  val repPart = 1 + EffortModel.effectiveReps(source.reps, config) / config.epleyDivisor
+  val density = weightScale / repPart
+  return scale / ((1 + EffortModel.effectiveReps(reps, config) / config.epleyDivisor) * density)
+}
+
+/**
  * The fitted expectation for one session, in both capacity and weight-at-typical-reps form.
  *
  * [expectedWeight] is *added* weight, on the same axis the sets are logged and plotted on, so

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortSeries.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortSeries.kt
@@ -23,9 +23,24 @@ enum class ExpectationSource { SESSION, BOOTSTRAP }
  * following closely on the one before it - it is not the bare [EffortModel.capacity] of the
  * weight and reps alone.
  *
- * [expectedWeight] is [expectation] expressed at the fit's typical reps, the same conversion
- * [TrendPoint] carries. It's per-set rather than per-session so a chart plotting one point per
- * set can draw a trend that moves across a session instead of stepping once per day.
+ * [expectedWeight] is [expectation] converted into weight *on this set's own terms* - its rep
+ * count and the rest that preceded it - not at the fit's session-wide typical reps the way
+ * [TrendPoint] does it. A chart whose y-axis is raw weight can only compare a dot against a
+ * line drawn this way; against a typical-reps line, every set whose reps differ from the
+ * average is misplaced, and a set can render below the line while scoring above it.
+ *
+ * [weightScale] is the conversion that produced it - what one pound of this set is worth in
+ * capacity - exposed so a caller can put [residualScale] into the same units:
+ *
+ * ```
+ * (source.weight - expectedWeight) / (residualScale / weightScale) == z
+ * ```
+ *
+ * exactly, for any set at or above 1 lb whose [z] is not clamped. That identity is what lets a
+ * band drawn at the zone thresholds *be* the zone boundaries rather than a decoration beside
+ * them. Bodyweight sets are the exception by construction: [EffortModel.capacity] floors weight
+ * at 1.0 so rep progress still registers, so a set logged at 0 plots below a line that cannot
+ * reach it.
  */
 data class ScoredSet(
   val source: EffortSet,
@@ -36,6 +51,8 @@ data class ScoredSet(
   val capacity: Double,
   val expectation: Double?,
   val expectedWeight: Double? = null,
+  val residualScale: Double? = null,
+  val weightScale: Double = 1.0,
   val z: Double?,
   val size: Float,
   val zone: EffortZone,

--- a/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
+++ b/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
@@ -555,6 +555,50 @@ class EffortModelTest {
     }
 
     @Test
+    fun `a comeback is not implausible for landing near the detrained bar`() {
+      // Two years off, back at a fraction of the old numbers - the single most ordinary thing a
+      // long-dormant exercise can do, and it used to pin z at the clamp and render amber.
+      val lastSession = comeback(layoffDays = 730, comebackWeight = 75.0)
+        .sets.takeLast(3)
+
+      lastSession.forEach {
+        assertThat(it.zone).isNotEqualTo(EffortZone.IMPLAUSIBLE)
+        assertThat(abs(it.z!!)).isLessThan(EffortConfig.Default.maxAbsZ)
+      }
+    }
+
+    @Test
+    fun `time away widens the band rather than narrowing it with the bar`() {
+      fun bandOf(layoffDays: Long) = comeback(layoffDays).sets.last()
+        .let { (it.capacity - it.expectation!!) / it.z!! }
+
+      val week = bandOf(7)
+      val quarter = bandOf(90)
+      val twoYears = bandOf(730)
+
+      assertThat(quarter).isGreaterThan(week)
+      // Past the detrain floor the haircut stops growing, so neither does the uncertainty.
+      assertThat(twoYears).isWithin(1e-9).of(quarter)
+    }
+
+    @Test
+    fun `the widened band is confined to sessions that follow a layoff`() {
+      // The session after the comeback has no gap in front of it, so it is scored on the
+      // ordinary band again - the widening must not linger once training resumes.
+      val block = (0..5).flatMap { s ->
+        (0 until 3).map { EffortSet(day(s * 7L).plusSeconds(it * 180L), 100.0, 8) }
+      }
+      val back = (0 until 3).map { EffortSet(day(400).plusSeconds(it * 180L), 75.0, 8) }
+      val next = (0 until 3).map { EffortSet(day(403).plusSeconds(it * 180L), 75.0, 8) }
+
+      val series = EffortModel.score(block + back + next)
+      fun bandAt(sessionIndex: Int) = series.sets.last { it.sessionIndex == sessionIndex }
+        .let { (it.capacity - it.expectation!!) / it.z!! }
+
+      assertThat(bandAt(7)).isLessThan(bandAt(6))
+    }
+
+    @Test
     fun `stale history stops outweighing what happened since`() {
       // Identical session counts and identical numbers either way - only the calendar distance
       // between the old block and the recent one differs. When that distance ages the old block

--- a/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
+++ b/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
@@ -136,107 +136,61 @@ class EffortModelTest {
   }
 
   @Nested
-  @DisplayName("bubbleSize")
-  inner class Hump {
-    @Test
-    fun `hits every anchor exactly`() {
-      assertThat(EffortModel.bubbleSize(-2.0)).isEqualTo(0.00f)
-      assertThat(EffortModel.bubbleSize(-1.0)).isEqualTo(0.30f)
-      assertThat(EffortModel.bubbleSize(0.0)).isEqualTo(0.60f)
-      assertThat(EffortModel.bubbleSize(0.5)).isEqualTo(0.85f)
-      assertThat(EffortModel.bubbleSize(1.0)).isEqualTo(1.00f)
-      assertThat(EffortModel.bubbleSize(1.5)).isEqualTo(0.90f)
-      assertThat(EffortModel.bubbleSize(2.5)).isEqualTo(0.40f)
-    }
-
-    @Test
-    fun `clamps flat below -2 and above 2_5`() {
-      assertThat(EffortModel.bubbleSize(-5.0)).isEqualTo(0.00f)
-      assertThat(EffortModel.bubbleSize(50.0)).isEqualTo(0.40f)
-    }
-
-    @Test
-    fun `rises monotonically from -2 to the peak at +1`() {
-      val samples = generateSequence(-2.0) { it + 0.1 }.takeWhile { it <= 1.0 }.toList()
-      val sizes = samples.map { EffortModel.bubbleSize(it) }
-      assertThat(sizes).isInOrder()
-    }
-
-    @Test
-    fun `falls monotonically from the peak at +1 to +2_5`() {
-      val samples = generateSequence(1.0) { it + 0.1 }.takeWhile { it <= 2.5 }.toList()
-      val sizes = samples.map { EffortModel.bubbleSize(it) }
-      assertThat(sizes).isInOrder(compareByDescending<Float> { it })
-    }
-
-    @Test
-    fun `null z is neutral, not zero`() {
-      assertThat(EffortModel.bubbleSize(null)).isEqualTo(EffortModel.NEUTRAL_SIZE)
-    }
-  }
-
-  @Nested
   @DisplayName("worked examples (spec table, curve at ĉ=133, s=10)")
   inner class WorkedExamples {
-    private fun sizeFor(weight: Double, reps: Int): Float {
-      val c = EffortModel.capacity(weight, reps)
-      val z = (c - 133.0) / 10.0
-      return EffortModel.bubbleSize(z)
+    private fun zoneFor(weight: Double, reps: Int): EffortZone =
+      EffortModel.zoneOf((EffortModel.capacity(weight, reps) - 133.0) / 10.0)
+
+    @Test
+    fun `80 lb x 15 - somewhat below`() {
+      assertThat(zoneFor(80.0, 15)).isEqualTo(EffortZone.BELOW)
     }
 
     @Test
-    fun `80 lb x 15 - somewhat below - smallish`() {
-      assertThat(sizeFor(80.0, 15).toDouble()).isWithin(1e-3).of(0.21)
+    fun `90 lb x 15 - slightly above, still on the curve`() {
+      assertThat(zoneFor(90.0, 15)).isEqualTo(EffortZone.ON_CURVE)
     }
 
     @Test
-    fun `90 lb x 15 - slightly above - larger than on-curve`() {
-      val size = sizeFor(90.0, 15)
-      assertThat(size.toDouble()).isWithin(1e-3).of(0.70)
-      assertThat(size).isGreaterThan(EffortModel.bubbleSize(0.0))
+    fun `130 lb x 3 - above`() {
+      assertThat(zoneFor(130.0, 3)).isEqualTo(EffortZone.GROWTH)
     }
 
     @Test
-    fun `130 lb x 3 - above - peak`() {
-      assertThat(sizeFor(130.0, 3)).isEqualTo(1.00f)
+    fun `100 lb x 2 - well below`() {
+      assertThat(zoneFor(100.0, 2)).isEqualTo(EffortZone.BELOW)
     }
 
     @Test
-    fun `100 lb x 2 - well below - minimum`() {
-      assertThat(sizeFor(100.0, 2)).isEqualTo(0.00f)
+    fun `100 lb x 10 - on the curve`() {
+      assertThat(zoneFor(100.0, 10)).isEqualTo(EffortZone.ON_CURVE)
     }
 
     @Test
-    fun `100 lb x 10 - on-just above - large`() {
-      assertThat(sizeFor(100.0, 10).toDouble()).isWithin(1e-3).of(0.617)
+    fun `100 lb x 12 - above`() {
+      assertThat(zoneFor(100.0, 12)).isEqualTo(EffortZone.GROWTH)
     }
 
     @Test
-    fun `100 lb x 12 - on-just above - near peak`() {
-      assertThat(sizeFor(100.0, 12).toDouble()).isWithin(1e-3).of(0.91)
-    }
-
-    @Test
-    fun `180 lb x 5 - far above - punished`() {
-      assertThat(sizeFor(180.0, 5)).isEqualTo(0.40f)
+    fun `180 lb x 5 - far above`() {
+      assertThat(zoneFor(180.0, 5)).isEqualTo(EffortZone.IMPLAUSIBLE)
     }
 
     @Test
     fun `ordering matches the spec table`() {
-      val below = sizeFor(100.0, 2)
-      val somewhatBelow = sizeFor(80.0, 15)
-      val onCurve = EffortModel.bubbleSize(0.0)
-      val slightlyAbove = sizeFor(90.0, 15)
-      val peakA = sizeFor(130.0, 3)
-      val peakB = sizeFor(100.0, 12)
-      val punished = sizeFor(180.0, 5)
+      // The table is a ladder, so read it back as one: the same inputs in the same order have
+      // to give z values that only ever climb.
+      val ladder = listOf(
+        100.0 to 2,
+        80.0 to 15,
+        100.0 to 10,
+        90.0 to 15,
+        100.0 to 12,
+        130.0 to 3,
+        180.0 to 5
+      ).map { (w, r) -> (EffortModel.capacity(w, r) - 133.0) / 10.0 }
 
-      assertThat(below).isLessThan(somewhatBelow)
-      assertThat(somewhatBelow).isLessThan(onCurve)
-      assertThat(onCurve).isLessThan(slightlyAbove)
-      assertThat(slightlyAbove).isLessThan(peakB)
-      assertThat(peakB).isLessThan(peakA)
-      assertThat(punished).isLessThan(slightlyAbove)
+      assertThat(ladder).isInOrder()
     }
   }
 
@@ -295,7 +249,7 @@ class EffortModelTest {
       series.sets.forEach {
         assertThat(it.expectation).isNull()
         assertThat(it.z).isNull()
-        assertThat(it.size).isEqualTo(EffortModel.NEUTRAL_SIZE)
+        assertThat(it.zone).isEqualTo(EffortZone.COLD)
         assertThat(it.zone).isEqualTo(EffortZone.COLD)
       }
     }
@@ -365,9 +319,9 @@ class EffortModelTest {
       val probeScored = session3.first { it.source.weight == c * 1.05 }
 
       assertThat(onCurveScored.z!!).isWithin(1e-6).of(0.0)
-      assertThat(onCurveScored.size.toDouble()).isWithin(1e-3).of(0.60)
+      assertThat(onCurveScored.zone).isEqualTo(EffortZone.ON_CURVE)
       assertThat(probeScored.z!!).isWithin(1e-6).of(1.0)
-      assertThat(probeScored.size).isEqualTo(1.00f)
+      assertThat(probeScored.zone).isEqualTo(EffortZone.GROWTH)
     }
   }
 

--- a/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
+++ b/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
@@ -554,6 +554,96 @@ class EffortModelTest {
       lastSession.forEach { assertThat(it.zone).isNotEqualTo(EffortZone.BELOW) }
     }
 
+    /** A block of [count] identical sessions spaced [cadenceDays] apart - a flat plateau. */
+    private fun plateau(cadenceDays: Long, count: Int = 12) = (0 until count).flatMap { s ->
+      (0 until 3).map { EffortSet(day(s * cadenceDays).plusSeconds(it * 180L), 100.0, 10) }
+    }
+
+    @Test
+    fun `an exercise trained on a rotation is not treated as detrained`() {
+      // The point of the whole chart: zero progress must not read as growth. A fixed calendar
+      // grace made anything slower than 10 days permanently detrained, so the lowered bar
+      // turned a flat plateau into GROWTH on every set.
+      listOf(7L, 14L, 21L, 28L).forEach { cadence ->
+        val scored = EffortModel.score(plateau(cadence)).sets.filter { it.z != null }
+
+        assertThat(scored).isNotEmpty()
+        scored.forEach {
+          assertThat(it.zone).isEqualTo(EffortZone.ON_CURVE)
+          assertThat(it.z!!).isWithin(1e-9).of(0.0)
+        }
+      }
+    }
+
+    @Test
+    fun `identical progress scores the same however often the exercise comes round`() {
+      fun lastZ(cadenceDays: Long): Double {
+        val sets = (0 until 12).flatMap { s ->
+          (0 until 3).map {
+            EffortSet(day(s * cadenceDays).plusSeconds(it * 180L), 100.0 + s * 2.5, 10)
+          }
+        }
+        return EffortModel.score(sets).sets.last().z!!
+      }
+
+      // Same gain per exposure either way - only the calendar spacing differs, and spacing is
+      // exactly what must not be scored.
+      val weekly = lastZ(7)
+      assertThat(lastZ(14)).isWithin(0.25).of(weekly)
+      assertThat(lastZ(28)).isWithin(0.25).of(weekly)
+    }
+
+    @Test
+    fun `a gap abnormal for the exercise still detrains, whatever the cadence`() {
+      fun comebackZ(cadenceDays: Long): Double {
+        val block = plateau(cadenceDays, count = 10)
+        val back = (0 until 2).map {
+          EffortSet(day(cadenceDays * 9 + 730).plusSeconds(it * 180L), 75.0, 10)
+        }
+        return EffortModel.score(block + back).sets.last().z!!
+      }
+
+      // Two years off is two years off whether the exercise came round every 3 days or every 28.
+      val fast = comebackZ(3)
+      assertThat(comebackZ(14)).isWithin(1e-6).of(fast)
+      assertThat(comebackZ(28)).isWithin(1e-6).of(fast)
+    }
+
+    @Test
+    fun `one long break does not redefine what a normal gap is`() {
+      // The layoff must not feed the cadence average it is measured against, or a single
+      // two-year break makes "normal for this exercise" years wide and every later gap free.
+      val block = plateau(cadenceDays = 4, count = 10)
+      val back = (0 until 3).map { EffortSet(day(36 + 730).plusSeconds(it * 180L), 75.0, 10) }
+      val laterGap = (0 until 3).map {
+        EffortSet(day(36 + 730 + 200).plusSeconds(it * 180L), 75.0, 10)
+      }
+
+      val series = EffortModel.score(block + back + laterGap)
+      val comeback = series.sets.first { it.sessionIndex == 10 }
+      val afterSecondBreak = series.sets.first { it.sessionIndex == 11 }
+
+      // A 200-day gap on an exercise trained every 4 days is still a layoff the second time.
+      assertThat(comeback.expectation!!).isLessThan(comeback.capacity)
+      assertThat(afterSecondBreak.expectation!!)
+        .isLessThan(afterSecondBreak.capacity)
+    }
+
+    @Test
+    fun `the cadence is measured once per day, not once per set`() {
+      // At set grain every set of a day shares that day's layoff; billing each of them would
+      // report a five-set session as five gaps and inflate the cadence the grace comes from.
+      val block = (0 until 8).flatMap { s ->
+        (0 until 5).map { EffortSet(day(s * 14L).plusSeconds(it * 180L), 100.0, 10) }
+      }
+      val lean = (0 until 8).map { s -> EffortSet(day(s * 14L), 100.0, 10) }
+
+      val many = EffortModel.scoreWithBootstrap(block).sets.last { it.sessionIndex == 7 }
+      val few = EffortModel.scoreWithBootstrap(lean).sets.last { it.sessionIndex == 7 }
+
+      assertThat(many.expectation!!).isWithin(1e-9).of(few.expectation!!)
+    }
+
     @Test
     fun `a comeback is not implausible for landing near the detrained bar`() {
       // Two years off, back at a fraction of the old numbers - the single most ordinary thing a

--- a/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
+++ b/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
@@ -374,6 +374,42 @@ class EffortModelTest {
     }
 
     @Test
+    fun `a set's distance from its own expected weight, in bands, is exactly its z`() {
+      // The identity a cone drawn at the zone thresholds rests on: if this does not hold
+      // exactly, a dot can sit below the line while scoring above it, which is what the
+      // session-wide typical-reps conversion used to do to every set with off-average reps.
+      val sets = (0 until 10).flatMap { i ->
+        listOf(
+          EffortSet(day(i * 3L), 100.0 + i * 2, 12),
+          EffortSet(day(i * 3L).plusSeconds(180), 110.0 + i * 2, 8),
+          EffortSet(day(i * 3L).plusSeconds(420), 115.0 + i * 2, 5)
+        )
+      }
+      val scored = EffortModel.score(sets).sets
+        .filter { it.z != null && abs(it.z!!) < EffortConfig.Default.maxAbsZ }
+
+      assertThat(scored).isNotEmpty()
+      scored.forEach {
+        val band = it.residualScale!! / it.weightScale
+        assertThat((it.source.weight - it.expectedWeight!!) / band).isWithin(1e-9).of(it.z!!)
+      }
+    }
+
+    @Test
+    fun `sets in one session expect different weights when their reps differ`() {
+      val sets = (0 until 8).flatMap { i ->
+        listOf(
+          EffortSet(day(i * 3L), 100.0, 12),
+          EffortSet(day(i * 3L).plusSeconds(180), 100.0, 6)
+        )
+      }
+      val last = EffortModel.score(sets).sets.takeLast(2)
+
+      // Same weight, half the reps - the bar for the low-rep set has to be higher.
+      assertThat(last[1].expectedWeight!!).isGreaterThan(last[0].expectedWeight!!)
+    }
+
+    @Test
     fun `typical reps tracks the top set, ignoring warm-up reps`() {
       val sets = (0 until 6).flatMap { i ->
         listOf(

--- a/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
+++ b/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
@@ -63,6 +63,19 @@ class EffortModelTest {
     fun `the bodyweight floor stops applying once real weight is logged`() {
       assertThat(EffortModel.capacity(5.0, 8)).isGreaterThan(EffortModel.capacity(0.0, 8))
     }
+
+    @Test
+    fun `a baseline makes the first plate an increment, not a multiple`() {
+      val baseline = EffortConfig.Default.bodyweightBaselineLoad
+      val unweighted = EffortModel.capacity(0.0, 8, baselineLoad = baseline)
+      val firstPlate = EffortModel.capacity(5.0, 8, baselineLoad = baseline)
+
+      // Against the bare floor this step is 5x - hanging one dumbbell on a set of pull-ups
+      // reads as quintupling the load, which is why it used to score IMPLAUSIBLE.
+      assertThat(EffortModel.capacity(5.0, 8) / EffortModel.capacity(0.0, 8))
+        .isWithin(1e-9).of(5.0)
+      assertThat(firstPlate / unweighted).isLessThan(1.1)
+    }
   }
 
   @Nested
@@ -393,6 +406,64 @@ class EffortModelTest {
         val band = it.residualScale!! / it.weightScale
         assertThat((it.source.weight - it.expectedWeight!!) / band).isWithin(1e-9).of(it.z!!)
       }
+    }
+
+    /** Unloadable work: reps climbing at zero added weight, then a first plate. */
+    private fun bodyweightClimb(sessions: Int = 14) = (0 until sessions).flatMap { i ->
+      (0 until 3).map { EffortSet(day(i * 3L).plusSeconds(it * 180L), 0.0, 8 + i) }
+    }
+
+    @Test
+    fun `an unloadable movement expects added weight, rising through zero`() {
+      // What progression on bodyweight work looks like: you sit at the bottom of the band
+      // adding reps, while the weight the model expects you to be able to hang on climbs from
+      // below the axis toward the first increment you could actually load.
+      val expected = EffortModel.score(bodyweightClimb()).sets
+        .filter { it.setIndexInSession == 0 && it.expectedWeight != null }
+        .map { it.expectedWeight!! }
+
+      assertThat(expected).isNotEmpty()
+      assertThat(expected.first()).isLessThan(0.0)
+      assertThat(expected.last()).isGreaterThan(0.0)
+      // Monotone, so "the line is coming up to meet the next plate" is a readable claim.
+      expected.zipWithNext { a, b -> assertThat(b).isAtLeast(a) }
+    }
+
+    @Test
+    fun `adding a first plate to bodyweight work is not implausible`() {
+      // The exact transition the chart exists to encourage. Against the bare 1 lb floor this
+      // quadrupled demonstrated capacity and clamped z at the maximum.
+      val stepUp = bodyweightClimb(sessions = 6) +
+        (0 until 3).map { EffortSet(day(18).plusSeconds(it * 180L), 5.0, 13) }
+
+      EffortModel.score(stepUp).sets.takeLast(3).forEach {
+        assertThat(it.zone).isNotEqualTo(EffortZone.IMPLAUSIBLE)
+      }
+    }
+
+    @Test
+    fun `the distance-in-bands identity survives zero-weight sets`() {
+      val scored = EffortModel.score(bodyweightClimb()).sets
+        .filter { it.z != null && abs(it.z!!) < EffortConfig.Default.maxAbsZ }
+
+      assertThat(scored).isNotEmpty()
+      scored.forEach {
+        val band = it.residualScale!! / it.weightScale
+        assertThat((it.source.weight - it.expectedWeight!!) / band).isWithin(1e-9).of(it.z!!)
+      }
+    }
+
+    @Test
+    fun `a loadable exercise carries no baseline`() {
+      // The baseline keys off ever having logged an unweighted set, so ordinary barbell work
+      // has to be bit-for-bit unaffected by any of this.
+      val loaded = (0 until 10).flatMap { i ->
+        (0 until 3).map { EffortSet(day(i * 3L).plusSeconds(it * 180L), 100.0 + i * 2, 10) }
+      }
+      val last = EffortModel.score(loaded).sets.last()
+
+      assertThat(last.weightScale)
+        .isWithin(1e-9).of(last.capacity / last.source.weight)
     }
 
     @Test

--- a/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
+++ b/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
@@ -421,6 +421,56 @@ class EffortModelTest {
     }
 
     @Test
+    fun `projecting to the reps a set actually did returns its own expected weight`() {
+      val sets = (0 until 10).flatMap { i ->
+        listOf(
+          EffortSet(day(i * 3L), 100.0 + i, 12),
+          EffortSet(day(i * 3L).plusSeconds(150), 110.0 + i, 6)
+        )
+      }
+
+      EffortModel.score(sets).sets.filter { it.expectedWeight != null }.forEach {
+        assertThat(it.expectedWeightAt(it.source.reps)!!).isWithin(1e-9).of(it.expectedWeight!!)
+      }
+    }
+
+    @Test
+    fun `asking for more reps asks for less weight`() {
+      val sets = (0 until 10).map { EffortSet(day(it * 3L), 100.0 + it, 8) }
+      val last = EffortModel.score(sets).sets.last()
+
+      val heavy = last.expectedWeightAt(6)!!
+      val target = last.expectedWeightAt(10)!!
+      val light = last.expectedWeightAt(15)!!
+
+      assertThat(target).isLessThan(heavy)
+      assertThat(light).isLessThan(target)
+      // The band travels with it, so a rep count that lowers the bar narrows the miss too.
+      assertThat(last.bandHalfWidthAt(15)!!).isLessThan(last.bandHalfWidthAt(6)!!)
+    }
+
+    @Test
+    fun `a prescribed rep count never changes what a completed set scored`() {
+      // The projection is weight-space only. Exceeding the target is progress, not a miss, so
+      // nothing about the target may reach the capacity a set is judged on.
+      val sets = (0 until 10).map { EffortSet(day(it * 3L), 100.0 + it, 8) }
+      val last = EffortModel.score(sets).sets.last()
+      val before = last.z
+
+      last.expectedWeightAt(20)
+      assertThat(last.z).isEqualTo(before)
+      assertThat(last.expectation).isEqualTo(EffortModel.score(sets).sets.last().expectation)
+    }
+
+    @Test
+    fun `projection stays in added-weight terms on unloadable work`() {
+      val last = EffortModel.score(bodyweightClimb()).sets.last()
+
+      // Fewer reps than the lifter has been doing needs weight adding; far more does not.
+      assertThat(last.expectedWeightAt(5)!!).isGreaterThan(last.expectedWeightAt(25)!!)
+    }
+
+    @Test
     fun `sets in one session expect different weights when their reps differ`() {
       val sets = (0 until 8).flatMap { i ->
         listOf(

--- a/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
+++ b/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
@@ -527,7 +527,10 @@ class EffortModelTest {
       val week = comebackExpectation(7)
       val quarter = comebackExpectation(90)
 
-      assertThat(quarter).isAtLeast(week * EffortConfig.Default.detrainFloor)
+      // Stated as the ratio it actually constrains - on a flat history the quarter-long layoff
+      // lands exactly on the floor, and comparing the two products asserts equality of floats
+      // that agree only to within a few ULP.
+      assertThat(quarter / week).isAtLeast(EffortConfig.Default.detrainFloor - 1e-9)
       // Past the point the floor binds, more time away costs nothing further.
       assertThat(comebackExpectation(365)).isWithin(1e-9).of(quarter)
       assertThat(comebackExpectation(3650)).isWithin(1e-9).of(quarter)
@@ -686,6 +689,106 @@ class EffortModelTest {
         .let { (it.capacity - it.expectation!!) / it.z!! }
 
       assertThat(bandAt(7)).isLessThan(bandAt(6))
+    }
+
+    /**
+     * A block improving by [gainPerSession] every 4 days, then [layoffDays] off, then a rebuild
+     * resuming at [comebackWeight] and improving at the same rate.
+     */
+    private fun rebuild(
+      layoffDays: Long = 730,
+      comebackWeight: Double = 80.0,
+      gainPerSession: Double = 2.0,
+      rebuildSessions: Int = 10
+    ): EffortSeries {
+      val pre = (0 until 12).flatMap { s ->
+        (0 until 3).map {
+          EffortSet(day(s * 4L).plusSeconds(it * 180L), 100.0 + gainPerSession * s, 10)
+        }
+      }
+      val post = (0 until rebuildSessions).flatMap { s ->
+        (0 until 3).map {
+          EffortSet(
+            day(44 + layoffDays + s * 4L).plusSeconds(it * 180L),
+            comebackWeight + gainPerSession * s,
+            10
+          )
+        }
+      }
+      return EffortModel.score(pre + post)
+    }
+
+    /** Fitted capacity-per-day between consecutive rebuild sessions' expectations. */
+    private fun rebuildSlopes(series: EffortSeries): List<Double> =
+      series.trend.filter { it.sessionIndex > 12 }
+        .zipWithNext { a, b ->
+          (b.expectedCapacity - a.expectedCapacity) / (b.dayOffset - a.dayOffset)
+        }
+
+    @Test
+    fun `a rebuild is predicted as growth, not as decline`() {
+      // The gap used to sit in the regression's x-domain as a lever arm, tipping the fitted
+      // slope negative while the lifter gained every single session.
+      val slopes = rebuildSlopes(rebuild())
+
+      assertThat(slopes).isNotEmpty()
+      slopes.forEach { assertThat(it).isGreaterThan(0.0) }
+    }
+
+    @Test
+    fun `the pace carried across a gap tracks the pace before it`() {
+      // +2 lb per session on a 4-day cadence, in capacity terms per day.
+      val trueSlope = (EffortModel.capacity(102.0, 10) - EffortModel.capacity(100.0, 10)) / 4.0
+      val slopes = rebuildSlopes(rebuild())
+
+      // Same order of magnitude and same sign - not a refit from scratch, which lands near zero.
+      assertThat(slopes.last()).isGreaterThan(trueSlope / 3.0)
+      assertThat(slopes.last()).isLessThan(trueSlope * 2.0)
+    }
+
+    @Test
+    fun `a steady rebuild stops reading as a surprise every session`() {
+      val rebuilt = rebuild()
+      val postLayoff = rebuilt.sets.filter { it.sessionIndex > 12 && it.z != null }
+
+      assertThat(postLayoff).isNotEmpty()
+      // Predicted, not marvelled at: nothing drifts toward the outlier line.
+      postLayoff.forEach { assertThat(it.zone).isNotEqualTo(EffortZone.IMPLAUSIBLE) }
+      assertThat(postLayoff.map { it.z!! }.max()).isLessThan(1.5)
+    }
+
+    @Test
+    fun `a session of nothing but a light feeler cannot re-level the history`() {
+      val block = (0..7).flatMap { s ->
+        (0 until 3).map { EffortSet(day(s * 4L).plusSeconds(it * 180L), 200.0, 8) }
+      }
+      val feeler = listOf(EffortSet(day(28 + 730), 20.0, 5))
+      val next = (0 until 3).map {
+        EffortSet(day(28 + 730 + 4).plusSeconds(it * 180L), 150.0, 8)
+      }
+
+      val settled = EffortModel.score(block + feeler + next).sets.last()
+
+      // The clamp bounds the *rescale* of retained history, not the feeler's own fold-in - a
+      // 20 lb set logged as a whole session is still evidence and still moves the fit. What
+      // must not happen is the model concluding this is a 20 lb lifter.
+      assertThat(settled.expectation!!).isGreaterThan(EffortModel.capacity(20.0, 5) * 2.0)
+    }
+
+    @Test
+    fun `an ordinary gap inside the grace is left completely alone`() {
+      // The whole comeback path must be inert during normal training - no slide, no re-level.
+      val steady = (0..11).flatMap { s ->
+        (0 until 3).map { EffortSet(day(s * 4L).plusSeconds(it * 180L), 100.0 + s, 10) }
+      }
+      val series = EffortModel.score(steady)
+
+      series.trend.forEach { assertThat(it.expectedCapacity).isGreaterThan(0.0) }
+      // A pure straight line in, a pure straight line out.
+      val slopes = series.trend.zipWithNext { a, b ->
+        (b.expectedCapacity - a.expectedCapacity) / (b.dayOffset - a.dayOffset)
+      }
+      slopes.forEach { assertThat(it).isGreaterThan(0.0) }
     }
 
     @Test

--- a/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
+++ b/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
@@ -917,21 +917,92 @@ class EffortModelTest {
       assertThat(stale).isLessThan(contiguous)
     }
 
-    @Test
-    fun `a layoff is charged once, not once per set`() {
-      // The exploded fit sees one fit session per set, so a five-set comeback must not age the
-      // history by five layoffs.
-      val many = (0 until 5).map { EffortSet(day(200).plusSeconds(it * 180L), 100.0, 8) }
-      val few = listOf(EffortSet(day(200), 100.0, 8))
+    /** Six weekly sessions, a year off, then a comeback whose sets are [comebackSets]. */
+    private fun comebackSession(vararg comebackSets: Pair<Double, Int>): List<EffortSet> {
       val block = (0..5).flatMap { s ->
         (0 until 3).map { EffortSet(day(s * 7L).plusSeconds(it * 180L), 100.0, 8) }
       }
+      return block + comebackSets.mapIndexed { i, (w, r) ->
+        EffortSet(day(400).plusSeconds(i * 180L), w, r)
+      }
+    }
 
-      val withMany = EffortModel.scoreWithBootstrap(block + many)
-      val withFew = EffortModel.scoreWithBootstrap(block + few)
+    @Test
+    fun `a cautious first set back reads light once the working sets land`() {
+      // Exactly the live-strip story: open at a weight you are unsure of, and it looks fine
+      // against a guess the model admits it cannot make; find your real level on the next set
+      // and the opener is revealed as the feeler it was.
+      val alone = EffortModel.scoreWithBootstrap(comebackSession(75.0 to 8))
+      val settled = EffortModel.scoreWithBootstrap(
+        comebackSession(75.0 to 8, 95.0 to 8, 95.0 to 8)
+      )
 
-      assertThat(withMany.sets.first { it.sessionIndex == 6 }.expectation!!)
-        .isWithin(1e-9).of(withFew.sets.first { it.sessionIndex == 6 }.expectation!!)
+      val openerAlone = alone.sets.last { it.sessionIndex == 6 }
+      val openerSettled = settled.sets.first { it.sessionIndex == 6 }
+
+      assertThat(openerSettled.z!!).isLessThan(openerAlone.z!!)
+      assertThat(openerSettled.zone).isEqualTo(EffortZone.BELOW)
+    }
+
+    @Test
+    fun `the band closes as the guess becomes a measurement`() {
+      val oneSet = EffortModel.scoreWithBootstrap(comebackSession(95.0 to 8))
+        .sets.last { it.sessionIndex == 6 }
+      val threeSets = EffortModel.scoreWithBootstrap(
+        comebackSession(95.0 to 8, 95.0 to 8, 95.0 to 8)
+      ).sets.last { it.sessionIndex == 6 }
+
+      assertThat(threeSets.residualScale!!).isLessThan(oneSet.residualScale!!)
+    }
+
+    @Test
+    fun `the long-term history never recalibrates within a session`() {
+      // score() is what the drawer renders, and a dot that changes colour while you scroll is
+      // a different promise from a live strip that is telling you what to do next.
+      val sets = comebackSession(75.0 to 8, 95.0 to 8, 95.0 to 8)
+      val session = EffortModel.score(sets).sets.filter { it.sessionIndex == 6 }
+
+      assertThat(session).hasSize(3)
+      session.zipWithNext { a, b ->
+        assertThat(b.expectation!!).isWithin(1e-9).of(a.expectation!!)
+      }
+      // And that shared expectation is the time-based guess, untouched by the session itself.
+      assertThat(session.first().expectation!!)
+        .isLessThan(EffortModel.capacity(100.0, 8))
+    }
+
+    @Test
+    fun `recalibration does not leak into the fit's own error estimate`() {
+      // The residual accumulator measures prediction error. Feeding it a level this session
+      // helped set would report the fit as far more accurate than it is, and collapse the band
+      // for every session after it.
+      val sets = comebackSession(95.0 to 8, 95.0 to 8, 95.0 to 8) +
+        (0 until 3).map { EffortSet(day(407).plusSeconds(it * 180L), 95.0, 8) }
+
+      val viaStrip = EffortModel.scoreWithBootstrap(sets).sets.last().residualScale!!
+      val viaDrawer = EffortModel.score(sets).sets.last().residualScale!!
+
+      assertThat(viaStrip).isWithin(1e-9).of(viaDrawer)
+    }
+
+    @Test
+    fun `a layoff is charged once, not once per set`() {
+      // The exploded fit sees one fit session per set, so a five-set comeback must not age the
+      // history by five layoffs. Only two prior days, so the session fit is still cold here and
+      // the values under test are genuinely the set-grain ones.
+      val block = (0..1).flatMap { s ->
+        (0 until 3).map { EffortSet(day(s * 7L).plusSeconds(it * 180L), 100.0, 8) }
+      }
+      val comeback = (0 until 5).map { EffortSet(day(200).plusSeconds(it * 180L), 100.0, 8) }
+
+      val scored = EffortModel.scoreWithBootstrap(block + comeback)
+        .sets.filter { it.sessionIndex == 2 && it.expectation != null }
+
+      assertThat(scored).hasSize(5)
+      // Billing the gap per set decays the history by 0.5^(200/90) again on every one of them,
+      // so by the fifth set the expectation would have collapsed to a fraction of a percent.
+      val first = scored.first().expectation!!
+      scored.forEach { assertThat(it.expectation!!).isGreaterThan(first * 0.8) }
     }
   }
 

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
@@ -18,7 +18,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.PointMode
@@ -32,25 +34,94 @@ import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp as lerpDp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.util.lerp
+import androidx.compose.ui.util.lerp as lerpFloat
 import com.litus_animae.refitted.data.effort.EffortZone
 import com.litus_animae.refitted.ui.R
-import com.litus_animae.refitted.ui.compose.util.Theme
 import kotlin.math.sqrt
 
 /**
- * One bubble to draw: [x] and [weight] in the caller's chosen domain, [size] in `[0, 1]`.
- * [emphasized] draws a ring around this bubble (e.g. "the set you just did") - false costs
- * nothing extra to draw.
+ * One bubble to draw: [x] and [weight] in the caller's chosen domain. [emphasized] draws a ring
+ * around this bubble (e.g. "the set you just did") - false costs nothing extra to draw.
+ *
+ * Size comes from [zone] in three discrete steps and colour from [reps]; neither is passed in,
+ * so every chart drawing effort encodes them the same way. See [EffortSizeStep] and [RepRamp].
  */
 data class EffortPoint(
   val x: Float,
   val weight: Float,
-  val size: Float,
+  val reps: Int,
   val zone: EffortZone,
   val emphasized: Boolean = false
 )
+
+/**
+ * One x-position's slice of the expectation band: the weight the model expects at [x] and the
+ * weights the zone thresholds sit at either side of it, all in the caller's y-domain.
+ *
+ * [lower] and [upper] are the BELOW/ON_CURVE and ON_CURVE/GROWTH boundaries expressed as
+ * weights, so a bubble's vertical position against this band *is* its zone rather than
+ * something the reader has to decode from its colour. [reps] tints the slice to match the dots
+ * it belongs to.
+ */
+data class EffortBand(
+  val x: Float,
+  val lower: Float,
+  val center: Float,
+  val upper: Float,
+  val reps: Int
+)
+
+/**
+ * The three sizes a bubble can take. A continuum reads as noise here: the old one gave the
+ * whole GROWTH zone about 1dp of diameter while spending 5dp inside ON_CURVE, so size varied
+ * more within a zone than between them, and it was not even monotonic - one diameter meant
+ * either "well under" or "implausibly over", leaving colour to say which.
+ */
+enum class EffortSizeStep { UNDER, ON, OVER }
+
+internal fun sizeStepOf(zone: EffortZone): EffortSizeStep = when (zone) {
+  EffortZone.BELOW -> EffortSizeStep.UNDER
+  // A cold set has no expectation to be over or under, so it takes the neutral middle.
+  EffortZone.COLD, EffortZone.ON_CURVE -> EffortSizeStep.ON
+  // IMPLAUSIBLE is folded in rather than given a step of its own: with the band no longer
+  // narrowing after a layoff it means a typo, and a typo is still an over-shoot.
+  EffortZone.GROWTH, EffortZone.IMPLAUSIBLE -> EffortSizeStep.OVER
+}
+
+private fun EffortSizeStep.fraction(): Float = when (this) {
+  EffortSizeStep.UNDER -> 0f
+  EffortSizeStep.ON -> 0.5f
+  EffortSizeStep.OVER -> 1f
+}
+
+/** The same three steps at swatch scale, for a legend key or an inline caption. */
+internal fun sizeStepDot(step: EffortSizeStep): Dp = lerpDp(5.dp, 11.dp, step.fraction())
+
+/**
+ * Sequential single-hue ramp for rep count - light for few reps, dark for many.
+ *
+ * One hue, monotonically darkening, because reps are a magnitude: a rainbow would imply
+ * categories that aren't there. It starts at Blue 500 rather than anything lighter because
+ * every step has to clear 3:1 against this app's white chart surface, and Blue 400 only
+ * manages 2.65:1; the range runs 3.12:1 to 8.63:1.
+ */
+private val RepRamp = listOf(
+  Color(0xFF2196F3),
+  Color(0xFF1E88E5),
+  Color(0xFF1976D2),
+  Color(0xFF1565C0),
+  Color(0xFF0D47A1)
+)
+
+internal fun repColor(reps: Int, minReps: Int, maxReps: Int): Color {
+  if (maxReps <= minReps) return RepRamp[RepRamp.size / 2]
+  val t = ((reps - minReps).toFloat() / (maxReps - minReps)).coerceIn(0f, 1f)
+  val pos = t * (RepRamp.size - 1)
+  val index = pos.toInt().coerceAtMost(RepRamp.size - 2)
+  return lerp(RepRamp[index], RepRamp[index + 1], pos - index)
+}
 
 private val LabelPadding = 4.dp
 private val GapMarkDash = 4.dp
@@ -58,12 +129,15 @@ private val EmphasisRingGap = 3.dp
 private val EmphasisRingWidth = 1.5.dp
 
 /**
- * Effort-scored sets as bubbles (radius by demonstrated capacity vs. expectation) plus the
- * adaptive expectation curve.
+ * Effort-scored sets as bubbles against the band their trend expects them in.
  *
- * [trend] is a list of runs rather than one flat polyline - a run breaks wherever the caller's
+ * Three channels, one meaning each: vertical position is weight, size is where the set landed
+ * against the band, colour is rep count. Nothing is encoded twice, and the zone a bubble is in
+ * is legible from where it sits rather than from a colour the reader has to remember.
+ *
+ * [bands] is a list of runs rather than one flat ribbon - a run breaks wherever the caller's
  * domain has no prediction (cold start, or a skipped index in a compact window), and each run
- * is drawn as its own connected segment rather than one line bridging the gap.
+ * is drawn as its own connected shape rather than one bridging the gap.
  *
  * [xLabels] and [yLabels] are axis ticks in the caller's domain (`domain value to display
  * text`); [gapMarks] are x-domain positions for a dashed rule (e.g. between sessions with a
@@ -74,18 +148,15 @@ private val EmphasisRingWidth = 1.5.dp
 fun EffortChart(
   modifier: Modifier = Modifier,
   points: List<EffortPoint>,
-  trend: List<List<Pair<Float, Float>>> = emptyList(),
-  // A second trend line, drawn dashed and beneath [trend] - for callers that fit two kinds
-  // of expectation (e.g. a coarser stand-in while there isn't enough history for the real
-  // one) and want the dash itself to carry that distinction rather than a text label.
-  dashedTrend: List<List<Pair<Float, Float>>> = emptyList(),
+  bands: List<List<EffortBand>> = emptyList(),
+  // A second band, drawn dashed - for callers that fit two kinds of expectation (e.g. a
+  // coarser stand-in while there isn't enough history for the real one) and want the dash
+  // itself to carry that distinction rather than a text label.
+  dashedBands: List<List<EffortBand>> = emptyList(),
   compact: Boolean = false,
   xLabels: List<Pair<Float, String>> = emptyList(),
   yLabels: List<Pair<Float, String>> = emptyList(),
   gapMarks: List<Float> = emptyList(),
-  baseColor: Color = MaterialTheme.colors.primary,
-  peakColor: Color = Theme.goodAttention,
-  punishedColor: Color = Theme.timerAmber,
   coldColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.25f),
   trendColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.35f),
   emphasisColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
@@ -100,17 +171,26 @@ fun EffortChart(
     return
   }
 
-  val minX = remember(points, trend, dashedTrend) {
-    minOf(points.minOf { it.x }, (trend + dashedTrend).flatten().minOfOrNull { it.first } ?: Float.POSITIVE_INFINITY)
+  val allBands = remember(bands, dashedBands) { (bands + dashedBands).flatten() }
+  val minX = remember(points, allBands) {
+    minOf(points.minOf { it.x }, allBands.minOfOrNull { it.x } ?: Float.POSITIVE_INFINITY)
   }
-  val maxX = remember(points, trend, dashedTrend) {
-    maxOf(points.maxOf { it.x }, (trend + dashedTrend).flatten().maxOfOrNull { it.first } ?: Float.NEGATIVE_INFINITY)
+  val maxX = remember(points, allBands) {
+    maxOf(points.maxOf { it.x }, allBands.maxOfOrNull { it.x } ?: Float.NEGATIVE_INFINITY)
   }
-  val minY = remember(points, trend, dashedTrend) {
-    minOf(points.minOf { it.weight }, (trend + dashedTrend).flatten().minOfOrNull { it.second } ?: Float.POSITIVE_INFINITY)
+  val minY = remember(points, allBands) {
+    minOf(points.minOf { it.weight }, allBands.minOfOrNull { it.lower } ?: Float.POSITIVE_INFINITY)
   }
-  val maxY = remember(points, trend, dashedTrend) {
-    maxOf(points.maxOf { it.weight }, (trend + dashedTrend).flatten().maxOfOrNull { it.second } ?: Float.NEGATIVE_INFINITY)
+  val maxY = remember(points, allBands) {
+    maxOf(points.maxOf { it.weight }, allBands.maxOfOrNull { it.upper } ?: Float.NEGATIVE_INFINITY)
+  }
+  // The rep-count ramp is normalised across everything on screen, bands included, so a dot and
+  // the slice of band it sits in read as the same colour when they describe the same reps.
+  val minReps = remember(points, allBands) {
+    minOf(points.minOf { it.reps }, allBands.minOfOrNull { it.reps } ?: Int.MAX_VALUE)
+  }
+  val maxReps = remember(points, allBands) {
+    maxOf(points.maxOf { it.reps }, allBands.maxOfOrNull { it.reps } ?: Int.MIN_VALUE)
   }
 
   val xSpan = maxX - minX
@@ -124,7 +204,9 @@ fun EffortChart(
 
   // Largest first so a peak bubble never visually swallows a smaller one drawn after it -
   // hoisted out of the draw scope so it isn't re-sorted every frame.
-  val sortedPoints = remember(points) { points.sortedByDescending { it.size } }
+  val sortedPoints = remember(points) {
+    points.sortedByDescending { sizeStepOf(it.zone).fraction() }
+  }
 
   val density = LocalDensity.current
   val minPx = with(density) { minPointSize.toPx() }
@@ -167,8 +249,8 @@ fun EffortChart(
     val plotTop = maxR.coerceAtMost(size.height / 2f)
     val plotBottom = (size.height - maxR - bottomGutter).coerceAtLeast(plotTop)
 
-    fun px(x: Float) = lerp(plotLeft, plotRight, nx(x))
-    fun py(y: Float) = lerp(plotBottom, plotTop, ny(y))
+    fun px(x: Float) = lerpFloat(plotLeft, plotRight, nx(x))
+    fun py(y: Float) = lerpFloat(plotBottom, plotTop, ny(y))
 
     gapMarks.forEach { x ->
       drawLine(
@@ -180,41 +262,67 @@ fun EffortChart(
       )
     }
 
-    // Drawn first, and beneath the solid trend below, so a solid segment starting exactly
-    // where a dashed one ends (the bootstrap-to-real handoff) renders over it cleanly.
-    dashedTrend.forEach { run ->
-      if (run.size < 2) return@forEach
-      val path = Path().apply {
-        run.forEachIndexed { index, (x, y) ->
-          val offset = Offset(px(x), py(y))
-          if (index == 0) moveTo(offset.x, offset.y) else lineTo(offset.x, offset.y)
+    // The band's own fill is what makes the thresholds readable: a bubble inside it is
+    // ON_CURVE, above it is over, below it is under. Tinted along x by the reps each slice
+    // describes, so the prediction is coloured on the same scale as the dots sitting in it.
+    fun drawBand(run: List<EffortBand>, dashed: Boolean) {
+      if (run.isEmpty()) return
+      if (run.size >= 2) {
+        val area = Path().apply {
+          run.forEachIndexed { index, b ->
+            if (index == 0) moveTo(px(b.x), py(b.upper)) else lineTo(px(b.x), py(b.upper))
+          }
+          run.asReversed().forEach { b -> lineTo(px(b.x), py(b.lower)) }
+          close()
+        }
+        val stops = run.mapIndexed { index, b ->
+          (if (run.size == 1) 0f else index / (run.size - 1f)) to
+            repColor(b.reps, minReps, maxReps).copy(alpha = if (dashed) 0.08f else 0.14f)
+        }
+        drawPath(
+          area,
+          Brush.horizontalGradient(
+            colorStops = stops.toTypedArray(),
+            startX = px(run.first().x),
+            endX = px(run.last().x)
+          )
+        )
+      }
+      if (run.size < 2) return
+      val centre = Path().apply {
+        run.forEachIndexed { index, b ->
+          if (index == 0) moveTo(px(b.x), py(b.center)) else lineTo(px(b.x), py(b.center))
         }
       }
       drawPath(
-        path,
+        centre,
         trendColor,
-        style = Stroke(width = trendPx, pathEffect = PathEffect.dashPathEffect(floatArrayOf(gapDashPx, gapDashPx)))
+        style = Stroke(
+          width = trendPx,
+          pathEffect = if (dashed) {
+            PathEffect.dashPathEffect(floatArrayOf(gapDashPx, gapDashPx))
+          } else {
+            null
+          }
+        )
       )
     }
 
-    trend.forEach { run ->
-      if (run.size < 2) return@forEach
-      val offsets = run.map { (x, y) -> Offset(px(x), py(y)) }
-      drawPoints(
-        offsets.zipWithNext().flatMap { sequenceOf(it.first, it.second) },
-        PointMode.Lines,
-        trendColor,
-        trendPx
-      )
-    }
+    // Dashed first, so a solid run starting exactly where a dashed one ends (the
+    // bootstrap-to-real handoff) renders over it cleanly.
+    dashedBands.forEach { drawBand(it, dashed = true) }
+    bands.forEach { drawBand(it, dashed = false) }
 
     sortedPoints.forEach { point ->
       // Stroke width is a diameter, so mapping size -> diameter linearly would make the
       // *area* (what the eye actually reads as "bigger") grow quadratically with size.
       // Interpolating the squared diameter and taking the root keeps size proportional to area.
-      val clampedSize = point.size.coerceIn(0f, 1f)
-      val diameter = sqrt(lerp(minPx * minPx, maxPx * maxPx, clampedSize))
-      val color = zoneColor(point.zone, baseColor, peakColor, punishedColor, coldColor)
+      val diameter = sqrt(lerpFloat(minPx * minPx, maxPx * maxPx, sizeStepOf(point.zone).fraction()))
+      val color = if (point.zone == EffortZone.COLD) {
+        coldColor
+      } else {
+        repColor(point.reps, minReps, maxReps)
+      }
       val center = Offset(px(point.x), py(point.weight))
       drawPoints(listOf(center), PointMode.Points, color, diameter, StrokeCap.Round)
       if (point.emphasized) {
@@ -240,31 +348,82 @@ fun EffortChart(
   }
 }
 
-/** Dot + label per [EffortZone], decoding the bubble colors drawn by [EffortChart]. */
+/**
+ * Decodes the two channels [EffortChart] actually uses: size for where a set landed against
+ * the band, colour for how many reps it took. Zone is deliberately *not* listed colour-by-
+ * colour any more - it is readable straight off the chart now, from whether a bubble sits
+ * inside the band or outside it.
+ */
 @Composable
 fun EffortLegend(
   modifier: Modifier = Modifier,
-  baseColor: Color = MaterialTheme.colors.primary,
-  peakColor: Color = Theme.goodAttention,
-  punishedColor: Color = Theme.timerAmber,
+  repRange: IntRange? = null,
   coldColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.25f)
 ) {
+  val inkColor = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
   FlowRow(
     modifier,
     horizontalArrangement = Arrangement.spacedBy(12.dp),
-    verticalArrangement = Arrangement.spacedBy(2.dp)
+    verticalArrangement = Arrangement.spacedBy(4.dp)
   ) {
-    EffortZone.entries.forEach { zone ->
-      Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+    EffortSizeStep.entries.forEach { step ->
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+      ) {
         Box(
           Modifier
-            .size(8.dp)
-            .background(zoneColor(zone, baseColor, peakColor, punishedColor, coldColor), CircleShape)
+            .size(sizeStepDot(step))
+            .background(inkColor, CircleShape)
         )
-        Text(stringResource(zoneLabelRes(zone)), style = MaterialTheme.typography.caption)
+        Text(stringResource(sizeStepLabelRes(step)), style = MaterialTheme.typography.caption)
+      }
+    }
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+      Box(
+        Modifier
+          .size(8.dp)
+          .background(coldColor, CircleShape)
+      )
+      Text(stringResource(R.string.effort_zone_cold), style = MaterialTheme.typography.caption)
+    }
+    if (repRange != null && repRange.last > repRange.first) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+      ) {
+        Text(
+          stringResource(R.string.effort_reps_low, repRange.first),
+          style = MaterialTheme.typography.caption
+        )
+        Box(
+          Modifier
+            .size(width = 36.dp, height = 8.dp)
+            .background(
+              Brush.horizontalGradient(
+                listOf(
+                  repColor(repRange.first, repRange.first, repRange.last),
+                  repColor(repRange.last, repRange.first, repRange.last)
+                )
+              )
+            )
+        )
+        Text(
+          stringResource(R.string.effort_reps_high, repRange.last),
+          style = MaterialTheme.typography.caption
+        )
       }
     }
   }
+}
+
+internal fun sizeStepLabelRes(step: EffortSizeStep): Int = when (step) {
+  EffortSizeStep.UNDER -> R.string.effort_step_under
+  EffortSizeStep.ON -> R.string.effort_step_on
+  EffortSizeStep.OVER -> R.string.effort_step_over
 }
 
 internal fun zoneLabelRes(zone: EffortZone): Int = when (zone) {
@@ -275,19 +434,13 @@ internal fun zoneLabelRes(zone: EffortZone): Int = when (zone) {
   EffortZone.IMPLAUSIBLE -> R.string.effort_zone_implausible
 }
 
-internal fun zoneColor(
-  zone: EffortZone,
-  baseColor: Color,
-  peakColor: Color,
-  punishedColor: Color,
-  coldColor: Color
-): Color = when (zone) {
-  EffortZone.COLD -> coldColor
-  EffortZone.BELOW -> baseColor.copy(alpha = 0.55f)
-  EffortZone.ON_CURVE -> baseColor.copy(alpha = 0.85f)
-  EffortZone.GROWTH -> peakColor
-  EffortZone.IMPLAUSIBLE -> punishedColor
-}
+private fun band(x: Float, center: Float, half: Float, reps: Int) = EffortBand(
+  x = x,
+  lower = center - half,
+  center = center,
+  upper = center + half / 2f,
+  reps = reps
+)
 
 @Preview
 @Composable
@@ -303,19 +456,7 @@ private fun PreviewEffortChartEmpty() {
 private fun PreviewEffortChartSinglePoint() {
   EffortChart(
     Modifier.size(300.dp).background(Color.White),
-    points = listOf(EffortPoint(0f, 100f, 0.45f, EffortZone.COLD))
-  )
-}
-
-@Preview
-@Composable
-private fun PreviewEffortChartTwoSameDay() {
-  EffortChart(
-    Modifier.size(300.dp).background(Color.White),
-    points = listOf(
-      EffortPoint(0f, 95f, 0.45f, EffortZone.COLD),
-      EffortPoint(0f, 100f, 0.45f, EffortZone.COLD)
-    )
+    points = listOf(EffortPoint(0f, 100f, 10, EffortZone.COLD))
   )
 }
 
@@ -325,114 +466,144 @@ private fun PreviewEffortChartColdStartOnly() {
   EffortChart(
     Modifier.size(300.dp).background(Color.White),
     points = listOf(
-      EffortPoint(0f, 90f, 0.45f, EffortZone.COLD),
-      EffortPoint(1f, 95f, 0.45f, EffortZone.COLD)
+      EffortPoint(0f, 90f, 10, EffortZone.COLD),
+      EffortPoint(1f, 95f, 10, EffortZone.COLD)
     )
   )
 }
 
+/** The three size steps and the rep ramp together, against a band they can be read against. */
 @Preview
 @Composable
-private fun PreviewEffortChartLongHistoryWithSpike() {
+private fun PreviewEffortChartBandAndSteps() {
+  EffortChart(
+    Modifier.size(340.dp, 200.dp).background(Color.White),
+    points = listOf(
+      EffortPoint(0f, 96f, 12, EffortZone.ON_CURVE),
+      EffortPoint(1f, 88f, 15, EffortZone.BELOW),
+      EffortPoint(2f, 104f, 8, EffortZone.GROWTH),
+      EffortPoint(3f, 101f, 10, EffortZone.ON_CURVE),
+      EffortPoint(4f, 112f, 5, EffortZone.IMPLAUSIBLE)
+    ),
+    bands = listOf(
+      listOf(
+        band(0f, 97f, 5f, 12),
+        band(1f, 98f, 5f, 15),
+        band(2f, 99f, 5f, 8),
+        band(3f, 100f, 5f, 10),
+        band(4f, 101f, 5f, 5)
+      )
+    ),
+    yLabels = listOf(88f to "88", 112f to "112")
+  )
+}
+
+/** The flare across a layoff: the band should visibly widen where the model stops knowing. */
+@Preview
+@Composable
+private fun PreviewEffortChartPostLayoffFlare() {
+  EffortChart(
+    Modifier.size(340.dp, 200.dp).background(Color.White),
+    points = listOf(
+      EffortPoint(0f, 130f, 8, EffortZone.ON_CURVE),
+      EffortPoint(1f, 133f, 8, EffortZone.ON_CURVE),
+      EffortPoint(2f, 136f, 8, EffortZone.ON_CURVE),
+      EffortPoint(3f, 105f, 10, EffortZone.ON_CURVE),
+      EffortPoint(4f, 108f, 10, EffortZone.GROWTH)
+    ),
+    bands = listOf(
+      listOf(
+        band(0f, 129f, 6f, 8),
+        band(1f, 132f, 6f, 8),
+        band(2f, 135f, 6f, 8),
+        band(3f, 104f, 34f, 10),
+        band(4f, 106f, 7f, 10)
+      )
+    ),
+    gapMarks = listOf(2.5f),
+    xLabels = listOf(0f to "Aug '24", 3f to "Aug '26"),
+    yLabels = listOf(105f to "105", 136f to "136")
+  )
+}
+
+/** Bootstrap (dashed) handing off to the real fit (solid) at x=2. */
+@Preview
+@Composable
+private fun PreviewEffortChartBandHandoff() {
   EffortChart(
     Modifier.size(300.dp).background(Color.White),
     points = listOf(
-      EffortPoint(0f, 90f, 0.45f, EffortZone.COLD),
-      EffortPoint(1f, 92f, 0.45f, EffortZone.COLD),
-      EffortPoint(2f, 95f, 0.45f, EffortZone.COLD),
-      EffortPoint(3f, 98f, 0.70f, EffortZone.ON_CURVE),
-      EffortPoint(4f, 100f, 0.85f, EffortZone.GROWTH),
-      EffortPoint(5f, 130f, 0.40f, EffortZone.IMPLAUSIBLE),
-      EffortPoint(6f, 103f, 0.60f, EffortZone.ON_CURVE),
-      EffortPoint(7f, 105f, 1.00f, EffortZone.GROWTH)
+      EffortPoint(0f, 90f, 10, EffortZone.COLD),
+      EffortPoint(1f, 95f, 10, EffortZone.ON_CURVE),
+      EffortPoint(2f, 98f, 10, EffortZone.ON_CURVE),
+      EffortPoint(3f, 100f, 9, EffortZone.ON_CURVE),
+      EffortPoint(4f, 103f, 8, EffortZone.GROWTH)
     ),
-    trend = listOf(
-      listOf(3f to 96f, 4f to 98f, 5f to 100f, 6f to 101f, 7f to 103f)
+    dashedBands = listOf(listOf(band(1f, 94f, 5f, 10), band(2f, 97f, 5f, 10))),
+    bands = listOf(
+      listOf(band(2f, 97f, 5f, 10), band(3f, 99f, 5f, 9), band(4f, 101f, 5f, 8))
     )
   )
 }
 
+/** Unloadable work: every dot at zero while the band climbs from below the axis toward a plate. */
 @Preview
 @Composable
-private fun PreviewEffortChartEmphasizedNewest() {
+private fun PreviewEffortChartBodyweightClimb() {
   EffortChart(
-    Modifier.size(300.dp).background(Color.White),
-    points = listOf(
-      EffortPoint(0f, 90f, 0.45f, EffortZone.COLD),
-      EffortPoint(1f, 95f, 0.60f, EffortZone.ON_CURVE),
-      EffortPoint(2f, 98f, 0.85f, EffortZone.GROWTH, emphasized = true)
+    Modifier.size(340.dp, 200.dp).background(Color.White),
+    points = (0..5).map { EffortPoint(it.toFloat(), 0f, 11 + it, EffortZone.ON_CURVE) },
+    bands = listOf(
+      (0..5).map { band(it.toFloat(), -3.5f + it * 0.9f, 5f, 11 + it) }
     ),
-    gapMarks = listOf(0.5f, 1.5f),
-    yLabels = listOf(90f to "90", 98f to "98")
+    yLabels = listOf(0f to "0")
   )
 }
 
 @Preview
 @Composable
-private fun PreviewEffortChartDashedTrendHandoff() {
+private fun PreviewEffortChartCompactStrip() {
   EffortChart(
-    Modifier.size(300.dp).background(Color.White),
+    Modifier.size(150.dp, 70.dp).background(Color.White),
+    compact = true,
     points = listOf(
-      EffortPoint(0f, 90f, 0.45f, EffortZone.COLD),
-      EffortPoint(1f, 95f, 0.60f, EffortZone.ON_CURVE),
-      EffortPoint(2f, 98f, 0.60f, EffortZone.ON_CURVE),
-      EffortPoint(3f, 100f, 0.70f, EffortZone.ON_CURVE),
-      EffortPoint(4f, 103f, 0.85f, EffortZone.GROWTH)
+      EffortPoint(0f, 100f, 10, EffortZone.ON_CURVE),
+      EffortPoint(1f, 100f, 10, EffortZone.ON_CURVE),
+      EffortPoint(2f, 95f, 12, EffortZone.BELOW),
+      EffortPoint(3f, 105f, 8, EffortZone.GROWTH),
+      EffortPoint(4f, 105f, 8, EffortZone.GROWTH, emphasized = true)
     ),
-    // The bootstrap (dashed) run hands off to the real (solid) run at x=2 - the solid
-    // segment should render cleanly over the dash where they overlap.
-    dashedTrend = listOf(listOf(1f to 94f, 2f to 97f)),
-    trend = listOf(listOf(2f to 97f, 3f to 99f, 4f to 101f))
+    bands = listOf(
+      listOf(
+        band(0f, 99f, 5f, 10),
+        band(1f, 100f, 5f, 10),
+        band(2f, 100f, 5f, 12),
+        band(3f, 101f, 5f, 8),
+        band(4f, 102f, 5f, 8)
+      )
+    ),
+    gapMarks = listOf(1.5f),
+    yLabels = listOf(95f to "95", 105f to "105")
   )
 }
 
-@Preview
-@Composable
-private fun PreviewEffortChartFlatHistory() {
-  EffortChart(
-    Modifier.size(300.dp).background(Color.White),
-    points = (0..6).map { EffortPoint(it.toFloat(), 100f, 0.60f, EffortZone.ON_CURVE) },
-    trend = listOf((3..6).map { it.toFloat() to 100f })
-  )
-}
-
-/** Regression check for the plot-rect inset: max-size bubbles sit at every domain corner and
- * must not touch the [Color.White] box edge. */
+/** Regression check for the plot-rect inset: max-size bubbles must not touch the box edge. */
 @Preview
 @Composable
 private fun PreviewEffortChartCornerPoints() {
   EffortChart(
     Modifier.size(300.dp).background(Color.White),
     points = listOf(
-      EffortPoint(0f, 0f, 1.00f, EffortZone.GROWTH),
-      EffortPoint(0f, 100f, 1.00f, EffortZone.GROWTH),
-      EffortPoint(10f, 0f, 1.00f, EffortZone.GROWTH),
-      EffortPoint(10f, 100f, 1.00f, EffortZone.GROWTH)
+      EffortPoint(0f, 0f, 10, EffortZone.GROWTH),
+      EffortPoint(0f, 100f, 10, EffortZone.GROWTH),
+      EffortPoint(10f, 0f, 10, EffortZone.GROWTH),
+      EffortPoint(10f, 100f, 10, EffortZone.GROWTH)
     )
   )
 }
 
 @Preview
 @Composable
-private fun PreviewEffortChartWithAxesAndGaps() {
-  EffortChart(
-    Modifier.size(340.dp, 220.dp).background(Color.White),
-    points = listOf(
-      EffortPoint(0f, 20f, 0.30f, EffortZone.COLD),
-      EffortPoint(1f, 20f, 0.30f, EffortZone.COLD),
-      EffortPoint(2f, 15f, 0.60f, EffortZone.ON_CURVE),
-      EffortPoint(3f, 35f, 0.85f, EffortZone.GROWTH),
-      EffortPoint(4f, 40f, 1.00f, EffortZone.GROWTH)
-    ),
-    trend = listOf(listOf(3f to 33f, 4f to 38f)),
-    gapMarks = listOf(1.5f, 2.5f),
-    xLabels = listOf(0f to "Nov '21", 2f to "Jan '23", 4f to "Jun '23"),
-    yLabels = listOf(15f to "15", 40f to "40")
-  )
-}
-
-@Preview
-@Composable
 private fun PreviewEffortLegend() {
-  EffortLegend(Modifier.background(Color.White).padding(8.dp))
+  EffortLegend(Modifier.background(Color.White).padding(8.dp), repRange = 5..20)
 }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
@@ -267,6 +267,27 @@ fun EffortChart(
     // describes, so the prediction is coloured on the same scale as the dots sitting in it.
     fun drawBand(run: List<EffortBand>, dashed: Boolean) {
       if (run.isEmpty()) return
+      // A lone slice is the target for a set not done yet, so there is no ribbon to fill -
+      // draw it as the upright bar it is, with a tick at the weight being aimed at.
+      if (run.size == 1) {
+        val b = run.single()
+        val tint = repColor(b.reps, minReps, maxReps)
+        val barWidth = maxPx / 3f
+        drawLine(
+          tint.copy(alpha = 0.35f),
+          Offset(px(b.x), py(b.upper)),
+          Offset(px(b.x), py(b.lower)),
+          strokeWidth = barWidth,
+          cap = StrokeCap.Round
+        )
+        drawLine(
+          tint,
+          Offset(px(b.x) - barWidth / 2f, py(b.center)),
+          Offset(px(b.x) + barWidth / 2f, py(b.center)),
+          strokeWidth = trendPx
+        )
+        return
+      }
       if (run.size >= 2) {
         val area = Path().apply {
           run.forEachIndexed { index, b ->

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortTrendRuns.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortTrendRuns.kt
@@ -1,52 +1,52 @@
 package com.litus_animae.refitted.ui.compose.charts
 
+import com.litus_animae.refitted.data.effort.EffortModel
+import com.litus_animae.refitted.data.effort.ExpectationSource
+import com.litus_animae.refitted.data.effort.ScoredSet
+
 /**
- * Breaks a trend line into runs keyed by contiguous session - a session with no predicted
- * weight (cold start, or filtered out of the caller's window) breaks the polyline rather
- * than bridging across the gap.
+ * This set's slice of the expectation band, in weight, or `null` if it has no expectation yet.
  *
- * [xBySessionIndex] is the x-domain position to draw each session at, paired with the
- * session index used to look it up in [expectedWeightBySession]. Order matters - runs are
- * built in list order, so callers must already be sorted along x.
+ * The edges are the zone thresholds converted through the set's own weight scale, which is what
+ * makes a bubble's position against the band identical to the zone its size shows - see
+ * [ScoredSet.weightScale] for the identity that guarantees it.
  */
-fun buildTrendRuns(
-  xBySessionIndex: List<Pair<Float, Int>>,
-  expectedWeightBySession: Map<Int, Double>
-): List<List<Pair<Float, Float>>> {
-  val runs = mutableListOf<MutableList<Pair<Float, Float>>>()
-  var current: MutableList<Pair<Float, Float>>? = null
-  xBySessionIndex.forEach { (x, sessionIndex) ->
-    val expectedWeight = expectedWeightBySession[sessionIndex]
-    if (expectedWeight == null) {
-      current = null
-    } else {
-      val run = current ?: mutableListOf<Pair<Float, Float>>().also {
-        current = it
-        runs.add(it)
-      }
-      run.add(x to expectedWeight.toFloat())
-    }
-  }
-  return runs
+fun ScoredSet.bandAt(x: Float): EffortBand? {
+  val center = expectedWeight ?: return null
+  val scale = residualScale ?: return null
+  val half = scale / weightScale
+  return EffortBand(
+    x = x,
+    lower = (center + EffortModel.UNDER_EDGE_Z * half).toFloat(),
+    center = center.toFloat(),
+    upper = (center + EffortModel.OVER_EDGE_Z * half).toFloat(),
+    reps = source.reps
+  )
 }
 
 /**
- * Same run-breaking semantics as the session-keyed overload, for callers that already carry a
- * per-point expected weight and so don't need the session-index indirection. A null expectation
- * breaks the polyline.
+ * Breaks the expectation band into runs - a set with no expectation (cold start, or belonging
+ * to the other [ExpectationSource]) breaks the ribbon rather than bridging across the gap, so a
+ * caller can draw the real fit and its coarser stand-in as visually distinct bands.
+ *
+ * Order matters: runs are built in list order, so callers must already be sorted along x.
  */
-fun buildTrendRuns(points: List<Pair<Float, Double?>>): List<List<Pair<Float, Float>>> {
-  val runs = mutableListOf<MutableList<Pair<Float, Float>>>()
-  var current: MutableList<Pair<Float, Float>>? = null
-  points.forEach { (x, expectedWeight) ->
-    if (expectedWeight == null) {
+fun List<ScoredSet>.bandRuns(
+  source: ExpectationSource,
+  x: (index: Int, set: ScoredSet) -> Float = { index, _ -> index.toFloat() }
+): List<List<EffortBand>> {
+  val runs = mutableListOf<MutableList<EffortBand>>()
+  var current: MutableList<EffortBand>? = null
+  forEachIndexed { index, scored ->
+    val band = if (scored.expectationSource == source) scored.bandAt(x(index, scored)) else null
+    if (band == null) {
       current = null
     } else {
-      val run = current ?: mutableListOf<Pair<Float, Float>>().also {
+      val run = current ?: mutableListOf<EffortBand>().also {
         current = it
         runs.add(it)
       }
-      run.add(x to expectedWeight.toFloat())
+      run.add(band)
     }
   }
   return runs

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortTrendRuns.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortTrendRuns.kt
@@ -3,6 +3,8 @@ package com.litus_animae.refitted.ui.compose.charts
 import com.litus_animae.refitted.data.effort.EffortModel
 import com.litus_animae.refitted.data.effort.ExpectationSource
 import com.litus_animae.refitted.data.effort.ScoredSet
+import com.litus_animae.refitted.data.effort.bandHalfWidthAt
+import com.litus_animae.refitted.data.effort.expectedWeightAt
 
 /**
  * This set's slice of the expectation band, in weight, or `null` if it has no expectation yet.
@@ -21,6 +23,33 @@ fun ScoredSet.bandAt(x: Float): EffortBand? {
     center = center.toFloat(),
     upper = (center + EffortModel.OVER_EDGE_Z * half).toFloat(),
     reps = source.reps
+  )
+}
+
+/**
+ * The band for a set not yet done, at the rep count the program is asking for.
+ *
+ * Where a history band is one rep count with uncertainty either side, this one is the envelope
+ * over the whole prescribed range: [upper] is the weight you would be over the curve at if you
+ * only managed [targetReps], [lower] the weight you would be under it at even taking the full
+ * [targetRepsHigh]. Anything landing between them is on the curve for *some* rep count you were
+ * asked for, which is the actual question - "what do I load next?" - and it collapses back to an
+ * ordinary band when the program prescribes a single number.
+ *
+ * Evaluated at the target rather than at whatever reps the last set happened to take: a history
+ * skewed to heavy triples would otherwise recommend a weight nobody can get ten reps with.
+ */
+fun ScoredSet.forwardBandAt(x: Float, targetReps: Int, targetRepsHigh: Int): EffortBand? {
+  val heavy = expectedWeightAt(targetReps) ?: return null
+  val light = expectedWeightAt(targetRepsHigh) ?: return null
+  val heavyHalf = bandHalfWidthAt(targetReps) ?: return null
+  val lightHalf = bandHalfWidthAt(targetRepsHigh) ?: return null
+  return EffortBand(
+    x = x,
+    lower = (light + EffortModel.UNDER_EDGE_Z * lightHalf).toFloat(),
+    center = heavy.toFloat(),
+    upper = (heavy + EffortModel.OVER_EDGE_Z * heavyHalf).toFloat(),
+    reps = targetReps
   )
 }
 

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
@@ -56,6 +56,7 @@ import androidx.paging.PagingData
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.litus_animae.refitted.data.effort.EffortConfig
 import com.litus_animae.refitted.data.effort.EffortModel
+import com.litus_animae.refitted.data.effort.ExpectationSource
 import com.litus_animae.refitted.data.effort.ScoredSet
 import com.litus_animae.refitted.data.effort.TrendPoint
 import com.litus_animae.refitted.data.effort.toEffortSet
@@ -70,7 +71,7 @@ import com.litus_animae.refitted.ui.compose.charts.EffortChart
 import com.litus_animae.refitted.ui.compose.charts.EffortLegend
 import com.litus_animae.refitted.ui.compose.charts.EffortPoint
 import com.litus_animae.refitted.ui.compose.charts.LineChart
-import com.litus_animae.refitted.ui.compose.charts.buildTrendRuns
+import com.litus_animae.refitted.ui.compose.charts.bandRuns
 import com.litus_animae.refitted.ui.compose.state.SetHistory
 import com.litus_animae.refitted.ui.compose.util.LoadingView
 import com.litus_animae.refitted.ui.compose.util.Theme
@@ -380,14 +381,25 @@ private fun EffortHistoryCard(
 
   val points = remember(sortedEntries) {
     sortedEntries.map { (sessionIndex, scored) ->
-      EffortPoint(sessionIndex.toFloat(), scored.source.weight.toFloat(), scored.size, scored.zone)
+      EffortPoint(
+        sessionIndex.toFloat(),
+        scored.source.weight.toFloat(),
+        scored.source.reps,
+        scored.zone
+      )
     }
   }
-  val expectedWeightBySession = remember(trend) {
-    trend.associateBy({ it.sessionIndex }, { it.expectedWeight })
+  // Built from the plotted set's own band rather than TrendPoint's session-level, typical-reps
+  // expectation. The dot is drawn at that set's raw weight, so a line placed at the session's
+  // average rep count sits somewhere it never has to agree with - which is how the old chart
+  // managed to draw a GROWTH bubble visibly below its own trend line.
+  val bandRuns = remember(sortedEntries) {
+    sortedEntries.map { it.value }
+      .bandRuns(ExpectationSource.SESSION) { index, _ -> sortedEntries[index].key.toFloat() }
   }
-  val trendRuns = remember(sortedEntries, expectedWeightBySession) {
-    buildTrendRuns(sortedEntries.map { it.key.toFloat() to it.key }, expectedWeightBySession)
+  val repRange = remember(sortedEntries) {
+    val reps = sortedEntries.map { it.value.source.reps }
+    if (reps.isEmpty()) null else reps.min()..reps.max()
   }
   val gapMarks = remember(sortedEntries) {
     sortedEntries.zipWithNext().mapNotNull { (a, b) ->
@@ -436,7 +448,7 @@ private fun EffortHistoryCard(
           .fillMaxWidth()
           .weight(1f),
         points = points,
-        trend = trendRuns,
+        bands = bandRuns,
         xLabels = xLabels,
         yLabels = yLabels,
         gapMarks = gapMarks
@@ -460,7 +472,8 @@ private fun EffortHistoryCard(
         EffortLegend(
           Modifier
             .fillMaxWidth()
-            .padding(top = 4.dp)
+            .padding(top = 4.dp),
+          repRange = repRange
         )
       }
     }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/ExerciseSetView.kt
@@ -281,6 +281,10 @@ fun ColumnScope.ExerciseSetView(
                   .fillMaxWidth()
                   .height(stripHeight ?: StripPreferredHeight),
                 merged = trend?.sets.orEmpty(),
+                // reps(numCompleted) rather than the bare field, so a sequenced scheme aims at
+                // the rep count this particular set is asking for.
+                targetReps = exerciseSet.reps(numCompleted),
+                targetRepsHigh = exerciseSet.reps(numCompleted) + exerciseSet.repsRange,
                 onClick = onOpenHistory
               )
             }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
@@ -40,11 +40,11 @@ import com.litus_animae.refitted.data.models.SetRecord
 import com.litus_animae.refitted.ui.R
 import com.litus_animae.refitted.ui.compose.charts.EffortChart
 import com.litus_animae.refitted.ui.compose.charts.EffortPoint
-import com.litus_animae.refitted.ui.compose.charts.buildTrendRuns
-import com.litus_animae.refitted.ui.compose.charts.zoneColor
+import com.litus_animae.refitted.ui.compose.charts.bandRuns
+import com.litus_animae.refitted.ui.compose.charts.sizeStepDot
+import com.litus_animae.refitted.ui.compose.charts.sizeStepOf
 import com.litus_animae.refitted.ui.compose.charts.zoneLabelRes
 import com.litus_animae.refitted.ui.compose.exercise.exampleExerciseSet
-import com.litus_animae.refitted.ui.compose.util.Theme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
@@ -128,7 +128,7 @@ fun SetTrendStrip(
         EffortPoint(
           index.toFloat(),
           scored.source.weight.toFloat(),
-          scored.size,
+          scored.source.reps,
           scored.zone,
           emphasized = index == windowed.lastIndex
         )
@@ -147,36 +147,20 @@ fun SetTrendStrip(
       val maxWeight = points.maxOf { it.weight }
       listOf(minWeight, maxWeight).distinct().map { it to it.roundToInt().toString() }
     }
-    // Split by source rather than text-labeling the two - EffortChart draws dashedTrend
-    // beneath trend, so the dash itself is the only signal a segment is the coarser,
+    // Split by source rather than text-labeling the two - EffortChart draws the dashed band
+    // beneath the solid one, so the dash itself is the only signal a segment is the coarser,
     // strip-only stand-in rather than the real session-based fit.
     //
-    // Built from each set's own expectedWeight rather than a per-session lookup: the bootstrap
-    // fit runs at set granularity, so its expectation genuinely moves set to set, and keying
-    // off sessionIndex would flatten that into one step per day.
-    val realTrend = remember(windowed) {
-      buildTrendRuns(
-        windowed.mapIndexed { index, scored ->
-          index.toFloat() to scored.expectedWeight.takeIf {
-            scored.expectationSource == ExpectationSource.SESSION
-          }
-        }
-      )
-    }
-    val bootstrapTrend = remember(windowed) {
-      buildTrendRuns(
-        windowed.mapIndexed { index, scored ->
-          index.toFloat() to scored.expectedWeight.takeIf {
-            scored.expectationSource == ExpectationSource.BOOTSTRAP
-          }
-        }
-      )
-    }
+    // Keyed off each set rather than its session: the bootstrap fit runs at set granularity, so
+    // its band genuinely moves set to set, and keying off sessionIndex would flatten that into
+    // one step per day.
+    val realBands = remember(windowed) { windowed.bandRuns(ExpectationSource.SESSION) }
+    val bootstrapBands = remember(windowed) { windowed.bandRuns(ExpectationSource.BOOTSTRAP) }
 
     Card(Modifier.fillMaxSize().clickable(onClick = onClick), elevation = 2.dp) {
       Column(Modifier.fillMaxSize()) {
-        // Doubles as the chart's only legend: it names the color of the bubble the user
-        // just earned, in the moment they earn it, rather than a static key for all five.
+        // Doubles as the chart's only legend: it names where the bubble the user just earned
+        // landed, in the moment they earn it, rather than a static key for every state.
         Row(
           Modifier
             .fillMaxWidth()
@@ -206,17 +190,13 @@ fun SetTrendStrip(
                 color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
               )
             } else {
+              // Sized, not coloured: colour means reps on the chart below, so a coloured key
+              // here would name the wrong channel. The dot matches the bubble it describes.
               Box(
                 Modifier
-                  .size(8.dp)
+                  .size(sizeStepDot(sizeStepOf(latestZone)))
                   .background(
-                    zoneColor(
-                      latestZone,
-                      MaterialTheme.colors.primary,
-                      Theme.goodAttention,
-                      Theme.timerAmber,
-                      MaterialTheme.colors.onSurface.copy(alpha = 0.25f)
-                    ),
+                    MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
                     CircleShape
                   )
               )
@@ -230,8 +210,8 @@ fun SetTrendStrip(
             .fillMaxWidth()
             .weight(1f),
           points = points,
-          trend = realTrend,
-          dashedTrend = bootstrapTrend,
+          bands = realBands,
+          dashedBands = bootstrapBands,
           yLabels = yLabels,
           gapMarks = sessionGapMarks,
           compact = true

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
@@ -41,6 +41,7 @@ import com.litus_animae.refitted.ui.R
 import com.litus_animae.refitted.ui.compose.charts.EffortChart
 import com.litus_animae.refitted.ui.compose.charts.EffortPoint
 import com.litus_animae.refitted.ui.compose.charts.bandRuns
+import com.litus_animae.refitted.ui.compose.charts.forwardBandAt
 import com.litus_animae.refitted.ui.compose.charts.sizeStepDot
 import com.litus_animae.refitted.ui.compose.charts.sizeStepOf
 import com.litus_animae.refitted.ui.compose.charts.zoneLabelRes
@@ -55,7 +56,9 @@ import java.time.ZoneId
 import kotlin.math.roundToInt
 
 private val MinSlotWidth = 20.dp
-private const val MIN_WINDOW = 5
+// One higher than it used to be: the last slot now belongs to the set about to be done, and the
+// floor is about how much history stays readable, not how many slots exist.
+private const val MIN_WINDOW = 6
 private const val MAX_WINDOW = 14
 
 /**
@@ -104,6 +107,8 @@ fun rememberEffortSets(
 fun SetTrendStrip(
   modifier: Modifier = Modifier,
   merged: List<EffortSet>,
+  targetReps: Int? = null,
+  targetRepsHigh: Int? = null,
   onClick: () -> Unit = {}
 ) {
   BoxWithConstraints(modifier) {
@@ -120,7 +125,12 @@ fun SetTrendStrip(
     // all-COLD regardless of its own set count (no prior session exists yet to bootstrap
     // from).
     val series = remember(merged) { EffortModel.scoreWithBootstrap(merged) }
-    val windowed = remember(series, window) { series.sets.takeLast(window) }
+    // The set the user is about to do is worth more than the oldest one still on screen, and
+    // takeLast drops exactly that one. The whole history is a tap away in the drawer.
+    val forwardSlots = if (targetReps == null) 0 else 1
+    val windowed = remember(series, window, forwardSlots) {
+      series.sets.takeLast(window - forwardSlots)
+    }
     if (windowed.isEmpty()) return@BoxWithConstraints
 
     val points = remember(windowed) {
@@ -156,6 +166,23 @@ fun SetTrendStrip(
     // one step per day.
     val realBands = remember(windowed) { windowed.bandRuns(ExpectationSource.SESSION) }
     val bootstrapBands = remember(windowed) { windowed.bandRuns(ExpectationSource.BOOTSTRAP) }
+    // Its own run, so it is never joined to the history by a line implying a set happened
+    // between them. Rendered at the prescribed reps rather than at whatever the last set took.
+    val forwardBand = remember(windowed, targetReps, targetRepsHigh) {
+      if (targetReps == null) {
+        emptyList()
+      } else {
+        listOfNotNull(
+          windowed.last()
+            .forwardBandAt(
+              x = windowed.size.toFloat(),
+              targetReps = targetReps,
+              targetRepsHigh = targetRepsHigh ?: targetReps
+            )
+            ?.let(::listOf)
+        )
+      }
+    }
 
     Card(Modifier.fillMaxSize().clickable(onClick = onClick), elevation = 2.dp) {
       Column(Modifier.fillMaxSize()) {
@@ -210,7 +237,7 @@ fun SetTrendStrip(
             .fillMaxWidth()
             .weight(1f),
           points = points,
-          bands = realBands,
+          bands = realBands + forwardBand,
           dashedBands = bootstrapBands,
           yLabels = yLabels,
           gapMarks = sessionGapMarks,
@@ -271,7 +298,22 @@ private fun PreviewSetTrendStripRealTrend() {
   SetTrendStrip(
     Modifier.width(300.dp).height(88.dp),
     merged = previewSets(daysAgo = (0L..9L).map { it * 3 }.reversed(), setsPerDay = 3)
-      .map { it.toEffortSet() }
+      .map { it.toEffortSet() },
+    targetReps = 8,
+    targetRepsHigh = 10
+  )
+}
+
+/** The narrow case: MIN_WINDOW slots, one of them spent on the target for the next set. */
+@Preview
+@Composable
+private fun PreviewSetTrendStripNarrowWithTarget() {
+  SetTrendStrip(
+    Modifier.width(140.dp).height(88.dp),
+    merged = previewSets(daysAgo = (0L..9L).map { it * 3 }.reversed(), setsPerDay = 3)
+      .map { it.toEffortSet() },
+    targetReps = 10,
+    targetRepsHigh = 12
   )
 }
 

--- a/ui/src/main/res/values/changelog.xml
+++ b/ui/src/main/res/values/changelog.xml
@@ -3,6 +3,7 @@
     <string name="changelog_version_header">**</string>
     <string-array name="changelog">
         <item>**v1.4.2</item>
+        <item>Effort chart learns how often you train each exercise, so alternating between two of them no longer looks like time off</item>
         <item>Effort chart no longer flags your first session back after a long break as an outlier</item>
         <item>**v1.4.1</item>
         <item>Give any exercise in a custom workout an alternate, then swap between them as you train</item>

--- a/ui/src/main/res/values/changelog.xml
+++ b/ui/src/main/res/values/changelog.xml
@@ -3,6 +3,9 @@
     <string name="changelog_version_header">**</string>
     <string-array name="changelog">
         <item>**v1.4.2</item>
+        <item>The effort strip now shows the weight to aim for on your next set, at the reps your workout asks for</item>
+        <item>Effort chart draws the range your trend expects instead of a bare line, with bubble colour showing reps</item>
+        <item>Bodyweight exercises track properly: adding your first plate reads as progress, not an anomaly</item>
         <item>Effort chart learns how often you train each exercise, so alternating between two of them no longer looks like time off</item>
         <item>Coming back from a long break no longer reads as an outlier, and the effort chart keeps predicting your progress as you rebuild</item>
         <item>**v1.4.1</item>

--- a/ui/src/main/res/values/changelog.xml
+++ b/ui/src/main/res/values/changelog.xml
@@ -4,7 +4,7 @@
     <string-array name="changelog">
         <item>**v1.4.2</item>
         <item>Effort chart learns how often you train each exercise, so alternating between two of them no longer looks like time off</item>
-        <item>Effort chart no longer flags your first session back after a long break as an outlier</item>
+        <item>Coming back from a long break no longer reads as an outlier, and the effort chart keeps predicting your progress as you rebuild</item>
         <item>**v1.4.1</item>
         <item>Give any exercise in a custom workout an alternate, then swap between them as you train</item>
         <item>Rename or delete your custom plans, from the workout list or the calendar menu</item>

--- a/ui/src/main/res/values/changelog.xml
+++ b/ui/src/main/res/values/changelog.xml
@@ -3,6 +3,7 @@
     <string name="changelog_version_header">**</string>
     <string-array name="changelog">
         <item>**v1.4.2</item>
+        <item>Effort chart no longer flags your first session back after a long break as an outlier</item>
         <item>**v1.4.1</item>
         <item>Give any exercise in a custom workout an alternate, then swap between them as you train</item>
         <item>Rename or delete your custom plans, from the workout list or the calendar menu</item>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -50,7 +50,12 @@
     <string name="reps_label">Reps</string>
     <string name="doubled_label">Barbell\nMode?</string>
     <string name="effort_label">Effort</string>
-    <string name="effort_chart_subtitle">Bubble size = effort vs. your trend</string>
+    <string name="effort_chart_subtitle">Band = what your trend expects · colour = reps</string>
+    <string name="effort_step_under">Under</string>
+    <string name="effort_step_on">On track</string>
+    <string name="effort_step_over">Over</string>
+    <string name="effort_reps_low">%1$d reps</string>
+    <string name="effort_reps_high">%1$d</string>
     <string name="effort_zone_cold">New</string>
     <string name="effort_zone_below">Below trend</string>
     <string name="effort_zone_on_curve">On curve</string>


### PR DESCRIPTION
Started from one bug — a first session back after a two-year gap was flagged `IMPLAUSIBLE`, rendered amber and shrunk to the "probably a typo" bubble size. Digging into it turned up a family of related defects rather than a single mistake, several of which were actively working against what the chart is for.

The stated purpose is **to surface non-progression without punishing the fact that the gap between identical sets is hard to predict** — alternating pull-ups and pull-downs week to week must not penalise either. The chart was doing close to the opposite.

## Three root defects

**The layoff model was a blind guess applied to the wrong things.** The grace period was a flat 10 calendar days, so any exercise on a slower rotation sat permanently in "detrained". The lowered bar meant a *flat plateau* on a 14- or 28-day rotation scored **GROWTH on every set** — zero progress reported as growth. Separately, the level was inferred from elapsed time and never checked against where the lifter actually landed, and the dead gap stayed in the regression's x-domain acting as a lever arm, so the fitted slope **inverted** after a comeback and stayed negative for ~10 sessions while the lifter gained every session.

**The chart's y-axis and the model's space were never reconciled.** The trend line was drawn at the fit's session-wide *typical* reps while dots sat at raw weight, so any set with off-average reps was misplaced against its own line — a 120×12 set rendered 7.7 lb *below* the line that scored it `GROWTH`. Rep count was invisible entirely (100×6 and 100×20 plot at the same point despite 22.6% different capacity), and so was uncertainty.

**Bubble size carried no information.** The whole GROWTH zone spanned ~1dp of diameter while ON_CURVE spanned 5dp — more variation *within* a zone than *between* them — and it wasn't monotonic, so one diameter meant either "well under" or "implausibly over" with only colour to disambiguate.

## Reviewing this

Nine commits, each self-contained and buildable. The first six are `:data` only and change no UI.

| commit | |
|---|---|
| `ab3d317` | Charge the detrain haircut as uncertainty instead of letting it narrow the band |
| `bf48efc` | Scale the detrain grace to how often the exercise is actually trained |
| `005fc2d` | Carry the pace across a layoff and re-anchor it to where you land |
| `3d20a43` | Express a set's expected weight on its own reps and rest |
| `4c851d4` | Give unloadable movements a baseline load to add weight to |
| `de36340` | Recalibrate a comeback session from the sets that land in it |
| `96ce711` | Draw the expectation as a band; stop encoding effort twice |
| `b3663c0` | Drop the bubble-size hump the chart no longer reads |
| `f8aabbc` | Spend a strip slot on the set the user is about to do |

`005fc2d` is the one to read closely. Its two halves are atomic — sliding x without re-levelling parks the old, higher block immediately beside a lower comeback and fits a cliff through them, which is worse than leaving the gap alone.

## What the numbers do now

- Two-year comeback: z **+6.00 (clamped) → ON_CURVE**
- Flat plateau on a 14/28-day rotation: **GROWTH → ON_CURVE**
- Identical per-exposure progress from a 3-day to a 28-day cadence: band was 5% → 28.7% of expectation, now a **flat 5.0%** throughout
- Rebuild slope after a layoff: **−0.060 → +0.679 capacity/day** against a true +0.667, never inverting
- First plate added to bodyweight work: **5× capacity jump → ~5%**, no longer IMPLAUSIBLE
- Bodyweight trend line: pinned at ~1.0 lb regardless of progress → climbs **−3.54 → 0.00 → +1.22**, so the band comes up to meet the first loadable increment

`:data` tests go 76 → 114. Every claim above has one behind it.

## Encoding

One meaning per channel, nothing encoded twice:

| channel | carries |
|---|---|
| vertical position | weight |
| size | three discrete steps — under / on / over |
| colour | sequential single-hue ramp on rep count |
| band | the zone thresholds, so position *is* zone |

The ramp starts at Blue 500 because every step has to clear 3:1 against this app's white chart surface and Blue 400 only manages 2.65:1; the range runs 3.12:1 to 8.63:1, monotonic in lightness.

## Verification beyond CI

Not covered by the build — worth a look on a device:

- Open an exercise with a long gap in its history (Lat Pulldown is the original case). The comeback session should not be amber, and the band should visibly **flare** across the gap, then tighten as sets land.
- A bodyweight exercise: dots sit at 0 while the centre line climbs from below the axis toward the first plate.
- The strip's last slot is the *next* set's target, drawn as an upright bar at the prescribed reps — check it reads as a target rather than as a logged set.
- Narrow layouts, where the strip is at `MIN_WINDOW` and the target slot costs a history bubble.

I could not run `assembleDebug` locally — `google-services.json` is a CI secret — so `:ui` was built and linted directly instead. The chart has been through Compose previews (post-layoff flare, bodyweight climb, bootstrap handoff, narrow strip) but not real rendering.

## Deliberately left out

- **No separate stall detector.** Once a plateau stops reading GROWTH, a flat centre line inside a band *is* the signal; a badge would be a second mechanism for the same thing, with false-positive risk on deloads and rebuilds. `slope` stays unexposed pending a look at real charts.
- **`IMPLAUSIBLE` folds into the "over" size step** rather than keeping its own amber, since colour now means reps. With the band no longer narrowing after a layoff it should be rare and mean "typo" — but it currently looks identical to a good set, which may want revisiting.
- **The bodyweight baseline is a single constant (100 lb),** not a per-movement table or a stored bodyweight. It largely cancels out of z; what it sets is how a rep trades against a pound (~3.3 lb per rep at 10 reps), which is what decides when loading beats another rep.
- **Erratic cadence still flickers.** The cadence fix handles regular-but-slow rotations; genuinely irregular scheduling still moves z around, and that residual is the day-offset extrapolation rather than detraining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8mxaUY76DXJMD4LrkhK7r

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8mxaUY76DXJMD4LrkhK7r)_