### PR TITLE
Keep Connect IQ SDK classes from R8 obfuscation

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -40,3 +40,7 @@
 -dontwarn org.codehaus.jackson.**
 -dontwarn org.apache.commons.logging.impl.**
 -dontwarn org.apache.http.conn.scheme.**
+
+# Connect IQ Mobile SDK — Parcelables (IQDevice, IQApp, etc.) are unmarshalled by literal
+# class name from broadcasts sent by Garmin Connect Mobile, an unobfuscated external process.
+-keep class com.garmin.android.connectiq.** { *; }


### PR DESCRIPTION
## Summary

- Fixes a release-only crash: `BadParcelableException` / `ClassNotFoundException: com.garmin.android.connectiq.IQDevice` in `IQMessageReceiver.onReceive`
- `app/proguard-rules.pro` had no `-keep` rule for the Connect IQ Mobile SDK, so R8 was free to rename/strip `IQDevice` and friends in release builds
- `IQMessageReceiver` unmarshals broadcast `Intent` extras that were written by an external, unobfuscated process (Garmin Connect Mobile), which embeds the literal class name `com.garmin.android.connectiq.IQDevice` in the `Parcel`. Once R8 renames that class in our dex, `Class.forName(...)` on the receiving side fails with exactly this crash.

## Fix

Added a `-keep class com.garmin.android.connectiq.** { *; }` rule to `app/proguard-rules.pro`.

## Test plan

- Manual: verify a release/minified build can still send/receive watch messages against a paired device without the SDK's Parcelable classes being obfuscated (can be spot-checked by inspecting the minified dex/mapping file for `com.garmin.android.connectiq.IQDevice`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XFMwid3hkF6QCwEt63oKWD)_