### PR TITLE
Fix Garmin SDK re-init and listener leak found in PR #1909 review

### DIFF
--- a/garmin/CLAUDE.md
+++ b/garmin/CLAUDE.md
@@ -27,9 +27,12 @@ service; this module never touches `BluetoothAdapter` directly.
   (`VmPolicy.detectLeakedClosableObjects().penaltyDeath()`), so this pairing must stay exact.
 - `GarminWatchService.kt` - Implements `WatchService`. Maps every `InvalidStateException` /
   `ServiceUnavailableException` at the boundary onto `WatchState.NoDevice` / `WatchState.Unsupported`
-  - these must never escape into `:ui`, which has no way to name them. Registers
+  - these must never escape into `:ui`, which has no way to name them. `refresh()` unregisters the
+  previously known device's listeners before registering
   `ConnectIQ.registerForAppEvents(IQDevice, IQApp, IQApplicationEventListener)` alongside device
-  events once a device is known; incoming messages are decoded via `WatchProtocol.decode` and, for
+  events for the current one - this service is `@Singleton` but `refresh()` runs once per
+  `ExerciseViewModel` init (scoped per nav destination), so skipping the unregister would pile up
+  listeners on repeated navigation. Incoming messages are decoded via `WatchProtocol.decode` and, for
   `SetDone`, resolved against the session's `WatchSessionState` (`toSetRecord`) and written through
   `SetRecordSink` on a service-owned `CoroutineScope` - this class is `@Singleton`, so it can't rely
   on a caller's scope living as long as an incoming message might arrive. `SessionEnded` (sent once

--- a/garmin/CLAUDE.md
+++ b/garmin/CLAUDE.md
@@ -21,7 +21,9 @@ service; this module never touches `BluetoothAdapter` directly.
 
 - `GarminConnection.kt` - `@Singleton`, `DefaultLifecycleObserver` hooked to
   `ProcessLifecycleOwner` in `RefittedApplication`. Initializes on first `onStart`, shuts down on
-  `onStop` only when no session is active. Debug builds hard-crash on a leaked SDK binding
+  `onStop` only when no session is active, and skips re-initializing on a later `onStart` while
+  already ready (`sdkReady` can still be `true` from a prior session-active `onStop` that skipped
+  shutdown). Debug builds hard-crash on a leaked SDK binding
   (`VmPolicy.detectLeakedClosableObjects().penaltyDeath()`), so this pairing must stay exact.
 - `GarminWatchService.kt` - Implements `WatchService`. Maps every `InvalidStateException` /
   `ServiceUnavailableException` at the boundary onto `WatchState.NoDevice` / `WatchState.Unsupported`

--- a/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminConnection.kt
+++ b/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminConnection.kt
@@ -32,6 +32,10 @@ class GarminConnection @Inject constructor(
   }
 
   override fun onStart(owner: LifecycleOwner) {
+    // onStop skips shutdown() while sessionActive, leaving sdkReady true across that
+    // background/foreground cycle - re-initializing an already-bound SDK here is what the
+    // leaked-binding VmPolicy death penalty (see class doc) actually catches.
+    if (sdkReady) return
     connectIQ.initialize(context, false, object : ConnectIQ.ConnectIQListener {
       override fun onSdkReady() {
         sdkReady = true

--- a/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminWatchService.kt
+++ b/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminWatchService.kt
@@ -67,6 +67,10 @@ class GarminWatchService @Inject constructor(
     try {
       val connectIQ = connection.connectIQ
       val knownDevice = connectIQ.knownDevices.orEmpty().firstOrNull()
+      // ExerciseViewModel (scoped per nav destination) calls this on every init, but this
+      // service is a @Singleton - unregister a prior device's listeners first, or repeated
+      // navigation piles up registrations and every incoming message gets handled N times.
+      unregisterDeviceListeners(connectIQ)
       device = knownDevice
       _state.value = if (knownDevice == null) {
         WatchState.NoDevice
@@ -83,6 +87,12 @@ class GarminWatchService @Inject constructor(
     } catch (e: ServiceUnavailableException) {
       _state.value = WatchState.Unsupported
     }
+  }
+
+  private fun unregisterDeviceListeners(connectIQ: ConnectIQ) {
+    val previousDevice = device ?: return
+    runCatching { connectIQ.unregisterForDeviceEvents(previousDevice) }
+    runCatching { connectIQ.unregisterForApplicationEvents(previousDevice, watchApp) }
   }
 
   override suspend fun startSession(plan: WatchPlan): Result<Unit> {


### PR DESCRIPTION
## Summary

Follow-up to the Claude Code review findings on #1909 ([comment](https://github.com/jeubank12/refitted/pull/1909#issuecomment-5261437827)), addressed post-merge per the owner's "holding off until next release" note there.

- `GarminConnection.onStart` now skips re-initializing the Connect IQ SDK when it's already ready, since `onStop` deliberately leaves `sdkReady == true` across a background/foreground cycle that happens mid-session (to avoid tearing the SDK down while a watch session is active). Without the guard, a second `initialize()` call on an already-bound SDK risks the leaked-binding `VmPolicy` death penalty debug builds enable.
- `GarminWatchService.refresh()` now unregisters the previously known device's listeners (`unregisterForDeviceEvents`/`unregisterForApplicationEvents`) before re-registering. `GarminWatchService` is a `@Singleton`, but `refresh()` runs on every `ExerciseViewModel` init (scoped per nav destination), so repeated navigation was piling up device/app-event registrations with no matching unregister - each incoming watch message would eventually be handled once per accumulated registration.

Both fixes are documented in `garmin/CLAUDE.md`.

## Test plan

- [ ] On a paired watch, background the app mid-workout (e.g. answer a call) and foreground it again, then confirm no crash/leak and the session still syncs correctly
- [ ] Navigate away from and back to the exercise screen a few times during an active watch session, then confirm a single `SET_DONE` from the watch only persists/ACKs once (not once per revisit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7Cbd6mQGHv5GZdA41Hzk4)_