### PR TITLE
watch: refuse new set once exercise's sets are all completed

### DIFF
--- a/connectiq/source/ActiveWorkout.mc
+++ b/connectiq/source/ActiveWorkout.mc
@@ -243,8 +243,15 @@ class ActiveWorkoutDelegate extends WatchUi.InputDelegate {
         // WORK -> (adjust picker) -> REST opens the confirm screen for the set in progress.
         if (key == WatchUi.KEY_ESC || key == WatchUi.KEY_LAP) {
             if (view.state == ActiveWorkoutView.REST) {
-                view.enterWork();
-                WatchUi.requestUpdate();
+                // sets == -1 is the open/challenge set (AMRAP) - no cap, always allowed. Otherwise
+                // once completedSets reaches the planned count there's nothing left to log for this
+                // exercise, so REST -> WORK is refused rather than starting an extra set.
+                var exercise = plan.exercises[view.currentIndex];
+                var setsRemaining = exercise.sets == -1 || view.completedSets[view.currentIndex] < exercise.sets;
+                if (setsRemaining) {
+                    view.enterWork();
+                    WatchUi.requestUpdate();
+                }
             } else {
                 onCompleteSet();
             }


### PR DESCRIPTION
## Summary
- `ActiveWorkoutDelegate.onKey`'s REST -> WORK transition (the LAP/BACK button, which starts the timer for a new set) now checks `completedSets[currentIndex]` against `exercise.sets` before starting a new set.
- AMRAP/challenge exercises (`sets == -1`) are unaffected — they have no cap, matching the existing convention used elsewhere in `ActiveWorkout.mc` and `WatchProtocol.mc`.
- Once all planned sets are logged for an exercise, pressing LAP is now a no-op instead of letting you record an extra, unplanned set.

## Test plan
- `connectiq/` has no CI job and no test infrastructure (Monkey C, deliberately outside the Gradle build — see `connectiq/CLAUDE.md`). No SDK was available in this environment to compile-verify; the change is a small, self-contained conditional using data already tracked on the view (`completedSets`, `plan.exercises[...].sets`).
- Manual verification on-device/simulator: page to an exercise, complete all of its planned sets, then confirm pressing LAP/BACK no longer starts a new WORK-state set (screen stays in REST).


---
_Generated by [Claude Code](https://claude.ai/code/session_013w51jq8px8xauwnzP5DjHY)_