### PR TITLE
Let a logged set be edited or deleted from the history drawer

### DIFF
--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepository.kt
@@ -198,6 +198,20 @@ class RoomCacheExerciseRepository @Inject constructor(
     log.d(TAG, "stored set record")
   }
 
+  // Called directly on the DAO rather than through setRecordSink, which is deliberately
+  // create-only (OnConflictStrategy.IGNORE) to keep watch-buffer replay from :garmin idempotent.
+  override suspend fun updateSetRecord(exercise: String, completed: Instant, weight: Double, reps: Int) {
+    withContext(Dispatchers.IO) {
+      refittedRoom.getExerciseDao().updateSetRecord(exercise, completed, weight, reps)
+    }
+  }
+
+  override suspend fun deleteSetRecord(exercise: String, completed: Instant) {
+    withContext(Dispatchers.IO) {
+      refittedRoom.getExerciseDao().deleteSetRecord(exercise, completed)
+    }
+  }
+
   override fun loadWorkoutRecords(workoutId: String) {
     currentWorkout.value = workoutId
   }

--- a/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
+++ b/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheExerciseRepositoryTest.kt
@@ -382,6 +382,41 @@ class RoomCacheExerciseRepositoryTest {
   }
 
   @Nested
+  @DisplayName("updateSetRecord")
+  inner class UpdateSetRecord {
+    @Test
+    fun `delegates to the DAO, not SetRecordSink`() = runTest {
+      // Given
+      val completed = Instant.now()
+      coEvery { exerciseDao.updateSetRecord("Chest_Bench Press", completed, 120.0, 8) } returns Unit
+
+      // When
+      subject.updateSetRecord("Chest_Bench Press", completed, 120.0, 8)
+
+      // Then
+      coVerify { exerciseDao.updateSetRecord("Chest_Bench Press", completed, 120.0, 8) }
+      coVerify(exactly = 0) { setRecordSink.store(any()) }
+    }
+  }
+
+  @Nested
+  @DisplayName("deleteSetRecord")
+  inner class DeleteSetRecord {
+    @Test
+    fun `delegates to the DAO`() = runTest {
+      // Given
+      val completed = Instant.now()
+      coEvery { exerciseDao.deleteSetRecord("Chest_Bench Press", completed) } returns Unit
+
+      // When
+      subject.deleteSetRecord("Chest_Bench Press", completed)
+
+      // Then
+      coVerify { exerciseDao.deleteSetRecord("Chest_Bench Press", completed) }
+    }
+  }
+
+  @Nested
   @DisplayName("addCustomExercise")
   inner class AddCustomExercise {
     @Test

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/ExerciseRepository.kt
@@ -7,6 +7,7 @@ import com.litus_animae.refitted.data.models.ExerciseSet
 import com.litus_animae.refitted.data.models.SetRecord
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import java.time.Instant
 
 /**
  * Repository interface for exercise-related operations.
@@ -17,6 +18,19 @@ interface ExerciseRepository {
   fun refreshExercises()
   suspend fun storeSetRecord(record: SetRecord)
   fun loadWorkoutRecords(workoutId: String)
+
+  /**
+   * Updates a previously-logged set's [weight] and [reps] in place, keyed by [exercise]/[completed]
+   * - SetRecord's composite identity (see RoomSetRecord's primary key). The completion timestamp
+   * itself is not editable here: it's part of the persisted primary key, and changing it would need
+   * delete+reinsert semantics rather than a plain update. No-op if the record doesn't exist.
+   */
+  suspend fun updateSetRecord(exercise: String, completed: Instant, weight: Double, reps: Int)
+
+  /**
+   * Deletes a single logged set, keyed by [exercise]/[completed]. No-op if the record doesn't exist.
+   */
+  suspend fun deleteSetRecord(exercise: String, completed: Instant)
 
   /**
    * Adds an exercise to a custom plan's day, as an open (no set limit) set. [exerciseId] should

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/ExerciseDao.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/ExerciseDao.kt
@@ -167,6 +167,14 @@ interface ExerciseDao {
   @Query("UPDATE SetRecord SET workout = :newName WHERE workout = :oldName")
   suspend fun renameSetRecordWorkout(oldName: String, newName: String)
 
+  /**
+   * Updates a single set record's weight/reps in place, keyed by its primary key
+   * (exercise, completed). The timestamp itself is never in the SET clause - see
+   * ExerciseRepository.updateSetRecord.
+   */
+  @Query("UPDATE SetRecord SET weight = :weight, reps = :reps WHERE exercise = :exercise AND completed = :completed")
+  suspend fun updateSetRecord(exercise: String, completed: Instant, weight: Double, reps: Int)
+
   @Query("DELETE FROM Exercise WHERE exercise_workout = :name")
   suspend fun deleteExercisesForWorkout(name: String)
 
@@ -175,6 +183,12 @@ interface ExerciseDao {
 
   @Query("DELETE FROM SetRecord WHERE workout = :name")
   suspend fun deleteSetRecordsForWorkout(name: String)
+
+  /**
+   * Deletes a single set record by its primary key (exercise, completed).
+   */
+  @Query("DELETE FROM SetRecord WHERE exercise = :exercise AND completed = :completed")
+  suspend fun deleteSetRecord(exercise: String, completed: Instant)
 
   data class ExerciseCompletionRecord(
     @ColumnInfo(name = "latest_completion") val latestCompletion: Instant,

--- a/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
+++ b/room/src/test/kotlin/com/litus_animae/refitted/data/InMemoryExerciseRepository.kt
@@ -9,6 +9,7 @@ import com.litus_animae.refitted.data.models.SetRecord
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import java.time.Instant
 
 class InMemoryExerciseRepository(
     private val initialExercises: List<ExerciseSet> = emptyList(),
@@ -27,6 +28,14 @@ class InMemoryExerciseRepository(
     }
 
     override suspend fun storeSetRecord(record: SetRecord) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun updateSetRecord(exercise: String, completed: Instant, weight: Double, reps: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteSetRecord(exercise: String, completed: Instant) {
         TODO("Not yet implemented")
     }
 

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/EditSetRecordDialog.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/EditSetRecordDialog.kt
@@ -1,5 +1,7 @@
 package com.litus_animae.refitted.ui.compose.exercise
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -17,17 +19,37 @@ import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.litus_animae.refitted.data.models.SetRecord
 import java.time.Instant
+
+/**
+ * `TextFieldValue` isn't Bundle-storable on its own, so `rememberSaveable` needs an explicit
+ * saver - see EditSetRecordDialog's weight/reps fields, which select-all-on-focus and therefore
+ * must carry [TextFieldValue.selection] through configuration changes alongside the text.
+ */
+private val TextFieldValueSaver = listSaver<TextFieldValue, Any>(
+  save = { listOf(it.text, it.selection.start, it.selection.end) },
+  restore = {
+    TextFieldValue(
+      text = it[0] as String,
+      selection = TextRange(it[1] as Int, it[2] as Int)
+    )
+  }
+)
 
 /**
  * Edits a single logged set's weight/reps in place. The completion timestamp isn't editable -
@@ -47,14 +69,16 @@ fun EditSetRecordDialog(
   // source, so if this dialog's composable slot were ever reused for a different SetRecord,
   // unkeyed state would leak the previous record's in-progress edit into the new one (see
   // ui/CLAUDE.md's Compose Gotchas).
-  var weight by rememberSaveable(record.exercise, record.completed) {
-    mutableStateOf(record.weight.toString())
+  var weight by rememberSaveable(record.exercise, record.completed, stateSaver = TextFieldValueSaver) {
+    mutableStateOf(TextFieldValue(record.weight.toString()))
   }
-  var reps by rememberSaveable(record.exercise, record.completed) {
-    mutableStateOf(record.reps.toString())
+  var reps by rememberSaveable(record.exercise, record.completed, stateSaver = TextFieldValueSaver) {
+    mutableStateOf(TextFieldValue(record.reps.toString()))
   }
-  val parsedWeight = weight.toDoubleOrNull()
-  val parsedReps = reps.toIntOrNull()
+  val parsedWeight = weight.text.replace(",", ".").toDoubleOrNull()
+  val parsedReps = reps.text.toIntOrNull()
+  val isWeightError = parsedWeight == null || parsedWeight < 0
+  val isRepsError = parsedReps == null || parsedReps < 0
 
   AlertDialog(
     onDismissRequest = onDismissRequest,
@@ -62,26 +86,22 @@ fun EditSetRecordDialog(
     title = { Text("Edit Set") },
     text = {
       Column {
-        OutlinedTextField(
+        SelectAllOnFocusField(
           value = weight,
           onValueChange = { weight = it },
           // TODO localize
-          label = { Text("Weight") },
-          singleLine = true,
-          isError = parsedWeight == null,
-          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-          modifier = Modifier.fillMaxWidth()
+          label = "Weight",
+          isError = isWeightError,
+          keyboardType = KeyboardType.Decimal
         )
         Spacer(Modifier.height(8.dp))
-        OutlinedTextField(
+        SelectAllOnFocusField(
           value = reps,
           onValueChange = { reps = it },
           // TODO localize
-          label = { Text("Reps") },
-          singleLine = true,
-          isError = parsedReps == null,
-          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-          modifier = Modifier.fillMaxWidth()
+          label = "Reps",
+          isError = isRepsError,
+          keyboardType = KeyboardType.Number
         )
       }
     },
@@ -104,13 +124,48 @@ fun EditSetRecordDialog(
         Spacer(Modifier.width(8.dp))
         Button(
           onClick = { onSave(parsedWeight ?: record.weight, parsedReps ?: record.reps) },
-          enabled = parsedWeight != null && parsedReps != null
+          enabled = !isWeightError && !isRepsError
         ) {
           // TODO localize
           Text("Save")
         }
       }
     }
+  )
+}
+
+/**
+ * A numeric [OutlinedTextField] that selects its entire value every time it gains focus, so
+ * typing a replacement overwrites rather than requiring the user to delete the old value first.
+ * Setting the selection directly from a focus callback doesn't survive: the same tap that focuses
+ * the field also drives BasicTextField's own tap-to-place-cursor `onValueChange`, which fires
+ * after and overwrites the selection we set. Applying it from [LaunchedEffect] instead means it
+ * runs as a coroutine dispatched after that frame's composition, so it lands after the tap's own
+ * update rather than racing it - and re-fires on every focus/blur cycle since it's keyed directly
+ * off `isFocused`, not a manually consumed one-shot flag.
+ */
+@Composable
+private fun SelectAllOnFocusField(
+  value: TextFieldValue,
+  onValueChange: (TextFieldValue) -> Unit,
+  label: String,
+  isError: Boolean,
+  keyboardType: KeyboardType
+) {
+  val interactionSource = remember { MutableInteractionSource() }
+  val isFocused by interactionSource.collectIsFocusedAsState()
+  LaunchedEffect(isFocused) {
+    if (isFocused) onValueChange(value.copy(selection = TextRange(0, value.text.length)))
+  }
+  OutlinedTextField(
+    value = value,
+    onValueChange = onValueChange,
+    label = { Text(label) },
+    singleLine = true,
+    isError = isError,
+    keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+    interactionSource = interactionSource,
+    modifier = Modifier.fillMaxWidth()
   )
 }
 

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/EditSetRecordDialog.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/EditSetRecordDialog.kt
@@ -1,0 +1,195 @@
+package com.litus_animae.refitted.ui.compose.exercise
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.litus_animae.refitted.data.models.SetRecord
+import java.time.Instant
+
+/**
+ * Edits a single logged set's weight/reps in place. The completion timestamp isn't editable -
+ * it's part of SetRecord's persisted identity (see ExerciseRepository.updateSetRecord) - so
+ * [record] only supplies starting values and the key carried through [onSave]/[onDelete]. Delete
+ * only opens [DeleteSetRecordConfirmDialog] via [onDelete], matching CustomPlanDialogs.kt's
+ * RenamePlanDialog rule that a destructive action never fires directly from the edit form.
+ */
+@Composable
+fun EditSetRecordDialog(
+  record: SetRecord,
+  onDismissRequest: () -> Unit,
+  onSave: (weight: Double, reps: Int) -> Unit,
+  onDelete: () -> Unit
+) {
+  // Keyed on the record's identity (exercise + completed) - these rows come from a Paging
+  // source, so if this dialog's composable slot were ever reused for a different SetRecord,
+  // unkeyed state would leak the previous record's in-progress edit into the new one (see
+  // ui/CLAUDE.md's Compose Gotchas).
+  var weight by rememberSaveable(record.exercise, record.completed) {
+    mutableStateOf(record.weight.toString())
+  }
+  var reps by rememberSaveable(record.exercise, record.completed) {
+    mutableStateOf(record.reps.toString())
+  }
+  val parsedWeight = weight.toDoubleOrNull()
+  val parsedReps = reps.toIntOrNull()
+
+  AlertDialog(
+    onDismissRequest = onDismissRequest,
+    // TODO localize
+    title = { Text("Edit Set") },
+    text = {
+      Column {
+        OutlinedTextField(
+          value = weight,
+          onValueChange = { weight = it },
+          // TODO localize
+          label = { Text("Weight") },
+          singleLine = true,
+          isError = parsedWeight == null,
+          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+          modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+          value = reps,
+          onValueChange = { reps = it },
+          // TODO localize
+          label = { Text("Reps") },
+          singleLine = true,
+          isError = parsedReps == null,
+          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+          modifier = Modifier.fillMaxWidth()
+        )
+      }
+    },
+    buttons = {
+      Row(
+        Modifier
+          .fillMaxWidth()
+          .padding(horizontal = 8.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+      ) {
+        TextButton(
+          onClick = onDelete,
+          colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colors.error)
+        ) {
+          // TODO localize
+          Text("Delete")
+        }
+        Spacer(Modifier.weight(1f))
+        DialogCancelButton(onDismissRequest)
+        Spacer(Modifier.width(8.dp))
+        Button(
+          onClick = { onSave(parsedWeight ?: record.weight, parsedReps ?: record.reps) },
+          enabled = parsedWeight != null && parsedReps != null
+        ) {
+          // TODO localize
+          Text("Save")
+        }
+      }
+    }
+  )
+}
+
+/**
+ * Confirms deletion of a single logged set - mirrors CustomPlanDialogs.kt's
+ * DeletePlanConfirmDialog: deletion is irreversible, so it gets its own explicit step and an
+ * error-colored confirm rather than the usual primary.
+ */
+@Composable
+fun DeleteSetRecordConfirmDialog(
+  onDismissRequest: () -> Unit,
+  onConfirm: () -> Unit
+) {
+  AlertDialog(
+    onDismissRequest = onDismissRequest,
+    // TODO localize
+    title = { Text("Delete Set") },
+    text = {
+      // TODO localize
+      Text("This permanently removes this set from your history. This cannot be undone.")
+    },
+    confirmButton = {
+      Button(
+        onClick = onConfirm,
+        colors = ButtonDefaults.buttonColors(
+          backgroundColor = MaterialTheme.colors.error,
+          contentColor = MaterialTheme.colors.onError
+        )
+      ) {
+        // TODO localize
+        Text("Delete")
+      }
+    },
+    dismissButton = { DialogCancelButton(onDismissRequest) }
+  )
+}
+
+/**
+ * Cancel/dismiss control for the set-record dialogs - low-emphasis by design, so it doesn't
+ * compete with the affirmative (or destructive) action next to it. Same shape as
+ * CustomPlanDialogs.kt's private DialogCancelButton.
+ */
+@Composable
+private fun DialogCancelButton(onClick: () -> Unit) {
+  TextButton(
+    onClick = onClick,
+    colors = ButtonDefaults.textButtonColors(
+      contentColor = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+    )
+  ) {
+    // TODO localize
+    Text("Cancel")
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewEditSetRecordDialog() {
+  MaterialTheme {
+    EditSetRecordDialog(
+      record = SetRecord(
+        weight = 120.0,
+        reps = 8,
+        workout = "TestWorkout",
+        targetSet = "1.1",
+        completed = Instant.now(),
+        exercise = "Chest_Bench Press"
+      ),
+      onDismissRequest = {},
+      onSave = { _, _ -> },
+      onDelete = {}
+    )
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewDeleteSetRecordConfirmDialog() {
+  MaterialTheme {
+    DeleteSetRecordConfirmDialog(onDismissRequest = {}, onConfirm = {})
+  }
+}

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/Main.kt
@@ -160,7 +160,13 @@ fun Exercise(
       }
     },
     scaffoldState = scaffoldState,
-    drawerContent = { SetRecordList(history = historyList) }
+    drawerContent = {
+      SetRecordList(
+        history = historyList,
+        onUpdateRecord = exerciseModel::updateSetRecord,
+        onDeleteRecord = exerciseModel::deleteSetRecord
+      )
+    }
   ) {
     var sheetWeight by remember { mutableStateOf(Weight(0.0)) }
     ModalBottomSheetLayout(

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -32,6 +33,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.contentColorFor
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Refresh
@@ -88,10 +90,18 @@ private const val MaxXLabels = 4
 @Composable
 fun SetRecordList(
   modifier: Modifier = Modifier,
-  history: SetHistory
+  history: SetHistory,
+  onUpdateRecord: (exercise: String, completed: Instant, weight: Double, reps: Int) -> Unit = { _, _, _, _ -> },
+  onDeleteRecord: (exercise: String, completed: Instant) -> Unit = { _, _ -> }
 ) {
   val records = history.paged.collectAsLazyPagingItems()
   val zone = remember { ZoneId.systemDefault() }
+
+  // Owned here, not per-SessionRow, since only one set can be under edit at a time across the
+  // whole drawer. Delete is a separate step from the edit dialog's own Delete button (see
+  // EditSetRecordDialog) - never fires directly from the edit form.
+  var editingRecord by remember { mutableStateOf<SetRecord?>(null) }
+  var confirmingDelete by remember { mutableStateOf<SetRecord?>(null) }
 
   // The oldest loaded session may be an arbitrary slice of Paging's page boundary rather
   // than the exercise's actual set count for that day - holding it back until pagination
@@ -250,7 +260,8 @@ fun SetRecordList(
                 onToggle = {
                   expandedOverrides = expandedOverrides +
                     (session.day.toEpochDay() to !isExpanded(session.day))
-                }
+                },
+                onEditSet = { editingRecord = it }
               )
             }
             if (records.loadState.append is LoadState.Loading) {
@@ -262,6 +273,31 @@ fun SetRecordList(
             }
           }
         }
+      }
+    )
+  }
+
+  editingRecord?.let { record ->
+    EditSetRecordDialog(
+      record = record,
+      onDismissRequest = { editingRecord = null },
+      onSave = { weight, reps ->
+        onUpdateRecord(record.exercise, record.completed, weight, reps)
+        editingRecord = null
+      },
+      onDelete = {
+        confirmingDelete = record
+        editingRecord = null
+      }
+    )
+  }
+
+  confirmingDelete?.let { record ->
+    DeleteSetRecordConfirmDialog(
+      onDismissRequest = { confirmingDelete = null },
+      onConfirm = {
+        onDeleteRecord(record.exercise, record.completed)
+        confirmingDelete = null
       }
     )
   }
@@ -277,7 +313,8 @@ private fun SessionRow(
   session: SessionGroup,
   isPR: Boolean,
   expanded: Boolean,
-  onToggle: () -> Unit
+  onToggle: () -> Unit,
+  onEditSet: (SetRecord) -> Unit
 ) {
   val dayFormat = remember { DateTimeFormatter.ofPattern("MMM d, yyyy") }
   val timeFormat = remember {
@@ -336,12 +373,24 @@ private fun SessionRow(
           Row(
             Modifier
               .fillMaxWidth()
-              .padding(horizontal = 12.dp, vertical = 8.dp),
+              .padding(horizontal = 12.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
           ) {
             Text(timeFormat.format(set.completed), style = MaterialTheme.typography.caption)
             Text(set.reps.toString(), style = MaterialTheme.typography.body2)
             Text(String.format("%.1f", set.weight), style = MaterialTheme.typography.body2)
+            IconButton(
+              onClick = { onEditSet(set) },
+              modifier = Modifier.size(32.dp)
+            ) {
+              Icon(
+                Icons.Default.Edit,
+                // TODO localize
+                "edit set",
+                modifier = Modifier.size(18.dp)
+              )
+            }
           }
         }
       }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -391,6 +391,28 @@ class ExerciseViewModel @Inject constructor(
     }
   }
 
+  fun updateSetRecord(exercise: String, completed: Instant, weight: Double, reps: Int) {
+    viewModelScope.launch {
+      try {
+        exerciseRepo.updateSetRecord(exercise, completed, weight, reps)
+      } catch (ex: Throwable) {
+        log.e(TAG, "error updating set record", ex)
+        exercisesError = "There was an error updating the set"
+      }
+    }
+  }
+
+  fun deleteSetRecord(exercise: String, completed: Instant) {
+    viewModelScope.launch {
+      try {
+        exerciseRepo.deleteSetRecord(exercise, completed)
+      } catch (ex: Throwable) {
+        log.e(TAG, "error deleting set record", ex)
+        exercisesError = "There was an error removing the set"
+      }
+    }
+  }
+
   companion object {
     private const val TAG = "ExerciseViewModel"
   }


### PR DESCRIPTION
## Summary

Set records could only be created, never fixed after logging - a mis-tapped weight or rep count during a workout was stuck in history forever. This adds in-place editing (and deletion) of an already-logged `SetRecord` from the existing "Set History" drawer.

- Only weight and reps are editable. The completion timestamp stays fixed since it's part of `SetRecord`'s composite primary key (`exercise`, `completed`) in Room.
- `SetRecord` never syncs to DynamoDB, so this is a `:data` → `:room` → `:app` → `:ui` change only, no network/`:garmin` changes.
- Each set row inside an expanded session in the drawer now has a small edit (pencil) icon that opens a dialog for that set; delete is a separate destructive confirm step, mirroring the existing `RenamePlanDialog`/`DeletePlanConfirmDialog` pattern.

## Changes, one commit per architecture tier

1. **`:data`** - `updateSetRecord`/`deleteSetRecord` added to `ExerciseRepository`, keyed by `(exercise, completed)` rather than a full replacement object.
2. **`:room`** - `ExerciseDao` gains plain `UPDATE`/`DELETE` queries keyed on the existing primary key. `storeExerciseRecord` stays `@Insert(IGNORE)` (needed for idempotent Garmin watch-buffer replay) and is untouched. No schema migration - table shape is unchanged.
3. **`:app`** - `RoomCacheExerciseRepository` implements the new methods by calling the DAO directly (not through `SetRecordSink`, which must stay create-only for the watch path). No optimistic in-memory patch needed since record reads go straight through Room's own `Flow`/`PagingSource`. `InMemoryExerciseRepository` test fake and new `RoomCacheExerciseRepositoryTest` cases included.
4. **`:ui`** - `ExerciseViewModel.updateSetRecord`/`deleteSetRecord` (same try/catch + `exercisesError` idiom as `saveExercise`), a new `EditSetRecordDialog`/`DeleteSetRecordConfirmDialog`, and the drawer wiring in `RecordList.kt`/`Main.kt`.

## Notes for review

- This container has no Android SDK, so I could not run `./gradlew` locally - every changed file was manually read through for correctness, but CI here is the first real compile.
- No automated UI/ViewModel tests were added: the `:ui` module has no existing test source set at all, and `:room` has no in-memory-Room DAO test harness either. Coverage for the new DAO queries relies on the mocked-DAO tests in `RoomCacheExerciseRepositoryTest` plus Room's compile-time `@Query` verification. The PR description's manual verification steps below aren't covered by CI.

## Manual verification (not covered by CI)

- Open a workout, log a set, open the history drawer, expand a session, tap the edit icon on a set row, change weight/reps and save - confirm the row updates and the effort chart/trend strip reflect the new value.
- Repeat and use Delete instead - confirm the two-step confirm dialog appears and the row disappears from history after confirming.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MJdWNJdLXyrziyewwGRgmH)_