### PR TITLE
Fix copyCustomDay to copy the source day's own sets/reps

### DIFF
--- a/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepository.kt
+++ b/app/src/main/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepository.kt
@@ -98,20 +98,7 @@ class RoomCacheWorkoutPlanRepository @Inject constructor(
         val newDay = currentPlan.totalDays + 1
 
         val sourceSets = exerciseDao.loadDayExerciseSets(fromDay.toString(), workoutPlan.workout)
-        // Targets come from what was actually completed, not the source day's (possibly still
-        // open, sets = -1) definition - that's the point of "copy day".
-        val completedByTargetSet = exerciseDao
-            .loadDaySetRecords(workoutPlan.workout, fromDay.toString())
-            .groupBy { it.targetSet }
-
-        val copiedSets = sourceSets.map { source ->
-            val completed = completedByTargetSet["$fromDay.${source.step}"]
-            if (completed.isNullOrEmpty()) {
-                source.copy(day = newDay.toString())
-            } else {
-                source.copy(day = newDay.toString(), sets = completed.size, reps = completed.last().reps)
-            }
-        }
+        val copiedSets = sourceSets.map { source -> source.copy(day = newDay.toString()) }
         exerciseDao.storeExerciseSets(copiedSets)
 
         workoutPlanDao.update(currentPlan.copy(totalDays = newDay))

--- a/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepositoryTest.kt
+++ b/app/src/test/kotlin/com/litus_animae/refitted/data/room/RoomCacheWorkoutPlanRepositoryTest.kt
@@ -11,7 +11,6 @@ import com.litus_animae.refitted.room.RefittedRoom
 import com.litus_animae.refitted.room.RefittedRoomProvider
 import com.litus_animae.refitted.room.WorkoutPlanDao
 import com.litus_animae.refitted.room.entities.RoomExerciseSet
-import com.litus_animae.refitted.room.entities.RoomSetRecord
 import com.litus_animae.refitted.room.entities.RoomWorkoutPlan
 import com.litus_animae.refitted.util.LogUtil
 import com.litus_animae.refitted.util.TestLogUtil
@@ -153,46 +152,23 @@ class RoomCacheWorkoutPlanRepositoryTest {
     )
 
     @Test
-    fun `appends a new day with targets derived from completed sets`() = runTest {
+    fun `appends a new day with the source day's own targets`() = runTest {
       // Given
       val existingPlan = RoomWorkoutPlan(workout = workoutName, totalDays = 2, isCustom = true)
       coEvery { workoutPlanDao.getByName(workoutName) } returns existingPlan
       coEvery { exerciseDao.loadDayExerciseSets("1", workoutName) } returns listOf(sourceExercise)
-      coEvery { exerciseDao.loadDaySetRecords(workoutName, "1") } returns listOf(
-        RoomSetRecord(25.0, 9, workoutName, "1.1", Instant.ofEpochMilli(1), "custom_Push-Up"),
-        RoomSetRecord(25.0, 8, workoutName, "1.1", Instant.ofEpochMilli(2), "custom_Push-Up")
-      )
       val stored = slot<List<RoomExerciseSet>>()
       coEvery { exerciseDao.storeExerciseSets(capture(stored)) } returns Unit
 
       // When
       val newDay = subject.copyCustomDay(existingPlan.toDomain(), fromDay = 1)
 
-      // Then - a new day 3, with sets/reps filled from what was actually completed
+      // Then - a new day 3, with the source day's sets/reps carried over unchanged
       assertThat(newDay).isEqualTo(3)
-      assertThat(stored.captured).containsExactly(
-        sourceExercise.copy(day = "3", sets = 2, reps = 8)
-      )
+      assertThat(stored.captured).containsExactly(sourceExercise.copy(day = "3"))
       // Copy is append-only - it must never touch an existing day's rows.
       coVerify(exactly = 0) { exerciseDao.clearDay(any(), any()) }
       coVerify { workoutPlanDao.update(existingPlan.copy(totalDays = 3)) }
-    }
-
-    @Test
-    fun `copies as still-open sets when nothing was completed`() = runTest {
-      // Given
-      val existingPlan = RoomWorkoutPlan(workout = workoutName, totalDays = 2, isCustom = true)
-      coEvery { workoutPlanDao.getByName(workoutName) } returns existingPlan
-      coEvery { exerciseDao.loadDayExerciseSets("1", workoutName) } returns listOf(sourceExercise)
-      coEvery { exerciseDao.loadDaySetRecords(workoutName, "1") } returns emptyList()
-      val stored = slot<List<RoomExerciseSet>>()
-      coEvery { exerciseDao.storeExerciseSets(capture(stored)) } returns Unit
-
-      // When
-      subject.copyCustomDay(existingPlan.toDomain(), fromDay = 1)
-
-      // Then
-      assertThat(stored.captured).containsExactly(sourceExercise.copy(day = "3"))
     }
   }
 

--- a/room/src/main/kotlin/com/litus_animae/refitted/room/ExerciseDao.kt
+++ b/room/src/main/kotlin/com/litus_animae/refitted/room/ExerciseDao.kt
@@ -145,13 +145,6 @@ interface ExerciseDao {
   @Insert(onConflict = OnConflictStrategy.IGNORE)
   suspend fun storeExerciseRecord(exerciseRecord: RoomSetRecord)
 
-  /**
-   * All records logged against target sets belonging to [day] (target_set ids are
-   * "$day.$step") - used to derive copy-day targets from what was actually completed.
-   */
-  @Query("select * from setrecord where workout = :workout and target_set like (:day || '.%') order by completed")
-  suspend fun loadDaySetRecords(workout: String, day: String): List<RoomSetRecord>
-
   @Query(
     "select max(completed) as latest_completion, target_set from setrecord " +
       "where workout = :workout group by target_set"


### PR DESCRIPTION
## Summary

- `copyCustomDay` was deriving the new day's `sets`/`reps` targets from the source day's *completed set records* (i.e. last session's actual performance) instead of the source day's own defined `sets`/`reps` values. This was a feature that had been decided against but had crept back in.
- `copyCustomDay` now copies the source day's exercises with their `sets`/`reps` values carried over as-is.
- Removed the now-unused `loadDaySetRecords` DAO query that only existed to support the reverted behavior.

## Test plan

- Updated `RoomCacheWorkoutPlanRepositoryTest` to assert the copied day keeps the source day's own `sets`/`reps` values, and removed the test coverage for the record-derived behavior.
- Could not run `./gradlew test` in this environment (no Android SDK installed) — CI will need to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RSP6XfvDR4ex7oikxpmPsP)_