### PR TITLE
Size effort chart bubbles by reps instead of effort z-score

### DIFF
--- a/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/effort/EffortModel.kt
@@ -65,6 +65,16 @@ object EffortModel {
     return config.repCap + config.repSoftCapScale * ln(1 + excess / config.repSoftCapScale)
   }
 
+  /**
+   * Reps mapped to `[0, 1]` for chart bubble size - a display-only alternative to [bubbleSize].
+   * Effort's z-score clusters most working sets near "on curve," so its bubble size barely
+   * varies across a real chart; reps vary far more per set and read as a visible size
+   * difference at a glance. [EffortConfig.repCap] is the natural ceiling already used to cap
+   * reps' contribution to capacity.
+   */
+  fun repSize(reps: Int, config: EffortConfig = EffortConfig.Default): Float =
+    (reps.toFloat() / config.repCap).coerceIn(0f, 1f)
+
   fun bubbleSize(z: Double?): Float {
     if (z == null) return NEUTRAL_SIZE
     if (z <= HUMP_ANCHORS.first().first) return HUMP_ANCHORS.first().second.toFloat()

--- a/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
+++ b/data/src/test/kotlin/com/litus_animae/refitted/data/effort/EffortModelTest.kt
@@ -163,6 +163,30 @@ class EffortModelTest {
   }
 
   @Nested
+  @DisplayName("repSize")
+  inner class RepSize {
+    @Test
+    fun `scales linearly up to repCap`() {
+      val cap = EffortConfig.Default.repCap
+      assertThat(EffortModel.repSize(0)).isEqualTo(0f)
+      assertThat(EffortModel.repSize(cap / 2)).isEqualTo((cap / 2).toFloat() / cap)
+      assertThat(EffortModel.repSize(cap)).isEqualTo(1f)
+    }
+
+    @Test
+    fun `clamps at 1 past repCap`() {
+      val cap = EffortConfig.Default.repCap
+      assertThat(EffortModel.repSize(cap * 3)).isEqualTo(1f)
+    }
+
+    @Test
+    fun `never goes negative for zero or negative reps`() {
+      assertThat(EffortModel.repSize(0)).isEqualTo(0f)
+      assertThat(EffortModel.repSize(-1)).isEqualTo(0f)
+    }
+  }
+
+  @Nested
   @DisplayName("worked examples (spec table, curve at ĉ=133, s=10)")
   inner class WorkedExamples {
     private fun sizeFor(weight: Double, reps: Int): Float {

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/charts/EffortChart.kt
@@ -58,8 +58,8 @@ private val EmphasisRingGap = 3.dp
 private val EmphasisRingWidth = 1.5.dp
 
 /**
- * Effort-scored sets as bubbles (radius by demonstrated capacity vs. expectation) plus the
- * adaptive expectation curve.
+ * Effort-scored sets as bubbles (radius by rep count, color by demonstrated capacity vs.
+ * expectation) plus the adaptive expectation curve.
  *
  * [trend] is a list of runs rather than one flat polyline - a run breaks wherever the caller's
  * domain has no prediction (cold start, or a skipped index in a compact window), and each run

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
@@ -429,7 +429,12 @@ private fun EffortHistoryCard(
 
   val points = remember(sortedEntries) {
     sortedEntries.map { (sessionIndex, scored) ->
-      EffortPoint(sessionIndex.toFloat(), scored.source.weight.toFloat(), scored.size, scored.zone)
+      EffortPoint(
+        sessionIndex.toFloat(),
+        scored.source.weight.toFloat(),
+        EffortModel.repSize(scored.source.reps),
+        scored.zone
+      )
     }
   }
   val expectedWeightBySession = remember(trend) {

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/set/SetTrendStrip.kt
@@ -128,7 +128,7 @@ fun SetTrendStrip(
         EffortPoint(
           index.toFloat(),
           scored.source.weight.toFloat(),
-          scored.size,
+          EffortModel.repSize(scored.source.reps),
           scored.zone,
           emphasized = index == windowed.lastIndex
         )


### PR DESCRIPTION
## Summary
- `EffortChart` bubbles were sized by `EffortModel.bubbleSize(z)`, the effort z-score. Most working sets cluster near "on curve," so in practice the size barely varied — a pixel or two of difference across a real chart.
- Adds `EffortModel.repSize(reps)`, a display-only `[0, 1]` mapping of reps against `EffortConfig.repCap`, and switches both chart call sites (`SetTrendStrip`, `RecordList`'s `EffortHistoryCard`) to size bubbles by rep count instead.
- Bubble color still carries the effort zone (`EffortZone` → color), so this doesn't drop the "was this set good" signal — it trades a redundant size encoding for one with real per-set spread.

## Test plan
- Added unit tests for `EffortModel.repSize` (linear scaling to `repCap`, clamping past it, non-negative for zero/negative reps).
- Not yet verified on-device — this sandbox has no Android SDK to build/run the app, so the visual bubble-size contrast should be eyeballed on a real chart before merging.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GCgYLis4W7MACfsKpvXyzA)_