### PR TITLE
Add debug-only strip chart tester activity

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -6,6 +6,18 @@
         <activity
             android:name="com.litus_animae.refitted.HiltTestActivity"
             android:exported="true" />
+
+        <!-- Manual harness for SetTrendStrip's windowing/session-collapse behavior. Debug-only:
+             this source set is never merged into the release build. -->
+        <activity
+            android:name="com.litus_animae.refitted.StripChartTesterActivity"
+            android:exported="true"
+            android:label="Strip Chart Tester">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/debug/kotlin/com/litus_animae/refitted/StripChartTesterActivity.kt
+++ b/app/src/debug/kotlin/com/litus_animae/refitted/StripChartTesterActivity.kt
@@ -1,0 +1,96 @@
+package com.litus_animae.refitted
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Slider
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.litus_animae.refitted.data.effort.toEffortSet
+import com.litus_animae.refitted.data.models.SetRecord
+import com.litus_animae.refitted.ui.compose.exercise.exampleExerciseSet
+import com.litus_animae.refitted.ui.compose.exercise.set.SetTrendStrip
+import com.litus_animae.refitted.ui.compose.util.Theme
+import java.time.Duration
+import java.time.Instant
+import kotlin.math.roundToInt
+
+private const val TODAY_SET_COUNT = 2
+
+/**
+ * Manual harness for [SetTrendStrip]'s windowing/session-collapse behavior, which is driven by
+ * the strip's actual measured width (see [SetTrendStrip]'s `BoxWithConstraints`) and can't be
+ * exercised meaningfully from a fixed-width `@Preview` - it needs a real device screen. Debug-only
+ * (registered in app/src/debug/AndroidManifest.xml), so it never reaches a release build.
+ */
+class StripChartTesterActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent {
+      MaterialTheme(colors = Theme.lightColors) {
+        StripChartTesterScreen()
+      }
+    }
+  }
+}
+
+@Composable
+private fun StripChartTesterScreen() {
+  var historicalCount by remember { mutableFloatStateOf(9f) }
+  val total = historicalCount.roundToInt()
+  val previousSessionCount = total - TODAY_SET_COUNT
+
+  val merged = remember(total) {
+    val previousSession = previewHistorySets(count = previousSessionCount, daysAgo = 3, weight = 95.0)
+    val todaysSession = previewHistorySets(count = TODAY_SET_COUNT, daysAgo = 0, weight = 100.0)
+    (previousSession + todaysSession).map { it.toEffortSet() }
+  }
+
+  Column(
+    Modifier.fillMaxSize().padding(16.dp),
+    verticalArrangement = Arrangement.spacedBy(12.dp)
+  ) {
+    Text("Strip chart tester", style = MaterialTheme.typography.h6)
+    Text(
+      "Historical entries: $total " +
+        "(previous session: $previousSessionCount, today: $TODAY_SET_COUNT)"
+    )
+    Slider(
+      value = historicalCount,
+      onValueChange = { historicalCount = it },
+      valueRange = 5f..15f,
+      steps = 9
+    )
+    SetTrendStrip(
+      Modifier.fillMaxWidth().height(88.dp),
+      merged = merged
+    )
+  }
+}
+
+private fun previewHistorySets(count: Int, daysAgo: Long, weight: Double): List<SetRecord> {
+  val completedBase = Instant.now().minus(Duration.ofDays(daysAgo))
+  return (0 until count).map { index ->
+    SetRecord(
+      weight = weight,
+      reps = 8,
+      workout = exampleExerciseSet.workout,
+      targetSet = exampleExerciseSet.id,
+      completed = completedBase.plusSeconds(index * 120L),
+      exercise = exampleExerciseSet.exerciseName
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Adds `StripChartTesterActivity`, a manual harness for iterating on `SetTrendStrip`'s windowing/session-collapse behavior without needing to redeploy code for each scenario. `SetTrendStrip` sizes its window from the strip's actual measured width (`BoxWithConstraints`, clamped 5–14), so this behavior can't be exercised meaningfully from a fixed-width `@Preview` — it needs a real device screen.

- A slider (5–15) controls the total number of historical entries fed into the real `SetTrendStrip` composable.
- A fixed 2-set "today" session plus a synthetic previous session (filling the remainder) are generated and merged live as the slider moves, so the previous-session-exploded → collapsed → off-axis progression can be observed directly on-device.

## Why it never ships

- The new activity and its manifest registration both live under `app/src/debug/`, the same source set that already hosts `HiltTestActivity` (used only for instrumented tests). Android/AGP only merges a build-type-named source set (`src/debug/`) into that matching build type — it's never included in `release` or the `minifiedDebug` build type, both of which have `debuggable=false`/minification for distribution.
- It's launchable directly from the device's app drawer (own `LAUNCHER` icon, labeled "Strip Chart Tester") for quick manual testing, or via `adb shell am start -n com.litus_animae.refitted.debug/com.litus_animae.refitted.StripChartTesterActivity`.
- It uses synthetic in-memory data only (no Hilt, no network, no Room) — a plain `ComponentActivity`, not wired into any DI graph or app flow.

## Test plan

- On-device manual verification only (not covered by CI): install the debug APK, launch "Strip Chart Tester" from the launcher, and drag the slider through 5, 6, 9, and 15 to confirm the expected explode/collapse/off-axis transitions on your screen.


---
_Generated by [Claude Code](https://claude.ai/code/session_014FUDTfms7bsGfbrS4b26WB)_