### PR TITLE
Redesign send-to-watch as an explicit device-picker dialog

### DIFF
--- a/data/src/main/kotlin/com/litus_animae/refitted/data/device/WatchDevice.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/device/WatchDevice.kt
@@ -1,0 +1,13 @@
+package com.litus_animae.refitted.data.device
+
+enum class WatchDeviceStatus { CONNECTED, NOT_CONNECTED, NOT_PAIRED, UNKNOWN }
+
+/**
+ * One Connect IQ-known device, independent of whether it's the one currently selected for
+ * [WatchService.state]. [id] is the SDK's device identifier, stable across refreshes.
+ */
+data class WatchDevice(
+  val id: String,
+  val name: String,
+  val status: WatchDeviceStatus
+)

--- a/data/src/main/kotlin/com/litus_animae/refitted/data/device/WatchService.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/device/WatchService.kt
@@ -11,7 +11,14 @@ sealed interface WatchState {
 
 interface WatchService {
   val state: StateFlow<WatchState>
+
+  /** Every device Connect IQ currently knows about, populated by [refresh] - not just the one [state] tracks. */
+  val availableDevices: StateFlow<List<WatchDevice>>
+
   suspend fun refresh()
+
+  /** Switches [state] to track the device with this [WatchDevice.id], from the last [refresh]. */
+  suspend fun selectDevice(deviceId: String)
   suspend fun startSession(plan: WatchPlan): Result<Unit>
   suspend fun endSession()
 }

--- a/garmin/CLAUDE.md
+++ b/garmin/CLAUDE.md
@@ -37,9 +37,12 @@ service; this module never touches `BluetoothAdapter` directly.
   different known device; it only reassigns `device`/`state` once `registerDeviceListeners`
   actually succeeds, wrapped in the same `InvalidStateException`/`ServiceUnavailableException`
   handling as `refresh()` - a mid-switch failure resets to `NoDevice`/`Unsupported` rather than
-  leaving `device` pointed at a target whose listeners never registered. Both it and `refresh()` share
-  `registerDeviceListeners`, which unregisters the previously selected device's listeners before
-  registering `ConnectIQ.registerForAppEvents(IQDevice, IQApp, IQApplicationEventListener)`
+  leaving `device` pointed at a target whose listeners never registered. Both it and `refresh()`
+  null out `device` on that failure, and both share `registerDeviceListeners`, which is atomic
+  w.r.t. its own two SDK calls (see Gotchas) since neither caller's cleanup can reach a listener
+  registration that isn't reachable through `device`. It unregisters the previously selected
+  device's listeners before registering
+  `ConnectIQ.registerForAppEvents(IQDevice, IQApp, IQApplicationEventListener)`
   alongside device events for the new one - this service is `@Singleton` but `refresh()` runs once
   per `ExerciseViewModel` init (scoped per nav destination), so skipping the unregister would pile
   up listeners on repeated navigation. Incoming messages are decoded via `WatchProtocol.decode` and, for
@@ -52,6 +55,17 @@ service; this module never touches `BluetoothAdapter` directly.
   showing a checkmark until the app restarts.
 
 ## Gotchas
+
+- **`registerDeviceListeners`'s two SDK calls must stay atomic, or a partial failure leaks a
+  listener registration for the `@Singleton`'s lifetime.** `registerForDeviceEvents` and
+  `registerForAppEvents` are two separate calls; if the first succeeds but the second throws
+  (`InvalidStateException`/`ServiceUnavailableException` - plausible if Connect IQ drops mid-call),
+  the caller (`refresh()` or `selectDevice()`) nulls out `device` in its own catch block (see
+  device/state consistency above). `unregisterDeviceListeners` reads `device` to know what to
+  unregister, so once it's `null` there's no way back to the registration that *did* succeed -
+  it's orphaned forever. `registerDeviceListeners` unregisters its own first call before
+  rethrowing if the second one throws, so it never hands a caller a state where the device is
+  half-registered - don't add a third SDK call here without extending that same rollback.
 
 - **`ConnectIQ.knownDevices` returns every paired device, not just the active one.** Early on,
   `GarminWatchService.refresh()` took `.firstOrNull()` and discarded the rest, so a second paired

--- a/garmin/CLAUDE.md
+++ b/garmin/CLAUDE.md
@@ -29,9 +29,12 @@ service; this module never touches `BluetoothAdapter` directly.
   `ServiceUnavailableException` at the boundary onto `WatchState.NoDevice` / `WatchState.Unsupported`
   - these must never escape into `:ui`, which has no way to name them. `refresh()` populates
   `availableDevices` from every `ConnectIQ.knownDevices` entry (not just the first - see Gotchas)
-  and, for backward-compatible convenience, still auto-selects the first known device into `state`
-  the same way it always did. `selectDevice(id)` is the explicit path `:ui`'s device-picker dialog
-  uses to switch `state` to a different known device; both it and `refresh()` share
+  and only falls back to auto-selecting the first known device into `state` when nothing is
+  currently selected - a device already selected, whether by an earlier `refresh()` or by an
+  explicit `selectDevice(id)`, survives repeat `refresh()` calls (one per `ExerciseViewModel`
+  init, plus one per watch-sync dialog open) rather than being silently reset back to device 0.
+  `selectDevice(id)` is the explicit path `:ui`'s device-picker dialog uses to switch `state` to a
+  different known device; both it and `refresh()` share
   `registerDeviceListeners`, which unregisters the previously selected device's listeners before
   registering `ConnectIQ.registerForAppEvents(IQDevice, IQApp, IQApplicationEventListener)`
   alongside device events for the new one - this service is `@Singleton` but `refresh()` runs once

--- a/garmin/CLAUDE.md
+++ b/garmin/CLAUDE.md
@@ -34,7 +34,10 @@ service; this module never touches `BluetoothAdapter` directly.
   explicit `selectDevice(id)`, survives repeat `refresh()` calls (one per `ExerciseViewModel`
   init, plus one per watch-sync dialog open) rather than being silently reset back to device 0.
   `selectDevice(id)` is the explicit path `:ui`'s device-picker dialog uses to switch `state` to a
-  different known device; both it and `refresh()` share
+  different known device; it only reassigns `device`/`state` once `registerDeviceListeners`
+  actually succeeds, wrapped in the same `InvalidStateException`/`ServiceUnavailableException`
+  handling as `refresh()` - a mid-switch failure resets to `NoDevice`/`Unsupported` rather than
+  leaving `device` pointed at a target whose listeners never registered. Both it and `refresh()` share
   `registerDeviceListeners`, which unregisters the previously selected device's listeners before
   registering `ConnectIQ.registerForAppEvents(IQDevice, IQApp, IQApplicationEventListener)`
   alongside device events for the new one - this service is `@Singleton` but `refresh()` runs once

--- a/garmin/CLAUDE.md
+++ b/garmin/CLAUDE.md
@@ -56,6 +56,17 @@ service; this module never touches `BluetoothAdapter` directly.
 
 ## Gotchas
 
+- **`refresh()`/`selectDevice()` share `deviceMutex` because both read-modify-write `device` and
+  `knownIQDevices` on `Dispatchers.IO`, a real multi-threaded pool.** Before device selection
+  existed, `refresh()` was the only mutator and ran once per `ExerciseViewModel` init, so two
+  calls landing concurrently was unlikely. `WatchSyncDialog` opening now fires its own `refresh()`
+  that can race the one from `ExerciseViewModel.init`, and a device row tap fires `selectDevice()`
+  that can race either - without the lock, two interleaved calls could each register/unregister
+  listeners against a stale read of `device`, leaking or double-registering them, and leave
+  `device`/`_state` pointed at whichever call happened to finish last. `awaitReady()` deliberately
+  sits *outside* the lock (each caller waits for SDK readiness independently, so a slow/never-ready
+  SDK can't starve one caller behind another that got the lock first while waiting).
+
 - **`registerDeviceListeners`'s two SDK calls must stay atomic, or a partial failure leaks a
   listener registration for the `@Singleton`'s lifetime.** `registerForDeviceEvents` and
   `registerForAppEvents` are two separate calls; if the first succeeds but the second throws

--- a/garmin/CLAUDE.md
+++ b/garmin/CLAUDE.md
@@ -27,12 +27,16 @@ service; this module never touches `BluetoothAdapter` directly.
   (`VmPolicy.detectLeakedClosableObjects().penaltyDeath()`), so this pairing must stay exact.
 - `GarminWatchService.kt` - Implements `WatchService`. Maps every `InvalidStateException` /
   `ServiceUnavailableException` at the boundary onto `WatchState.NoDevice` / `WatchState.Unsupported`
-  - these must never escape into `:ui`, which has no way to name them. `refresh()` unregisters the
-  previously known device's listeners before registering
-  `ConnectIQ.registerForAppEvents(IQDevice, IQApp, IQApplicationEventListener)` alongside device
-  events for the current one - this service is `@Singleton` but `refresh()` runs once per
-  `ExerciseViewModel` init (scoped per nav destination), so skipping the unregister would pile up
-  listeners on repeated navigation. Incoming messages are decoded via `WatchProtocol.decode` and, for
+  - these must never escape into `:ui`, which has no way to name them. `refresh()` populates
+  `availableDevices` from every `ConnectIQ.knownDevices` entry (not just the first - see Gotchas)
+  and, for backward-compatible convenience, still auto-selects the first known device into `state`
+  the same way it always did. `selectDevice(id)` is the explicit path `:ui`'s device-picker dialog
+  uses to switch `state` to a different known device; both it and `refresh()` share
+  `registerDeviceListeners`, which unregisters the previously selected device's listeners before
+  registering `ConnectIQ.registerForAppEvents(IQDevice, IQApp, IQApplicationEventListener)`
+  alongside device events for the new one - this service is `@Singleton` but `refresh()` runs once
+  per `ExerciseViewModel` init (scoped per nav destination), so skipping the unregister would pile
+  up listeners on repeated navigation. Incoming messages are decoded via `WatchProtocol.decode` and, for
   `SetDone`, resolved against the session's `WatchSessionState` (`toSetRecord`) and written through
   `SetRecordSink` on a service-owned `CoroutineScope` - this class is `@Singleton`, so it can't rely
   on a caller's scope living as long as an incoming message might arrive. `SessionEnded` (sent once
@@ -42,6 +46,14 @@ service; this module never touches `BluetoothAdapter` directly.
   showing a checkmark until the app restarts.
 
 ## Gotchas
+
+- **`ConnectIQ.knownDevices` returns every paired device, not just the active one.** Early on,
+  `GarminWatchService.refresh()` took `.firstOrNull()` and discarded the rest, so a second paired
+  watch was simply invisible with no way to see it existed - the phone's "send to watch" icon
+  looked broken with no indication why. `refresh()` now maps the full list into
+  `WatchDevice`/`availableDevices` for `:ui` to render as a picker, while `device` (the one `state`
+  and `startSession` actually target) is still chosen explicitly - either `refresh()`'s
+  first-known-device default or a later `selectDevice(id)` call.
 
 - **`sendMessage`'s `IQMessageStatus.SUCCESS` is not an app-level ack.** It only means Garmin
   Connect Mobile accepted the payload for BLE delivery to the *device* - it says nothing about

--- a/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminWatchService.kt
+++ b/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminWatchService.kt
@@ -123,9 +123,21 @@ class GarminWatchService @Inject constructor(
     val target = knownIQDevices.firstOrNull { it.watchDeviceId() == deviceId } ?: return@withContext
     val connectIQ = connection.connectIQ
     unregisterDeviceListeners(connectIQ)
-    device = target
-    registerDeviceListeners(connectIQ, target)
-    _state.value = WatchState.Idle(target.friendlyName, appInstalled = true, appOpen = false)
+    // device/state are only updated once registration actually succeeds - mirrors refresh()'s
+    // handling of the same SDK calls, so a mid-switch InvalidStateException/
+    // ServiceUnavailableException can't leave device pointed at a target whose listeners never
+    // registered while _state still shows the previous (now-unregistered) one as Idle.
+    try {
+      registerDeviceListeners(connectIQ, target)
+      device = target
+      _state.value = WatchState.Idle(target.friendlyName, appInstalled = true, appOpen = false)
+    } catch (e: InvalidStateException) {
+      device = null
+      _state.value = WatchState.NoDevice
+    } catch (e: ServiceUnavailableException) {
+      device = null
+      _state.value = WatchState.Unsupported
+    }
   }
 
   private fun registerDeviceListeners(connectIQ: ConnectIQ, target: IQDevice) {

--- a/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminWatchService.kt
+++ b/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminWatchService.kt
@@ -86,10 +86,19 @@ class GarminWatchService @Inject constructor(
       knownIQDevices = allKnownDevices
       _availableDevices.value = allKnownDevices.map { it.toWatchDevice() }
 
+      // refresh() runs on every ExerciseViewModel init (one per nav destination) and every
+      // WatchSyncDialog open, not just the first time - a device already selected here, whether
+      // by an earlier refresh() or by an explicit selectDevice(id), must survive those repeat
+      // calls. Re-defaulting to firstOrNull() every time would silently swap the send target back
+      // to device 0 out from under a user who picked a different paired watch.
+      val previouslySelected = device
+      if (previouslySelected != null &&
+        allKnownDevices.any { it.deviceIdentifier == previouslySelected.deviceIdentifier }
+      ) {
+        return@withContext
+      }
+
       val knownDevice = allKnownDevices.firstOrNull()
-      // ExerciseViewModel (scoped per nav destination) calls this on every init, but this
-      // service is a @Singleton - unregister a prior device's listeners first, or repeated
-      // navigation piles up registrations and every incoming message gets handled N times.
       unregisterDeviceListeners(connectIQ)
       device = knownDevice
       _state.value = if (knownDevice == null) {

--- a/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminWatchService.kt
+++ b/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminWatchService.kt
@@ -108,10 +108,16 @@ class GarminWatchService @Inject constructor(
         WatchState.Idle(knownDevice.friendlyName, appInstalled = true, appOpen = false)
       }
     } catch (e: InvalidStateException) {
+      // device must be cleared alongside _state here - startSession()/endSession() read device
+      // directly, and would otherwise keep targeting a stale device the UI is now showing as
+      // NoDevice/Unsupported (the same device/state consistency selectDevice() below now enforces
+      // on its own failure path).
+      device = null
       knownIQDevices = emptyList()
       _availableDevices.value = emptyList()
       _state.value = WatchState.NoDevice
     } catch (e: ServiceUnavailableException) {
+      device = null
       knownIQDevices = emptyList()
       _availableDevices.value = emptyList()
       _state.value = WatchState.Unsupported

--- a/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminWatchService.kt
+++ b/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminWatchService.kt
@@ -146,10 +146,21 @@ class GarminWatchService @Inject constructor(
     }
   }
 
+  // Atomic w.r.t. its own two SDK calls: if registerForDeviceEvents succeeds but
+  // registerForAppEvents then throws, the first registration is unregistered here before
+  // rethrowing - callers only track cleanup via the nullable `device` field, which they null out
+  // on failure, so a listener this function left half-registered against `target` would never be
+  // reachable again through unregisterDeviceListeners (it reads `device`, now null) and would leak
+  // for the @Singleton's lifetime.
   private fun registerDeviceListeners(connectIQ: ConnectIQ, target: IQDevice) {
     connectIQ.registerForDeviceEvents(target) { _, _ -> }
-    connectIQ.registerForAppEvents(target, watchApp) { _, _, message, status ->
-      onMessageReceived(message, status)
+    try {
+      connectIQ.registerForAppEvents(target, watchApp) { _, _, message, status ->
+        onMessageReceived(message, status)
+      }
+    } catch (e: Exception) {
+      runCatching { connectIQ.unregisterForDeviceEvents(target) }
+      throw e
     }
     startAppOpenPoller()
   }

--- a/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminWatchService.kt
+++ b/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminWatchService.kt
@@ -6,6 +6,8 @@ import com.garmin.android.connectiq.IQDevice
 import com.garmin.android.connectiq.exception.InvalidStateException
 import com.garmin.android.connectiq.exception.ServiceUnavailableException
 import com.litus_animae.refitted.data.device.SetRecordSink
+import com.litus_animae.refitted.data.device.WatchDevice
+import com.litus_animae.refitted.data.device.WatchDeviceStatus
 import com.litus_animae.refitted.data.device.WatchPlan
 import com.litus_animae.refitted.data.device.WatchProtocol
 import com.litus_animae.refitted.data.device.WatchService
@@ -54,11 +56,18 @@ class GarminWatchService @Inject constructor(
   private val _state = MutableStateFlow<WatchState>(WatchState.NoDevice)
   override val state: StateFlow<WatchState> = _state.asStateFlow()
 
+  private val _availableDevices = MutableStateFlow<List<WatchDevice>>(emptyList())
+  override val availableDevices: StateFlow<List<WatchDevice>> = _availableDevices.asStateFlow()
+
   // Owned here rather than reusing a caller's scope - incoming SET_DONE messages can arrive at
   // any point in this @Singleton's lifetime, not just while a ViewModel is collecting state.
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
   private var device: IQDevice? = null
+  // The IQDevice objects backing the last refresh()'s _availableDevices - selectDevice(id) needs
+  // the real IQDevice to register listeners against, not just the plain WatchDevice DTO exposed
+  // to :ui/:data.
+  private var knownIQDevices: List<IQDevice> = emptyList()
   private var session: WatchSessionState? = null
   private var lastHelloAt: Instant? = null
   private var appOpenPollerJob: Job? = null
@@ -70,7 +79,14 @@ class GarminWatchService @Inject constructor(
     awaitReady()
     try {
       val connectIQ = connection.connectIQ
-      val knownDevice = connectIQ.knownDevices.orEmpty().firstOrNull()
+      // Previously .firstOrNull() discarded every device past the first known one, so a second
+      // paired watch was invisible and there was no way to see it existed. Surface all of them -
+      // selectDevice(id) is what actually switches which one state/session tracks.
+      val allKnownDevices = connectIQ.knownDevices.orEmpty()
+      knownIQDevices = allKnownDevices
+      _availableDevices.value = allKnownDevices.map { it.toWatchDevice() }
+
+      val knownDevice = allKnownDevices.firstOrNull()
       // ExerciseViewModel (scoped per nav destination) calls this on every init, but this
       // service is a @Singleton - unregister a prior device's listeners first, or repeated
       // navigation piles up registrations and every incoming message gets handled N times.
@@ -79,18 +95,36 @@ class GarminWatchService @Inject constructor(
       _state.value = if (knownDevice == null) {
         WatchState.NoDevice
       } else {
-        connectIQ.registerForDeviceEvents(knownDevice) { _, _ -> }
-        connectIQ.registerForAppEvents(knownDevice, watchApp) { _, _, message, status ->
-          onMessageReceived(message, status)
-        }
-        startAppOpenPoller()
+        registerDeviceListeners(connectIQ, knownDevice)
         WatchState.Idle(knownDevice.friendlyName, appInstalled = true, appOpen = false)
       }
     } catch (e: InvalidStateException) {
+      knownIQDevices = emptyList()
+      _availableDevices.value = emptyList()
       _state.value = WatchState.NoDevice
     } catch (e: ServiceUnavailableException) {
+      knownIQDevices = emptyList()
+      _availableDevices.value = emptyList()
       _state.value = WatchState.Unsupported
     }
+  }
+
+  override suspend fun selectDevice(deviceId: String) = withContext(Dispatchers.IO) {
+    awaitReady()
+    val target = knownIQDevices.firstOrNull { it.watchDeviceId() == deviceId } ?: return@withContext
+    val connectIQ = connection.connectIQ
+    unregisterDeviceListeners(connectIQ)
+    device = target
+    registerDeviceListeners(connectIQ, target)
+    _state.value = WatchState.Idle(target.friendlyName, appInstalled = true, appOpen = false)
+  }
+
+  private fun registerDeviceListeners(connectIQ: ConnectIQ, target: IQDevice) {
+    connectIQ.registerForDeviceEvents(target) { _, _ -> }
+    connectIQ.registerForAppEvents(target, watchApp) { _, _, message, status ->
+      onMessageReceived(message, status)
+    }
+    startAppOpenPoller()
   }
 
   private fun unregisterDeviceListeners(connectIQ: ConnectIQ) {
@@ -243,3 +277,16 @@ class GarminWatchService @Inject constructor(
     }
   }
 }
+
+private fun IQDevice.watchDeviceId(): String = deviceIdentifier.toString()
+
+private fun IQDevice.toWatchDevice(): WatchDevice = WatchDevice(
+  id = watchDeviceId(),
+  name = friendlyName,
+  status = when (status) {
+    IQDevice.IQDeviceStatus.CONNECTED -> WatchDeviceStatus.CONNECTED
+    IQDevice.IQDeviceStatus.NOT_CONNECTED -> WatchDeviceStatus.NOT_CONNECTED
+    IQDevice.IQDeviceStatus.NOT_PAIRED -> WatchDeviceStatus.NOT_PAIRED
+    else -> WatchDeviceStatus.UNKNOWN
+  }
+)

--- a/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminWatchService.kt
+++ b/garmin/src/main/kotlin/com/litus_animae/refitted/garmin/GarminWatchService.kt
@@ -26,6 +26,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.time.Duration
 import java.time.Instant
@@ -63,6 +65,16 @@ class GarminWatchService @Inject constructor(
   // any point in this @Singleton's lifetime, not just while a ViewModel is collecting state.
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
+  // Serializes refresh()/selectDevice() against each other - both read-modify-write device,
+  // knownIQDevices, and the SDK's listener registration for `device` on Dispatchers.IO's
+  // multi-threaded pool. Before this PR refresh() was the only mutator and ran once per
+  // ExerciseViewModel init, so interleaving was unlikely; WatchSyncDialog now fires a second
+  // refresh() on open (which can race the one from ExerciseViewModel.init) and a device row tap
+  // fires selectDevice() that can race either - without this, two interleaved calls could each
+  // register/unregister listeners against a stale read of `device`, leaking or double-registering
+  // them, and leave device/_state pointed at whichever call happened to finish last.
+  private val deviceMutex = Mutex()
+
   private var device: IQDevice? = null
   // The IQDevice objects backing the last refresh()'s _availableDevices - selectDevice(id) needs
   // the real IQDevice to register listeners against, not just the plain WatchDevice DTO exposed
@@ -77,72 +89,76 @@ class GarminWatchService @Inject constructor(
   // dispatcher so it can't jank the caller.
   override suspend fun refresh() = withContext(Dispatchers.IO) {
     awaitReady()
-    try {
-      val connectIQ = connection.connectIQ
-      // Previously .firstOrNull() discarded every device past the first known one, so a second
-      // paired watch was invisible and there was no way to see it existed. Surface all of them -
-      // selectDevice(id) is what actually switches which one state/session tracks.
-      val allKnownDevices = connectIQ.knownDevices.orEmpty()
-      knownIQDevices = allKnownDevices
-      _availableDevices.value = allKnownDevices.map { it.toWatchDevice() }
+    deviceMutex.withLock {
+      try {
+        val connectIQ = connection.connectIQ
+        // Previously .firstOrNull() discarded every device past the first known one, so a second
+        // paired watch was invisible and there was no way to see it existed. Surface all of them -
+        // selectDevice(id) is what actually switches which one state/session tracks.
+        val allKnownDevices = connectIQ.knownDevices.orEmpty()
+        knownIQDevices = allKnownDevices
+        _availableDevices.value = allKnownDevices.map { it.toWatchDevice() }
 
-      // refresh() runs on every ExerciseViewModel init (one per nav destination) and every
-      // WatchSyncDialog open, not just the first time - a device already selected here, whether
-      // by an earlier refresh() or by an explicit selectDevice(id), must survive those repeat
-      // calls. Re-defaulting to firstOrNull() every time would silently swap the send target back
-      // to device 0 out from under a user who picked a different paired watch.
-      val previouslySelected = device
-      if (previouslySelected != null &&
-        allKnownDevices.any { it.deviceIdentifier == previouslySelected.deviceIdentifier }
-      ) {
-        return@withContext
-      }
+        // refresh() runs on every ExerciseViewModel init (one per nav destination) and every
+        // WatchSyncDialog open, not just the first time - a device already selected here, whether
+        // by an earlier refresh() or by an explicit selectDevice(id), must survive those repeat
+        // calls. Re-defaulting to firstOrNull() every time would silently swap the send target
+        // back to device 0 out from under a user who picked a different paired watch.
+        val previouslySelected = device
+        if (previouslySelected != null &&
+          allKnownDevices.any { it.deviceIdentifier == previouslySelected.deviceIdentifier }
+        ) {
+          return@withLock
+        }
 
-      val knownDevice = allKnownDevices.firstOrNull()
-      unregisterDeviceListeners(connectIQ)
-      device = knownDevice
-      _state.value = if (knownDevice == null) {
-        WatchState.NoDevice
-      } else {
-        registerDeviceListeners(connectIQ, knownDevice)
-        WatchState.Idle(knownDevice.friendlyName, appInstalled = true, appOpen = false)
+        val knownDevice = allKnownDevices.firstOrNull()
+        unregisterDeviceListeners(connectIQ)
+        device = knownDevice
+        _state.value = if (knownDevice == null) {
+          WatchState.NoDevice
+        } else {
+          registerDeviceListeners(connectIQ, knownDevice)
+          WatchState.Idle(knownDevice.friendlyName, appInstalled = true, appOpen = false)
+        }
+      } catch (e: InvalidStateException) {
+        // device must be cleared alongside _state here - startSession()/endSession() read device
+        // directly, and would otherwise keep targeting a stale device the UI is now showing as
+        // NoDevice/Unsupported (the same device/state consistency selectDevice() below now
+        // enforces on its own failure path).
+        device = null
+        knownIQDevices = emptyList()
+        _availableDevices.value = emptyList()
+        _state.value = WatchState.NoDevice
+      } catch (e: ServiceUnavailableException) {
+        device = null
+        knownIQDevices = emptyList()
+        _availableDevices.value = emptyList()
+        _state.value = WatchState.Unsupported
       }
-    } catch (e: InvalidStateException) {
-      // device must be cleared alongside _state here - startSession()/endSession() read device
-      // directly, and would otherwise keep targeting a stale device the UI is now showing as
-      // NoDevice/Unsupported (the same device/state consistency selectDevice() below now enforces
-      // on its own failure path).
-      device = null
-      knownIQDevices = emptyList()
-      _availableDevices.value = emptyList()
-      _state.value = WatchState.NoDevice
-    } catch (e: ServiceUnavailableException) {
-      device = null
-      knownIQDevices = emptyList()
-      _availableDevices.value = emptyList()
-      _state.value = WatchState.Unsupported
     }
   }
 
   override suspend fun selectDevice(deviceId: String) = withContext(Dispatchers.IO) {
     awaitReady()
-    val target = knownIQDevices.firstOrNull { it.watchDeviceId() == deviceId } ?: return@withContext
-    val connectIQ = connection.connectIQ
-    unregisterDeviceListeners(connectIQ)
-    // device/state are only updated once registration actually succeeds - mirrors refresh()'s
-    // handling of the same SDK calls, so a mid-switch InvalidStateException/
-    // ServiceUnavailableException can't leave device pointed at a target whose listeners never
-    // registered while _state still shows the previous (now-unregistered) one as Idle.
-    try {
-      registerDeviceListeners(connectIQ, target)
-      device = target
-      _state.value = WatchState.Idle(target.friendlyName, appInstalled = true, appOpen = false)
-    } catch (e: InvalidStateException) {
-      device = null
-      _state.value = WatchState.NoDevice
-    } catch (e: ServiceUnavailableException) {
-      device = null
-      _state.value = WatchState.Unsupported
+    deviceMutex.withLock {
+      val target = knownIQDevices.firstOrNull { it.watchDeviceId() == deviceId } ?: return@withLock
+      val connectIQ = connection.connectIQ
+      unregisterDeviceListeners(connectIQ)
+      // device/state are only updated once registration actually succeeds - mirrors refresh()'s
+      // handling of the same SDK calls, so a mid-switch InvalidStateException/
+      // ServiceUnavailableException can't leave device pointed at a target whose listeners never
+      // registered while _state still shows the previous (now-unregistered) one as Idle.
+      try {
+        registerDeviceListeners(connectIQ, target)
+        device = target
+        _state.value = WatchState.Idle(target.friendlyName, appInstalled = true, appOpen = false)
+      } catch (e: InvalidStateException) {
+        device = null
+        _state.value = WatchState.NoDevice
+      } catch (e: ServiceUnavailableException) {
+        device = null
+        _state.value = WatchState.Unsupported
+      }
     }
   }
 

--- a/garmin/src/test/kotlin/com/litus_animae/refitted/garmin/GarminWatchServiceTest.kt
+++ b/garmin/src/test/kotlin/com/litus_animae/refitted/garmin/GarminWatchServiceTest.kt
@@ -267,6 +267,23 @@ class GarminWatchServiceTest {
       // of the same exception.
       assertThat(freshService.state.value).isEqualTo(WatchState.NoDevice)
     }
+
+    @Test
+    fun `a refresh failure clears the send target along with state, not just state`() = runTest {
+      // First refresh succeeds and selects a device...
+      val freshService = GarminWatchService(connection, setRecordSink, log)
+      freshService.refresh()
+      assertThat(freshService.state.value).isInstanceOf(WatchState.Idle::class.java)
+
+      // ...then Garmin Connect Mobile becomes unavailable on a later refresh.
+      every { connectIQ.knownDevices } throws InvalidStateException("connect IQ not ready")
+      freshService.refresh()
+
+      assertThat(freshService.state.value).isEqualTo(WatchState.NoDevice)
+      // startSession must not silently target the now-stale device the UI no longer shows.
+      val result = freshService.startSession(plan)
+      assertThat(result.isFailure).isTrue()
+    }
   }
 
   @Nested

--- a/garmin/src/test/kotlin/com/litus_animae/refitted/garmin/GarminWatchServiceTest.kt
+++ b/garmin/src/test/kotlin/com/litus_animae/refitted/garmin/GarminWatchServiceTest.kt
@@ -229,6 +229,24 @@ class GarminWatchServiceTest {
       verify { connectIQ.unregisterForDeviceEvents(device) }
       verify { connectIQ.unregisterForApplicationEvents(device, watchApp) }
     }
+
+    @Test
+    fun `refresh preserves an explicit selectDevice choice instead of resetting to the first device`() = runTest {
+      every { connectIQ.knownDevices } returns listOf(device, secondDevice)
+      every { connectIQ.registerForDeviceEvents(secondDevice, any()) } just Runs
+      every { connectIQ.registerForAppEvents(secondDevice, any(), any()) } just Runs
+
+      val freshService = GarminWatchService(connection, setRecordSink, log)
+      freshService.refresh()
+      val secondDeviceId = freshService.availableDevices.value.last().id
+      freshService.selectDevice(secondDeviceId)
+
+      // ExerciseViewModel.init and WatchSyncDialog's open both call refresh() again on an
+      // already-running singleton - it must not silently swap the send target back to device 0.
+      freshService.refresh()
+
+      assertThat((freshService.state.value as WatchState.Idle).deviceName).isEqualTo("Fenix")
+    }
   }
 
   @Nested

--- a/garmin/src/test/kotlin/com/litus_animae/refitted/garmin/GarminWatchServiceTest.kt
+++ b/garmin/src/test/kotlin/com/litus_animae/refitted/garmin/GarminWatchServiceTest.kt
@@ -3,6 +3,7 @@ package com.litus_animae.refitted.garmin
 import com.garmin.android.connectiq.ConnectIQ
 import com.garmin.android.connectiq.IQApp
 import com.garmin.android.connectiq.IQDevice
+import com.garmin.android.connectiq.exception.InvalidStateException
 import com.google.common.truth.Truth.assertThat
 import com.litus_animae.refitted.data.device.SetRecordSink
 import com.litus_animae.refitted.data.device.WatchExercise
@@ -246,6 +247,25 @@ class GarminWatchServiceTest {
       freshService.refresh()
 
       assertThat((freshService.state.value as WatchState.Idle).deviceName).isEqualTo("Fenix")
+    }
+
+    @Test
+    fun `selectDevice leaves state and the send target consistent when registration throws`() = runTest {
+      every { connectIQ.knownDevices } returns listOf(device, secondDevice)
+      every {
+        connectIQ.registerForDeviceEvents(secondDevice, any())
+      } throws InvalidStateException("connect IQ not ready")
+
+      val freshService = GarminWatchService(connection, setRecordSink, log)
+      freshService.refresh()
+      val secondDeviceId = freshService.availableDevices.value.last().id
+
+      freshService.selectDevice(secondDeviceId)
+
+      // device must not silently point at a target whose listeners never registered - state
+      // reflects that no device is actually selected any more, matching refresh()'s own handling
+      // of the same exception.
+      assertThat(freshService.state.value).isEqualTo(WatchState.NoDevice)
     }
   }
 

--- a/garmin/src/test/kotlin/com/litus_animae/refitted/garmin/GarminWatchServiceTest.kt
+++ b/garmin/src/test/kotlin/com/litus_animae/refitted/garmin/GarminWatchServiceTest.kt
@@ -18,6 +18,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -178,6 +179,55 @@ class GarminWatchServiceTest {
       )
 
       assertThat((freshService.state.value as WatchState.Idle).appOpen).isTrue()
+    }
+  }
+
+  @Nested
+  @DisplayName("multiple known devices")
+  inner class MultiDeviceTests {
+
+    private val secondDevice = IQDevice(2L, "Fenix")
+
+    @Test
+    fun `refresh surfaces every known device, not just the first`() = runTest {
+      every { connectIQ.knownDevices } returns listOf(device, secondDevice)
+
+      val freshService = GarminWatchService(connection, setRecordSink, log)
+      freshService.refresh()
+
+      assertThat(freshService.availableDevices.value.map { it.name })
+        .containsExactly("Forerunner", "Fenix")
+    }
+
+    @Test
+    fun `selectDevice switches state to the chosen device`() = runTest {
+      every { connectIQ.knownDevices } returns listOf(device, secondDevice)
+      every { connectIQ.registerForDeviceEvents(secondDevice, any()) } just Runs
+      every { connectIQ.registerForAppEvents(secondDevice, any(), any()) } just Runs
+
+      val freshService = GarminWatchService(connection, setRecordSink, log)
+      freshService.refresh()
+      val secondDeviceId = freshService.availableDevices.value.last().id
+
+      freshService.selectDevice(secondDeviceId)
+
+      assertThat((freshService.state.value as WatchState.Idle).deviceName).isEqualTo("Fenix")
+    }
+
+    @Test
+    fun `selectDevice unregisters the previously selected device's listeners`() = runTest {
+      every { connectIQ.knownDevices } returns listOf(device, secondDevice)
+      every { connectIQ.registerForDeviceEvents(secondDevice, any()) } just Runs
+      every { connectIQ.registerForAppEvents(secondDevice, any(), any()) } just Runs
+
+      val freshService = GarminWatchService(connection, setRecordSink, log)
+      freshService.refresh()
+      val secondDeviceId = freshService.availableDevices.value.last().id
+
+      freshService.selectDevice(secondDeviceId)
+
+      verify { connectIQ.unregisterForDeviceEvents(device) }
+      verify { connectIQ.unregisterForApplicationEvents(device, watchApp) }
     }
   }
 

--- a/garmin/src/test/kotlin/com/litus_animae/refitted/garmin/GarminWatchServiceTest.kt
+++ b/garmin/src/test/kotlin/com/litus_animae/refitted/garmin/GarminWatchServiceTest.kt
@@ -269,6 +269,26 @@ class GarminWatchServiceTest {
     }
 
     @Test
+    fun `a partial registration failure unregisters the device-events listener it did register`() = runTest {
+      every { connectIQ.knownDevices } returns listOf(device, secondDevice)
+      every { connectIQ.registerForDeviceEvents(secondDevice, any()) } just Runs
+      every {
+        connectIQ.registerForAppEvents(secondDevice, any(), any())
+      } throws InvalidStateException("connect IQ not ready")
+
+      val freshService = GarminWatchService(connection, setRecordSink, log)
+      freshService.refresh()
+      val secondDeviceId = freshService.availableDevices.value.last().id
+
+      freshService.selectDevice(secondDeviceId)
+
+      // registerForDeviceEvents(secondDevice) succeeded before registerForAppEvents threw - it
+      // must not be left registered just because `device` ends up null on this failure path.
+      verify { connectIQ.unregisterForDeviceEvents(secondDevice) }
+      assertThat(freshService.state.value).isEqualTo(WatchState.NoDevice)
+    }
+
+    @Test
     fun `a refresh failure clears the send target along with state, not just state`() = runTest {
       // First refresh succeeds and selects a device...
       val freshService = GarminWatchService(connection, setRecordSink, log)

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/PagerExercise.kt
@@ -157,30 +157,31 @@ fun PagerExerciseView(
       // exercise is known - it lands next to the add-exercise icon either way.
       if (LocalFeatures.current.flags[ConfigProvider.Companion.Feature.WATCH_SYNC] == "enabled") {
         val watchState by model.watchState.collectAsStateWithLifecycle()
-        // NoDevice/Unsupported stay visible (this doubles as the connection-status affordance)
-        // but disabled - tapping send when there's nothing to send to silently no-oped before.
-        // Active is also disabled - a session is already running on the watch, so re-sending the
-        // plan would just be a confusing no-op there too.
-        val watchConnected = watchState is WatchState.Idle || watchState is WatchState.Active
-        val appOpen = (watchState as? WatchState.Idle)?.appOpen == true
-        IconButton(
-          { model.sendPlanToWatch(workoutPlan?.globalAlternate) },
-          enabled = watchState is WatchState.Idle && appOpen
-        ) {
+        var showWatchSync by remember { mutableStateOf(false) }
+        // Always tappable - the old enabled/disabled gating hid *why* nothing happened when
+        // there was no device or the watch app wasn't open. Now every tap opens the dialog,
+        // which shows that status directly instead of just refusing the tap.
+        IconButton({ showWatchSync = true }) {
           Icon(
             if (watchState is WatchState.Active) Icons.Default.Check else Icons.Default.Watch,
             tint = if (watchState is WatchState.Active) {
               MaterialTheme.colorScheme.secondary
             } else {
-              LocalContentColor.current.copy(alpha = if (watchConnected && appOpen) 1f else 0.38f)
+              LocalContentColor.current
             },
             // TODO localize
-            contentDescription = when {
-              watchState is WatchState.Active -> "watch session in progress"
-              watchState is WatchState.Idle && appOpen -> "send plan to watch"
-              watchState is WatchState.Idle -> "watch app not open"
-              else -> "no watch connected"
+            contentDescription = if (watchState is WatchState.Active) {
+              "watch session in progress"
+            } else {
+              "send plan to watch"
             }
+          )
+        }
+        if (showWatchSync) {
+          WatchSyncDialog(
+            model = model,
+            globalAlternate = workoutPlan?.globalAlternate,
+            onDismissRequest = { showWatchSync = false }
           )
         }
       }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/WatchSyncDialog.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/WatchSyncDialog.kt
@@ -1,0 +1,182 @@
+package com.litus_animae.refitted.ui.compose.exercise
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.litus_animae.refitted.data.device.WatchDevice
+import com.litus_animae.refitted.data.device.WatchDeviceStatus
+import com.litus_animae.refitted.data.device.WatchExercise
+import com.litus_animae.refitted.data.device.WatchPlan
+import com.litus_animae.refitted.data.device.WatchState
+import com.litus_animae.refitted.ui.models.ExerciseViewModel
+
+/**
+ * Replaces the old single-tap "send to watch" icon action: picking a device and reviewing what's
+ * about to be sent are now explicit steps in one dialog, rather than one opaque tap that either
+ * silently no-oped (disabled icon, no explanation) or fired the whole plan immediately. Device
+ * pick and the exercise-list summary share this one screen (no separate confirm step between
+ * them) - selecting a device just reveals the summary below it; only the final Send is a
+ * distinct action.
+ */
+@Composable
+fun WatchSyncDialog(
+  model: ExerciseViewModel,
+  globalAlternate: Int?,
+  onDismissRequest: () -> Unit
+) {
+  val devices by model.watchDevices.collectAsStateWithLifecycle()
+  val watchState by model.watchState.collectAsStateWithLifecycle()
+  var selectedDeviceId by remember { mutableStateOf<String?>(null) }
+  var plan by remember { mutableStateOf<WatchPlan?>(null) }
+
+  LaunchedEffect(Unit) {
+    model.refreshWatchState()
+    plan = model.previewWatchPlan(globalAlternate)
+  }
+
+  val appOpen = (watchState as? WatchState.Idle)?.appOpen == true
+  val sessionActive = watchState is WatchState.Active
+  val canSend = selectedDeviceId != null && appOpen && plan != null && !sessionActive
+
+  AlertDialog(
+    onDismissRequest = onDismissRequest,
+    // TODO localize
+    title = { Text("Send to Watch") },
+    text = {
+      Column {
+        when {
+          watchState is WatchState.Unsupported ->
+            Text("Watch sync isn't supported on this device.")
+          sessionActive ->
+            Text("A workout is already running on the watch. End it there before sending a new plan.")
+          devices.isEmpty() ->
+            Text("No paired Garmin devices found. Pair one in Garmin Connect Mobile, then try again.")
+          else -> {
+            // TODO localize
+            Text("Device", style = MaterialTheme.typography.labelLarge)
+            devices.forEach { device ->
+              DeviceRow(
+                device = device,
+                isSelected = device.id == selectedDeviceId,
+                appOpen = appOpen,
+                onSelect = {
+                  selectedDeviceId = device.id
+                  model.selectWatchDevice(device.id)
+                }
+              )
+            }
+          }
+        }
+
+        if (selectedDeviceId != null && !sessionActive) {
+          Spacer(Modifier.height(12.dp))
+          HorizontalDivider()
+          Spacer(Modifier.height(12.dp))
+          // TODO localize
+          Text("Exercises", style = MaterialTheme.typography.labelLarge)
+          val currentPlan = plan
+          if (currentPlan == null) {
+            CircularProgressIndicator(Modifier.padding(16.dp))
+          } else {
+            LazyColumn(Modifier.heightIn(max = 240.dp)) {
+              items(currentPlan.exercises, key = { it.name }) { exercise ->
+                WatchExerciseRow(exercise)
+              }
+            }
+          }
+        }
+      }
+    },
+    confirmButton = {
+      Button(onClick = { model.sendPlanToWatch(globalAlternate); onDismissRequest() }, enabled = canSend) {
+        // TODO localize
+        Text("Send")
+      }
+    },
+    dismissButton = {
+      TextButton(onClick = onDismissRequest) {
+        // TODO localize
+        Text("Cancel")
+      }
+    }
+  )
+}
+
+@Composable
+private fun DeviceRow(
+  device: WatchDevice,
+  isSelected: Boolean,
+  appOpen: Boolean,
+  onSelect: () -> Unit
+) {
+  Row(
+    Modifier
+      .fillMaxWidth()
+      .clickable(onClick = onSelect)
+      .padding(vertical = 8.dp),
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    RadioButton(selected = isSelected, onClick = onSelect)
+    Column {
+      Text(device.name, style = MaterialTheme.typography.bodyLarge)
+      Text(
+        deviceStatusLabel(device.status, isSelected, appOpen),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+      )
+    }
+  }
+}
+
+@Composable
+private fun WatchExerciseRow(exercise: WatchExercise) {
+  Column(Modifier.padding(vertical = 6.dp)) {
+    Text(exercise.name, style = MaterialTheme.typography.bodyMedium)
+    val setsLabel = if (exercise.sets < 0) "open" else "${exercise.sets}"
+    // TODO localize
+    Text(
+      "$setsLabel x ${exercise.reps}",
+      style = MaterialTheme.typography.bodySmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+  }
+}
+
+// TODO localize
+private fun deviceStatusLabel(status: WatchDeviceStatus, isSelected: Boolean, appOpen: Boolean): String {
+  if (isSelected) {
+    return if (appOpen) "connected, app open" else "connected, waiting on app"
+  }
+  return when (status) {
+    WatchDeviceStatus.CONNECTED -> "connected"
+    WatchDeviceStatus.NOT_CONNECTED -> "not connected"
+    WatchDeviceStatus.NOT_PAIRED -> "not paired"
+    WatchDeviceStatus.UNKNOWN -> "status unknown"
+  }
+}

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/WatchSyncDialog.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/WatchSyncDialog.kt
@@ -74,6 +74,16 @@ fun WatchSyncDialog(
     selectedDeviceId = devices.firstOrNull { it.name == activeDeviceName }?.id
   }
 
+  // A selectWatchDevice failure regresses watchState to NoDevice/Unsupported (GarminWatchService's
+  // own error handling) without clearing selectedDeviceId - without this, the picked row keeps
+  // rendering "connected, waiting on app" via deviceStatusLabel(isSelected = true) instead of
+  // reflecting that the selection actually failed.
+  LaunchedEffect(watchState) {
+    if (watchState is WatchState.NoDevice || watchState is WatchState.Unsupported) {
+      selectedDeviceId = null
+    }
+  }
+
   val appOpen = (watchState as? WatchState.Idle)?.appOpen == true
   val sessionActive = watchState is WatchState.Active
   val canSend = selectedDeviceId != null && appOpen && plan != null && !sessionActive

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/WatchSyncDialog.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/WatchSyncDialog.kt
@@ -105,8 +105,8 @@ fun WatchSyncDialog(
             CircularProgressIndicator(Modifier.padding(16.dp))
           } else {
             LazyColumn(Modifier.heightIn(max = 240.dp)) {
-              items(currentPlan.exercises, key = { it.name }) { exercise ->
-                WatchExerciseRow(exercise)
+              items(currentPlan.exercises.indices.toList(), key = { currentPlan.ids[it] }) { index ->
+                WatchExerciseRow(currentPlan.exercises[index])
               }
             }
           }

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/WatchSyncDialog.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/WatchSyncDialog.kt
@@ -60,6 +60,20 @@ fun WatchSyncDialog(
     plan = model.previewWatchPlan(globalAlternate)
   }
 
+  // GarminWatchService.refresh() already auto-selects the first known device into watchState
+  // before this dialog ever opens (see garmin/CLAUDE.md) - without this, a device that's already
+  // connected shows no radio selected and the summary/Send stay hidden until a redundant tap on
+  // the row that's already the active target.
+  LaunchedEffect(devices, watchState) {
+    if (selectedDeviceId != null) return@LaunchedEffect
+    val activeDeviceName = when (val currentState = watchState) {
+      is WatchState.Idle -> currentState.deviceName
+      is WatchState.Active -> currentState.deviceName
+      else -> null
+    } ?: return@LaunchedEffect
+    selectedDeviceId = devices.firstOrNull { it.name == activeDeviceName }?.id
+  }
+
   val appOpen = (watchState as? WatchState.Idle)?.appOpen == true
   val sessionActive = watchState is WatchState.Active
   val canSend = selectedDeviceId != null && appOpen && plan != null && !sessionActive

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModel.kt
@@ -11,6 +11,7 @@ import arrow.core.NonEmptyList
 import arrow.core.toNonEmptyListOrNull
 import com.litus_animae.refitted.data.ExerciseRepository
 import com.litus_animae.refitted.data.WorkoutPlanRepository
+import com.litus_animae.refitted.data.device.WatchDevice
 import com.litus_animae.refitted.data.device.WatchPlan
 import com.litus_animae.refitted.data.device.WatchService
 import com.litus_animae.refitted.data.device.WatchState
@@ -97,6 +98,7 @@ class ExerciseViewModel @Inject constructor(
       .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
   val watchState: StateFlow<WatchState> = watchService.state
+  val watchDevices: StateFlow<List<WatchDevice>> = watchService.availableDevices
 
   // The rest timer arbitration lives here (rather than being read directly off watchState by the
   // UI) because Top.kt scopes ViewModels per nav destination - this state must outlive navigation.
@@ -127,6 +129,24 @@ class ExerciseViewModel @Inject constructor(
       }
     }
   }
+
+  /** Switches which known device [watchState]/[sendPlanToWatch] target - the watch-sync dialog's device row tap. */
+  fun selectWatchDevice(deviceId: String) {
+    viewModelScope.launch {
+      try {
+        watchService.selectDevice(deviceId)
+      } catch (ex: Throwable) {
+        log.e(TAG, "error selecting watch device", ex)
+      }
+    }
+  }
+
+  /**
+   * Builds the same [WatchPlan] [sendPlanToWatch] would send, for the watch-sync dialog's
+   * exercise-list preview - lets the dialog show exactly what's about to go out before the user
+   * commits, without duplicating [resolveWatchPlan]'s alternate/weight-resolution logic.
+   */
+  suspend fun previewWatchPlan(globalAlternate: Int?): WatchPlan = resolveWatchPlan(globalAlternate)
 
   /**
    * Resolves the currently displayed instructions - `.set(globalAlternate)` is the same call

--- a/ui/src/test/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModelTest.kt
+++ b/ui/src/test/kotlin/com/litus_animae/refitted/ui/models/ExerciseViewModelTest.kt
@@ -12,6 +12,7 @@ import com.litus_animae.refitted.data.models.ExerciseSet
 import com.litus_animae.refitted.data.models.Record
 import com.litus_animae.refitted.util.LogUtil
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -149,6 +150,35 @@ class ExerciseViewModelTest {
       advanceUntilIdle()
 
       assertThat(planSlot.captured.exercises.single().suggestedWeight).isEqualTo(25.0)
+    }
+  }
+
+  @Nested
+  @DisplayName("Watch-sync dialog support")
+  inner class WatchSyncDialogSupport {
+    @Test
+    fun `selectWatchDevice delegates to the watch service`() = runTest(mainDispatcher) {
+      val model = ExerciseViewModel(exerciseRepo, workoutPlanRepo, watchService, log)
+
+      model.selectWatchDevice("device-1")
+      advanceUntilIdle()
+
+      coVerify { watchService.selectDevice("device-1") }
+    }
+
+    @Test
+    fun `previewWatchPlan resolves the same plan sendPlanToWatch would send`() = runTest(mainDispatcher) {
+      val set = exerciseSet()
+      every { exerciseRepo.exercises } returns flowOf(listOf(set))
+      every { exerciseRepo.records } returns flowOf(emptyList())
+
+      val model = ExerciseViewModel(exerciseRepo, workoutPlanRepo, watchService, log)
+      backgroundScope.launch { model.exercises.collect {} }
+      advanceUntilIdle()
+
+      val plan = model.previewWatchPlan(null)
+
+      assertThat(plan.exercises.single().name).isEqualTo(set.exerciseName)
     }
   }
 }


### PR DESCRIPTION
## Summary

The watch icon used to fire the plan directly on tap, gated by an enabled/disabled state that gave no explanation when it wouldn't fire (no device, watch app not open, etc). This replaces that with an explicit, debuggable flow:

- Tapping the watch icon now always opens a dialog listing every paired Garmin device (previously `GarminWatchService.refresh()` only ever looked at `knownDevices.firstOrNull()`, so a second paired device was invisible).
- Picking a device reveals a collapsed exercise summary (name/sets/reps, matching what the watch itself shows) on the same screen — no separate confirm step between picking and reviewing.
- Send is the one explicit action, using the existing single-call `startSession`.

Changes are tiered by module:
- **`:data`** — `WatchDevice`/`WatchDeviceStatus`, and `WatchService.availableDevices` / `selectDevice(id)`.
- **`:garmin`** — `GarminWatchService` now surfaces every known device instead of discarding all but the first; `selectDevice(id)` lets a caller switch which device `state`/`startSession` target.
- **`:ui`** — new `WatchSyncDialog` composable; the watch icon's `onClick` now opens it instead of calling `sendPlanToWatch` directly.

## Test plan

- Added `GarminWatchServiceTest` coverage for multi-device listing, `selectDevice`, and listener cleanup on device switch.
- Added `ExerciseViewModelTest` coverage for `selectWatchDevice` delegation and `previewWatchPlan` matching `sendPlanToWatch`'s resolved plan.
- Not verified on-device or in the Connect IQ simulator (no watch hardware/SDK available in this session) — worth a manual pairing/send check before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_015uqFZCk8H3xPteypa9RLFJ)_