### PR TITLE
Add share action to export set history as CSV

### DIFF
--- a/data/src/main/kotlin/com/litus_animae/refitted/data/models/SetRecordCsv.kt
+++ b/data/src/main/kotlin/com/litus_animae/refitted/data/models/SetRecordCsv.kt
@@ -1,0 +1,14 @@
+package com.litus_animae.refitted.data.models
+
+/**
+ * Plain CSV of the raw inputs [com.litus_animae.refitted.data.effort.EffortModel] scores -
+ * timestamp, weight, reps - so a chart anomaly can be diagnosed from the exact numbers instead
+ * of a screenshot. Exercise is included per row rather than assumed constant since callers may
+ * pool records across exercises before exporting.
+ */
+fun List<SetRecord>.toCsv(): String {
+  val header = "completed,exercise,weight,reps"
+  val rows = sortedBy { it.completed }
+    .joinToString("\n") { "${it.completed},${it.exercise},${it.weight},${it.reps}" }
+  return if (rows.isEmpty()) header else "$header\n$rows"
+}

--- a/data/src/test/kotlin/com/litus_animae/refitted/data/models/SetRecordCsvTest.kt
+++ b/data/src/test/kotlin/com/litus_animae/refitted/data/models/SetRecordCsvTest.kt
@@ -1,0 +1,29 @@
+package com.litus_animae.refitted.data.models
+
+import com.google.common.truth.Truth.assertThat
+import java.time.Instant
+import org.junit.jupiter.api.Test
+
+class SetRecordCsvTest {
+
+  @Test
+  fun `empty list is just the header`() {
+    assertThat(emptyList<SetRecord>().toCsv()).isEqualTo("completed,exercise,weight,reps")
+  }
+
+  @Test
+  fun `rows are sorted chronologically and include every field`() {
+    val later = SetRecord(155.0, 12, "W", "T", Instant.parse("2026-08-24T13:39:00Z"), "Legs_Leg Press")
+    val earlier = SetRecord(155.0, 12, "W", "T", Instant.parse("2026-08-24T13:37:00Z"), "Legs_Leg Press")
+
+    val csv = listOf(later, earlier).toCsv()
+
+    assertThat(csv).isEqualTo(
+      """
+      completed,exercise,weight,reps
+      2026-08-24T13:37:00Z,Legs_Leg Press,155.0,12
+      2026-08-24T13:39:00Z,Legs_Leg Press,155.0,12
+      """.trimIndent()
+    )
+  }
+}

--- a/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
+++ b/ui/src/main/kotlin/com/litus_animae/refitted/ui/compose/exercise/RecordList.kt
@@ -1,5 +1,6 @@
 package com.litus_animae.refitted.ui.compose.exercise
 
+import android.content.Intent
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -45,6 +46,7 @@ import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -57,6 +59,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -72,6 +75,7 @@ import com.litus_animae.refitted.data.effort.ScoredSet
 import com.litus_animae.refitted.data.effort.TrendPoint
 import com.litus_animae.refitted.data.effort.toEffortSet
 import com.litus_animae.refitted.data.models.SetRecord
+import com.litus_animae.refitted.data.models.toCsv
 import com.litus_animae.refitted.identity.ConfigProvider
 import com.litus_animae.refitted.ui.R
 import com.litus_animae.refitted.ui.compose.LocalFeatures
@@ -214,6 +218,26 @@ fun SetRecordList(
           }
         },
         actions = {
+          val context = LocalContext.current
+          // Exports whatever's currently loaded/retained (see displayRetained above), not the
+          // exercise's full remote history - scroll to load more sessions first if the anomaly
+          // being diagnosed is further back than what's already on screen.
+          IconButton(
+            {
+              val intent = Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_TEXT, displayRetained.toCsv())
+              }
+              context.startActivity(Intent.createChooser(intent, null))
+            },
+            enabled = displayRetained.isNotEmpty()
+          ) {
+            Icon(
+              Icons.Default.Share,
+              // TODO localize
+              "share set history"
+            )
+          }
           Box(Modifier.size(48.dp), contentAlignment = Alignment.Center) {
             IconButton({ records.refresh() }) {
               Icon(


### PR DESCRIPTION
## Summary

- Adds `List<SetRecord>.toCsv()` in `:data` — a plain `completed,exercise,weight,reps` CSV of raw set history.
- Adds a share icon to the Set History screen's top bar (`SetRecordList`) that fires an Android share sheet with the currently loaded sessions as CSV text.

The goal is a fast way to get exact set data (not a screenshot) off the release app for debugging things like effort chart anomalies — export straight from the phone, mid-workout, and share it wherever it's needed.

Note: the export is scoped to whatever's currently loaded/paged into the Set History screen (`displayRetained`), not the exercise's full remote history — scrolling further back loads more before exporting.

## Test plan

- On-device: open an exercise's Set History drawer, tap the new share icon, confirm the share sheet includes a CSV with every visible session's sets in `completed,exercise,weight,reps` form, sorted chronologically.
- Confirm the icon is disabled when the drawer has no sets loaded yet.

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_017iEpiphEG8uj6MhfkUxx8t)_